### PR TITLE
Introduce separate init vocabulary helpers

### DIFF
--- a/neuralmonkey/config/utils.py
+++ b/neuralmonkey/config/utils.py
@@ -26,7 +26,7 @@ def vocabulary_from_file(path):
 
 
 def vocabulary_from_dataset(datasets, series_ids, max_size, save_file=None,
-                            overwrite=False):
+                            overwrite=False, unk_sample_prob=0.5):
     """Loads vocabulary from a dataset with an option to save it.
 
     Arguments:
@@ -36,18 +36,16 @@ def vocabulary_from_dataset(datasets, series_ids, max_size, save_file=None,
         max_size: The maximum size of the vocabulary
         save_file: A file to save the vocabulary to. If None (default),
                    the vocabulary will not be saved.
+        unk_sample_prob: A probability of sampling UNK tokens out of rare words
     """
-    vocabulary = Vocabulary.from_datasets(datasets, series_ids, max_size)
-
-    if not overwrite and os.path.exists(save_file):
-        raise Exception("Cannot save the vocabulary. File exists: {}"
-                        .format(save_file))
+    vocabulary = Vocabulary.from_datasets(datasets, series_ids, max_size,
+                                          unk_sample_prob)
 
     directory = os.path.dirname(save_file)
     if not os.path.exists(directory):
         os.makedirs(directory)
 
-    vocabulary.save_to_file(save_file)
+    vocabulary.save_to_file(save_file, overwrite)
     return vocabulary
 
 

--- a/neuralmonkey/config/utils.py
+++ b/neuralmonkey/config/utils.py
@@ -24,7 +24,8 @@ def vocabulary_from_file(path):
         raise Exception("Vocabulary file does not exist: {}".format(path))
     return Vocabulary.from_pickled(path)
 
-
+# pylint: disable=too-many-arguments
+# helper function, this number of parameters is needed
 def vocabulary_from_dataset(datasets, series_ids, max_size, save_file=None,
                             overwrite=False, unk_sample_prob=0.5):
     """Loads vocabulary from a dataset with an option to save it.

--- a/neuralmonkey/config/utils.py
+++ b/neuralmonkey/config/utils.py
@@ -1,104 +1,16 @@
 """This module contains helper functions that are suppoosed to be called from
 the configuration file because calling the functions or the class constructors
 directly would be inconvinent or impossible.
-
 """
 #tests: lint
 
-import os
-
-from neuralmonkey.vocabulary import Vocabulary
-from neuralmonkey.dataset import load_dataset_from_files
+import neuralmonkey.vocabulary as vocabulary
+import neuralmonkey.dataset as dataset
 
 #pylint: disable=invalid-name
 # for backwards compatibility
-dataset_from_files = load_dataset_from_files
-
-def vocabulary_from_file(path):
-    """Loads vocabulary from a pickled file
-
-    Arguments:
-        filename: File name to load the vocabulary from
-    """
-    if not os.path.exists(path):
-        raise Exception("Vocabulary file does not exist: {}".format(path))
-    return Vocabulary.from_pickled(path)
-
-# pylint: disable=too-many-arguments
-# helper function, this number of parameters is needed
-def vocabulary_from_dataset(datasets, series_ids, max_size, save_file=None,
-                            overwrite=False, unk_sample_prob=0.5):
-    """Loads vocabulary from a dataset with an option to save it.
-
-    Arguments:
-        datasets: A list of datasets from which to create the vocabulary
-        series_ids: A list of ids of series of the datasets that should be used
-                    producing the vocabulary
-        max_size: The maximum size of the vocabulary
-        save_file: A file to save the vocabulary to. If None (default),
-                   the vocabulary will not be saved.
-        unk_sample_prob: A probability of sampling UNK tokens out of rare words
-    """
-    vocabulary = Vocabulary.from_datasets(datasets, series_ids, max_size,
-                                          unk_sample_prob)
-
-    directory = os.path.dirname(save_file)
-    if not os.path.exists(directory):
-        os.makedirs(directory)
-
-    vocabulary.save_to_file(save_file, overwrite)
-    return vocabulary
-
-
-def vocabulary_from_bpe(path):
-    """Loads vocabulary from Byte-pair encoding merge list.
-
-    NOTE: The frequencies of words in this vocabulary are not computed from
-    data. Instead, they correspond to the number of times the subword units
-    occurred in the BPE merge list. This means that smaller words will tend to
-    have larger frequencies assigned and therefore the truncation of the
-    vocabulary can be somehow performed (but not without a great deal of
-    thought).
-
-    Arguments:
-        path: File name to load the vocabulary from.
-    """
-    if not os.path.exists(path):
-        raise Exception("BPE file does not exist: {}".format(path))
-    return Vocabulary.from_bpe(path)
-
-
-def initialize_vocabulary(directory, name, datasets=None, series_ids=None,
-                          max_size=None):
-    """This function is supposed to initialize vocabulary when called from
-    the configuration file. It first checks whether the vocabulary is already
-    loaded on the provided path and if not, it tries to generate it from
-    the provided dataset.
-
-    Args:
-        directory: Directory where the vocabulary should be stored.
-
-        name: Name of the vocabulary which is also the name of the file
-              it is stored it.
-
-        datasets: A a list of datasets from which the vocabulary can be
-                  created.
-
-        series_ids: A list of ids of series of the datasets that should be used
-                    for producing the vocabulary.
-
-        max_size: The maximum size of the vocabulary
-    """
-    log("Warning! Use of deprecated initialize_vocabulary method. "
-        "Did you think this through?", color="red")
-
-    file_name = os.path.join(directory, name + ".pickle")
-    if os.path.exists(file_name):
-        return vocabulary_from_file(file_name)
-
-    if datasets is None or series_ids is None or max_size is None:
-        raise Exception("Vocabulary does not exist in \"{}\","+
-                        "neither dataset and series_id were provided.")
-
-    return vocabulary_from_dataset(datasets, series_ids, max_size,
-                                   save_file=file_name, overwrite=False)
+dataset_from_files = dataset.load_dataset_from_files
+vocabulary_from_file = vocabulary.from_file
+vocabulary_from_bpe = vocabulary.from_bpe
+vocabulary_from_dataset = vocabulary.from_dataset
+initialize_vocabulary = vocabulary.initialize_vocabulary

--- a/neuralmonkey/config/utils.py
+++ b/neuralmonkey/config/utils.py
@@ -14,15 +14,15 @@ from neuralmonkey.dataset import load_dataset_from_files
 # for backwards compatibility
 dataset_from_files = load_dataset_from_files
 
-def vocabulary_from_file(filename):
+def vocabulary_from_file(path):
     """Loads vocabulary from a pickled file
 
     Arguments:
         filename: File name to load the vocabulary from
     """
-    if not os.path.exists(filename):
-        raise Exception("Vocabulary file does not exist: {}".format(filename))
-    return Vocabulary.from_pickled(filename)
+    if not os.path.exists(path):
+        raise Exception("Vocabulary file does not exist: {}".format(path))
+    return Vocabulary.from_pickled(path)
 
 
 def vocabulary_from_dataset(datasets, series_ids, max_size, save_file=None,
@@ -30,12 +30,12 @@ def vocabulary_from_dataset(datasets, series_ids, max_size, save_file=None,
     """Loads vocabulary from a dataset with an option to save it.
 
     Arguments:
-        datasets:   A list of datasets from which to create the vocabulary
+        datasets: A list of datasets from which to create the vocabulary
         series_ids: A list of ids of series of the datasets that should be used
                     producing the vocabulary
-        max_size:   The maximum size of the vocabulary
-        save_file:  A file to save the vocabulary to. If None (default),
-                    the vocabulary will not be saved.
+        max_size: The maximum size of the vocabulary
+        save_file: A file to save the vocabulary to. If None (default),
+                   the vocabulary will not be saved.
     """
     vocabulary = Vocabulary.from_datasets(datasets, series_ids, max_size)
 
@@ -51,6 +51,24 @@ def vocabulary_from_dataset(datasets, series_ids, max_size, save_file=None,
     return vocabulary
 
 
+def vocabulary_from_bpe(path):
+    """Loads vocabulary from Byte-pair encoding merge list.
+
+    NOTE: The frequencies of words in this vocabulary are not computed from
+    data. Instead, they correspond to the number of times the subword units
+    occurred in the BPE merge list. This means that smaller words will tend to
+    have larger frequencies assigned and therefore the truncation of the
+    vocabulary can be somehow performed (but not without a great deal of
+    thought).
+
+    Arguments:
+        path: File name to load the vocabulary from.
+    """
+    if not os.path.exists(path):
+        raise Exception("BPE file does not exist: {}".format(path))
+    return Vocabulary.from_bpe(path)
+
+
 def initialize_vocabulary(directory, name, datasets=None, series_ids=None,
                           max_size=None):
     """This function is supposed to initialize vocabulary when called from
@@ -59,18 +77,18 @@ def initialize_vocabulary(directory, name, datasets=None, series_ids=None,
     the provided dataset.
 
     Args:
-        directory:  Directory where the vocabulary should be stored.
+        directory: Directory where the vocabulary should be stored.
 
-        name:       Name of the vocabulary which is also the name of the file
-                    it is stored it.
+        name: Name of the vocabulary which is also the name of the file
+              it is stored it.
 
-        datasets:   A a list of datasets from which the vocabulary can be
-                    created.
+        datasets: A a list of datasets from which the vocabulary can be
+                  created.
 
         series_ids: A list of ids of series of the datasets that should be used
                     for producing the vocabulary.
 
-        max_size:   The maximum size of the vocabulary
+        max_size: The maximum size of the vocabulary
     """
     log("Warning! Use of deprecated initialize_vocabulary method. "
         "Did you think this through?", color="red")

--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -4,6 +4,7 @@ import math
 import tensorflow as tf
 import numpy as np
 
+from neuralmonkey.vocabulary import START_TOKEN
 from neuralmonkey.decoding_function import attention_decoder
 from neuralmonkey.logging import log
 
@@ -340,7 +341,9 @@ class Decoder(object):
         # pylint: disable=invalid-name
         # fd is the common name for feed dictionary
         fd = {}
-        fd[self.go_symbols] = np.ones(len(dataset))
+
+        start_token_index = self.vocabulary.get_word_index(START_TOKEN)
+        fd[self.go_symbols] = np.repeat(start_token_index, len(dataset))
 
         sentences = dataset.get_series(self.data_id, allow_none=True)
 

--- a/neuralmonkey/vocabulary.py
+++ b/neuralmonkey/vocabulary.py
@@ -183,7 +183,7 @@ class Vocabulary(collections.Sized):
 
         with codecs.open(path, "r", encoding) as f_bpe:
             for line in f_bpe:
-                pair = f_bpe.split()
+                pair = line.split()
                 assert len(pair) == 2
 
                 vocab.add_word(pair[0])

--- a/neuralmonkey/vocabulary.py
+++ b/neuralmonkey/vocabulary.py
@@ -179,7 +179,7 @@ class Vocabulary(collections.Sized):
     @staticmethod
     def from_bpe(path, encoding="utf-8"):
         #type: (str) -> Vocabulary
-        vocab = Vocabuary()
+        vocab = Vocabulary()
 
         with codecs.open(path, "r", encoding) as f_bpe:
             for line in f_bpe:

--- a/neuralmonkey/vocabulary.py
+++ b/neuralmonkey/vocabulary.py
@@ -1,3 +1,6 @@
+"""This module implements the Vocabulary class and the helper functions that
+can be used to obtain a Vocabulary instance.
+"""
 # tests: lint, mypy
 
 from typing import List, Tuple

--- a/neuralmonkey/vocabulary.py
+++ b/neuralmonkey/vocabulary.py
@@ -173,7 +173,7 @@ class Vocabulary(collections.Sized):
             self,
             sentences: List[List[str]],
             max_len: int,
-            train: bool=False) -> Tuple[np.array, np.array]:
+            train: bool=False) -> Tuple[np.ndarray, np.ndarray]:
         """Generate the tensor representation for the provided sentences.
 
         Arguments:
@@ -211,7 +211,8 @@ class Vocabulary(collections.Sized):
         return word_indices, weights
 
 
-    def vectors_to_sentences(self, vectors: List[np.array]) -> List[List[str]]:
+    def vectors_to_sentences(self,
+                             vectors: List[np.ndarray]) -> List[List[str]]:
         """Convert vectors of indexes of vocabulary items to lists of words.
 
         Arguments:
@@ -221,6 +222,7 @@ class Vocabulary(collections.Sized):
             List of lists of words.
         """
         sentences = [[] for _ in range(vectors[0].shape[0])]
+        #type: List[List[str]]
 
         for vec in vectors:
             for sentence, word_i in zip(sentences, vec):

--- a/neuralmonkey/vocabulary.py
+++ b/neuralmonkey/vocabulary.py
@@ -1,7 +1,6 @@
 # tests: lint, mypy
 
 import re
-import codecs
 import collections
 import random
 import pickle as pickle
@@ -181,7 +180,7 @@ class Vocabulary(collections.Sized):
         #type: (str) -> Vocabulary
         vocab = Vocabulary()
 
-        with codecs.open(path, "r", encoding) as f_bpe:
+        with open(path, encoding=encoding) as f_bpe:
             for line in f_bpe:
                 pair = line.split()
                 assert len(pair) == 2

--- a/neuralmonkey/vocabulary.py
+++ b/neuralmonkey/vocabulary.py
@@ -1,6 +1,7 @@
 # tests: lint, mypy
 
 import re
+import codecs
 import collections
 import random
 import pickle as pickle
@@ -173,3 +174,20 @@ class Vocabulary(collections.Sized):
             vocabulary = pickle.load(f_pickle)
         assert isinstance(vocabulary, Vocabulary)
         return vocabulary
+
+
+    @staticmethod
+    def from_bpe(path, encoding="utf-8"):
+        #type: (str) -> Vocabulary
+        vocab = Vocabuary()
+
+        with codecs.open(path, "r", encoding) as f_bpe:
+            for line in f_bpe:
+                pair = f_bpe.split()
+                assert len(pair) == 2
+
+                vocab.add_word(pair[0])
+                vocab.add_word(pair[1])
+                vocab.add_word("".join(pair))
+
+        return vocab

--- a/neuralmonkey/vocabulary.py
+++ b/neuralmonkey/vocabulary.py
@@ -1,90 +1,164 @@
 # tests: lint, mypy
 
-import re
+from typing import List, Tuple
+
+import os
 import collections
 import random
 import pickle as pickle
 import numpy as np
 
 from neuralmonkey.logging import log
-from neuralmonkey.dataset import LazyDataset
+from neuralmonkey.dataset import Dataset, LazyDataset
 
-try:
-    #pylint: disable=unused-import,ungrouped-imports,bare-except,import-error,wrong-import-order
-    from typing import List, Tuple, Dict
-    from neuralmonkey.dataset import Dataset
-except:
-    pass
+PAD_TOKEN = "<pad>"
+START_TOKEN = "<s>"
+END_TOKEN = "</s>"
+UNK_TOKEN = "<unk>"
+
+def _is_special_token(word: str) -> bool:
+    """Check whether word is a special token (such as <pad> or <s>).
+
+    Arguments:
+        word: The word to check
+
+    Returns:
+        True if the word is special, False otherwise.
+    """
+    return (word == PAD_TOKEN
+            or word == START_TOKEN
+            or word == END_TOKEN
+            or word == UNK_TOKEN)
+
 
 class Vocabulary(collections.Sized):
-    def __init__(self, tokenized_text=None, random_seed=None):
-        # type: (List[str], int) -> None
+    def __init__(self, tokenized_text: List[str]=None,
+                 unk_sample_prob: float=0.0) -> None:
+        """Create a new instance of a vocabulary.
+
+        Arguments:
+            tokenized_text: The initial list of words to add.
+        """
         self.word_to_index = {} # type: Dict[str, int]
         self.index_to_word = [] # type: List[str]
         self.word_count = {} # type: Dict[str, int]
 
-        self.add_tokenized_text(["<pad>", "<s>", "</s>", "<unk>"])
+        self.unk_sample_prob = unk_sample_prob
+
+        self.add_word(PAD_TOKEN)
+        self.add_word(START_TOKEN)
+        self.add_word(END_TOKEN)
+        self.add_word(UNK_TOKEN)
 
         if tokenized_text:
             self.add_tokenized_text(tokenized_text)
-        random.seed(random_seed)
 
-    def add_word(self, word):
-        # type: (str) -> None
+
+    def __len__(self) -> int:
+        """Get the size of the vocabulary.
+
+        Returns:
+            The number of distinct words in the vocabulary.
+        """
+        return len(self.index_to_word)
+
+
+    def __contains__(self, word: str) -> bool:
+        """Check if a word is in the vocabulary.
+
+        Arguments:
+            word: The word to look up.
+
+        Returns:
+            True if the word was added to the vocabulary, False otherwise.
+        """
+        return word in self.word_to_index
+
+
+
+
+    def add_word(self, word: str) -> None:
+        """Add a word to the vocablulary.
+
+        Arguments:
+            word: The word to add. If it's already there, increment the count.
+        """
         if word not in self:
             self.word_to_index[word] = len(self.index_to_word)
             self.index_to_word.append(word)
             self.word_count[word] = 0
         self.word_count[word] += 1
 
-    def add_tokenized_text(self, tokenized_text):
-        # type: (List[str]) -> None
+
+    def add_tokenized_text(self, tokenized_text: List[str]) -> None:
+        """Add words from a list to the vocabulary.
+
+        Arguments:
+            tokenized_text: The list of words to add.
+        """
         for word in tokenized_text:
             self.add_word(word)
 
-    def get_train_word_index(self, word):
-        # type: (str) -> int
+
+    def get_word_index(self, word: str) -> int:
+        """ Return index of the specified word.
+
+        Arguments:
+            word: The word to look up.
+
+        Returns:
+            Index of the word or index of the unknown token if the word is not
+            present in the vocabulary.
+        """
         if word not in self:
-            return self.word_to_index["<unk>"]
-
-        if self.word_count[word] <= 1 and random.random() < 0.5:
-            return self.word_to_index["<unk>"]
-
+            return self.get_word_index(UNK_TOKEN)
         return self.word_to_index[word]
 
-    def get_word_index(self, word):
-        # type: (str) -> int
-        if word not in self:
-            return self.word_to_index["<unk>"]
-        else:
-            return self.word_to_index[word]
 
-    def __len__(self):
-        # type: () -> int
-        return len(self.index_to_word)
+    def get_unk_sampled_word_index(self, word):
+        """Return index of the specified word with sampling of unknown words.
 
-    def __contains__(self, word):
-        # type: (str) -> bool
-        return word in self.word_to_index
+        This method returns the index of the specified word in the vocabulary.
+        If the frequency of the word in the vocabulary is 1 (the word was only
+        seen once in the whole training dataset), with probability of
+        self.unk_sample_prob, generate the index of the unknown token instead.
 
-    def trunkate(self, size):
-        # type: (int) -> None
+        Arguments:
+            word: The word to look up.
+
+        Returns:
+            Index of the word, index of the unknown token if sampled, or index
+            of the unknown token if the word is not present in the vocabulary.
         """
-        Trunkates the Vocabulary to requested size by keep only the most
-        frequent tokens.
-        """
+        idx = self.word_to_index.get(word, self.get_word_index(UNK_TOKEN))
+        freq = self.word_count.get(word, 0)
 
+        if freq <= 1 and random.random() < self.unk_sample_prob:
+            return self.get_word_index(UNK_TOKEN)
+
+        return idx
+
+
+    def trunkate(self, size: int) -> None:
+        """Truncate the vocabulary to the requested size by discarding
+        infrequent tokens.
+
+        Arguments:
+            size: The final size of the vocabulary
+        """
         # sort by frequency
-        words_by_freq = \
-            sorted(list(self.word_count.keys()), key=lambda w: self.word_count[w])
+        words_by_freq = sorted(list(self.word_count.keys()),
+                               key=lambda w: self.word_count[w])
 
         # keep the least frequent words which are not special symbols
-        words_to_delete = \
-            [w for w in words_by_freq[:-size] if not re.match(r"^<.*>$", w)]
+        words_to_delete = [w for w in words_by_freq[:-size]
+                           if not _is_special_token(w)]
+
         # sort by index ... bigger indices needs to be removed first
         # to keep the lists propertly shaped
-        delete_words_by_index = \
-            sorted([(w, self.word_to_index[w]) for w in words_to_delete], key=lambda p: -p[1])
+        delete_words_by_index = sorted(
+            [(w, self.word_to_index[w]) for w in words_to_delete],
+            key=lambda p: -p[1])
 
         for word, index in delete_words_by_index:
             del self.word_count[word]
@@ -94,56 +168,88 @@ class Vocabulary(collections.Sized):
         for index, word in enumerate(self.index_to_word):
             self.word_to_index[word] = index
 
-    def sentences_to_tensor(self, sentences, max_len, train=False):
-        # type: (List[List[str]], int, bool) -> Tuple[np.Array, np.Array]
-        """
-        Generates the tensor representation for the provided sentences.
 
-        Args:
+    def sentences_to_tensor(
+            self,
+            sentences: List[List[str]],
+            max_len: int,
+            train: bool=False) -> Tuple[np.array, np.array]:
+        """Generate the tensor representation for the provided sentences.
 
+        Arguments:
             sentences: List of sentences as lists of tokens.
             max_len: Maximum lengh of a sentence toward which they will be
-              padded to.
-            train: Flag whether this is for training purposes.
+                     padded to.
+            train: Flag whether we are training or not
+                   (enables/disables unk sampling).
 
+        Returns:
+            A tensor representing the sentences ((max_length + 2) x batch)
+            and a weight tensor ((max_length + 1) x batch) that inidicates
+            padding.
         """
+        start_indices = [np.repeat(self.get_word_index(START_TOKEN),
+                                   len(sentences))]
+        pad_indices = [np.repeat(self.get_word_index(PAD_TOKEN), len(sentences))
+                       for _ in range(max_len + 1)]
 
-        word_indices = [np.zeros([len(sentences)], dtype=np.int) for _ in range(max_len + 2)]
+        word_indices = np.stack(start_indices + pad_indices)
         weights = [np.zeros([len(sentences)]) for _ in range(max_len + 1)]
-
-        word_indices[0] = np.repeat(self.get_word_index("<s>"), len(sentences))
 
         for i in range(max_len + 1):
             for j, sent in enumerate(sentences):
                 if i < len(sent):
-                    word_indices[i + 1][j] = self.get_train_word_index(sent[i]) if train \
-                                         else self.get_word_index(sent[i])
+                    word_indices[i + 1][j] = (
+                        self.get_unk_sampled_word_index(sent[i])
+                        if train else self.get_word_index(sent[i]))
                     weights[i][j] = 1.0
+
                 elif i == len(sent):
-                    word_indices[i + 1][j] = self.get_word_index("</s>")
+                    word_indices[i + 1][j] = self.get_word_index(END_TOKEN)
                     weights[i][j] = 1.0
 
         return word_indices, weights
 
-    def vectors_to_sentences(self, vectors):
-        # type: (List[np.Array]) -> List[List[str]]
+
+    def vectors_to_sentences(self, vectors: List[np.array]) -> List[List[str]]:
+        """Convert vectors of indexes of vocabulary items to lists of words.
+
+        Arguments:
+            vectors: List of vectors of vocabulary indices.
+
+        Returns:
+            List of lists of words.
+        """
         sentences = [[] for _ in range(vectors[0].shape[0])]
-        # type: List[List[str]]
 
         for vec in vectors:
             for sentence, word_i in zip(sentences, vec):
-                if not sentence or (sentence and sentence[-1] != "</s>"):
+                if not sentence or sentence[-1] != END_TOKEN:
                     sentence.append(self.index_to_word[word_i])
 
-        return [s[:-1] if s[-1] == "</s>" else s for s in sentences]
+        return [s[:-1] if s[-1] == END_TOKEN else s for s in sentences]
 
-    def save_to_file(self, path):
-        # type: (str) -> None
+
+    def save_to_file(self, path: str, overwrite: bool=False) -> None:
+        """Save the vocabulary to a file.
+
+        Arguments:
+            path: The path to save the file to.
+            overwrite: Flag whether to overwrite existing file.
+                       Defaults to False.
+        Raises:
+            FileExistsError if the file exists and overwrite flag is
+            disabled.
+        """
+        if os.path.exists(path) and not overwrite:
+            raise FileExistsError("Cannot save vocabulary: File exists and "
+                                  "overwrite is disabled. {}".format(path))
+
         with open(path, 'wb') as f_pickle:
             pickle.dump(self, f_pickle)
 
 
-    def log_sample(self, size=5):
+    def log_sample(self, size: int=5):
         """Logs a sample of the vocabulary
 
         Arguments:
@@ -155,9 +261,23 @@ class Vocabulary(collections.Sized):
 
 
     @staticmethod
-    def from_datasets(datasets, series_ids, max_size, random_seed=None):
-        # type: (List[Dataset], List[str], int, int) -> Vocabulary
-        vocabulary = Vocabulary(random_seed=random_seed)
+    def from_datasets(
+            datasets: List[Dataset], series_ids: List[str], max_size: int,
+            unk_sample_prob: float=0.5) -> 'Vocabulary':
+        """Create new vocabulary instance from datasets.
+
+        Arguments:
+            datasets: A list of datasets from which to create the vocabulary
+            series_ids: A list of ids of series of the datasets that should be
+                        used producing the vocabulary
+            max_size: The maximum size of the vocabulary
+            unk_sample_prob: The probability with which to sample unks out of
+                             words with frequency 1. Defaults to 0.5.
+
+        Returns:
+            The new Vocabulary instance.
+        """
+        vocabulary = Vocabulary(unk_sample_prob=unk_sample_prob)
 
         for dataset in datasets:
             if isinstance(dataset, LazyDataset):
@@ -177,9 +297,17 @@ class Vocabulary(collections.Sized):
         vocabulary.log_sample()
         return vocabulary
 
+
     @staticmethod
-    def from_pickled(path):
-        # type: (str) -> Vocabulary
+    def from_pickled(path: str) -> 'Vocabulary':
+        """Create new vocabulary instance from a pickle file.
+
+        Arguments:
+            path: The path to the pickle file
+
+        Returns:
+            The newly created vocabulary.
+        """
         with open(path, 'rb') as f_pickle:
             vocabulary = pickle.load(f_pickle)
         assert isinstance(vocabulary, Vocabulary)
@@ -190,8 +318,16 @@ class Vocabulary(collections.Sized):
 
 
     @staticmethod
-    def from_bpe(path, encoding="utf-8"):
-        #type: (str) -> Vocabulary
+    def from_bpe(path: str, encoding: str="utf-8") -> 'Vocabulary':
+        """Create new closed vocabulary instance from BPE merge file.
+
+        Arguments:
+            path: The path to the merge file.
+            encoding: The encoding of the merge file (defaults to UTF-8)
+
+        Returns:
+            The new instance of the Vocabulary
+        """
         vocab = Vocabulary()
 
         with open(path, encoding=encoding) as f_bpe:

--- a/tests/small.ini
+++ b/tests/small.ini
@@ -63,12 +63,12 @@ s_source=tests/data/val.tc.en
 s_target=tests/data/val.tc.de
 
 [encoder_vocabulary]
-class=config.utils.initialize_vocabulary
-directory=tests/tmp-encoder-vocabulary
-name=encoder_vocabulary
+class=config.utils.vocabulary_from_dataset
 datasets=[<train_data>]
 series_ids=[source]
-max_size=25000
+max_size=5000
+save_file=tests/tmp-test-output/encoder_vocabulary.pickle
+overwrite=True
 
 [encoder]
 ; This defines the sentence encoder object. All compulsory arguments from the
@@ -85,12 +85,12 @@ data_id=source
 vocabulary=<encoder_vocabulary>
 
 [decoder_vocabulary]
-class=config.utils.initialize_vocabulary
-directory=tests/tmp-decoder-vocabulary
-name=decoder_vocabulary
+class=config.utils.vocabulary_from_dataset
 datasets=[<train_data>]
 series_ids=[target]
-max_size=25000
+max_size=5000
+save_file=tests/tmp-test-output/decoder_vocabulary.pickle
+overwrite=True
 
 [decoder]
 class=decoders.decoder.Decoder


### PR DESCRIPTION
Additional helpers:

- `config.utils.vocabulary_from_file` - loads vocabulary from pickled file
- `config.utils.vocabulary_from_dataset` - loads vocabulary from a dataset and optionally save it to a pickled file

There is still possibility to use the old `config.utils.initialize_vocabulary` which maintains the same functionality as before. Additionally, it prints a warning message.