### PR TITLE
fix typos and English in comments

### DIFF
--- a/tests/small.ini
+++ b/tests/small.ini
@@ -46,10 +46,11 @@ random_seed=1234
 class=evaluators.bleu.BLEUEvaluator
 
 [train_data]
-; This is a definition of the training data object. Note that languages are
-; defined here because they are used as identifiers while preparing the vocabularies.
-; Dataset is not a standard class, it treats the __init__ method's arguments as
-; a dictionary, therefore the data series names can be any strings.
+; This is a definition of the training data object. Dataset is not a standard
+; class, it treats the __init__ method's arguments as a dictionary, therefore
+; the data series names can be any string, prefixed with "s_". To specify the
+; output file for a series, use "s_" prefix and "_out" suffix, e.g.
+; "s_target_out"
 class=config.utils.dataset_from_files
 s_source=tests/data/train.tc.en
 s_target=tests/data/train.tc.de

--- a/tests/small.ini
+++ b/tests/small.ini
@@ -1,7 +1,7 @@
 ; This is an example configuration for training machine translation.  It is an
-; INI file with few added syntanctic restrictions.
+; INI file with few added syntactic restrictions.
 ;
-; Names in suqare brackest refer to objects in the program. With the exception
+; Names in square brackets refer to objects in the program. With the exception
 ; of the [main] block, all of them will be instantiated as objects.
 ;
 ; The field values can be of several types:
@@ -10,21 +10,21 @@
 ;   * True / False - interpreted as boolean values
 ;   * integers
 ;   * floating point numbers
-;   * python types (fully defined with module name)
+;   * Python types (fully defined with module name)
 ;   * references to other objects in the configuration, closed in <>
 ;   * strings (if it does not match any other pattern)
 ;   * list of the previous, enclosed in square brackets, comma-separated
 ;
-; The vocabularies are handeled in a special way. If the vocabularies source is
-; defined in the [main] (a dataset object) a dictionary that maps the language
-; code to the vocaburies is created. Later, if any other block has a field
+; The vocabularies are handled in a special way. If the vocabularies source is
+; defined in the [main] (a dataset object), a dictionary that maps the language
+; code to the vocabularies is created. Later, if any other block has a field
 ; called 'vocabulary', and its value is a known language code, the vocabulary
-; form the dictionary is used. Vocabularies can be also defined as objects
+; from the dictionary is used. Vocabularies can also be defined as objects
 ; in the INI file and can be referenced using the <> notation.
 ;
 
 [main]
-; The main block contains the mandatory fields for running and experiment.
+; The main block contains the mandatory fields for running an experiment.
 name=translation
 output=tests/tmp-test-output
 overwrite_output_dir=True
@@ -46,9 +46,9 @@ random_seed=1234
 class=evaluators.bleu.BLEUEvaluator
 
 [train_data]
-; This is definition of the training data object. Notice that language are
-; defined here, because they are used identifiers while preparing vocabularies.
-; Dataset is not a standard class, it treats the __init__ methods arguements as
+; This is a definition of the training data object. Note that languages are
+; defined here because they are used as identifiers while preparing the vocabularies.
+; Dataset is not a standard class, it treats the __init__ method's arguments as
 ; a dictionary, therefore the data series names can be any strings.
 class=config.utils.dataset_from_files
 s_source=tests/data/train.tc.en
@@ -56,8 +56,8 @@ s_target=tests/data/train.tc.de
 lazy=True
 
 [val_data]
-; Validation data, the languages are not necessary here, encoders and decoder
-; acces the data series via the string identifiers defined here.
+; Validation data, the languages are not necessary here, encoders and decoders
+; access the data series via the string identifiers defined here.
 class=config.utils.dataset_from_files
 s_source=tests/data/val.tc.en
 s_target=tests/data/val.tc.de
@@ -72,8 +72,8 @@ overwrite=True
 
 [encoder]
 ; This defines the sentence encoder object. All compulsory arguments from the
-; __init__ methods must be defined in this block. The additional arguments may
-; be defines, if they are not, the default value from the __init__ method is
+; __init__ methods must be defined in this block. Additional arguments may
+; be defined.  Otherwise, the default value from the __init__ method is
 ; used. Notice the vocabulary is aquired via the language string.
 class=encoders.sentence_encoder.SentenceEncoder
 rnn_size=256
@@ -109,8 +109,8 @@ decoder=<decoder>
 l2_regularization=1.0e-8
 
 [runner]
-; This is block is used for both validation and testing to run the model on
-; given dataset.
+; This block is used for both validation and testing to run the model on
+; a given dataset.
 class=runners.runner.GreedyRunner
 decoder=<decoder>
 batch_size=16


### PR DESCRIPTION
Now I see some duplicates in examples/translation.ini