### PR TITLE
Require the name attribute in all encoders and decoders explicitly

### DIFF
--- a/examples/language_model.ini
+++ b/examples/language_model.ini
@@ -65,6 +65,7 @@ max_size=25000
 
 [decoder]
 class=decoders.decoder.Decoder
+name=decoder
 encoders=[]
 rnn_size=256
 embedding_size=256

--- a/examples/translation.ini
+++ b/examples/translation.ini
@@ -87,6 +87,7 @@ merge_file=examples/data/bpe_merges
 ; be defined.  Otherwise, the default value from the __init__ method is
 ; used. Notice the vocabulary is aquired via the language string.
 class=encoders.sentence_encoder.SentenceEncoder
+name=sentence_encoder
 rnn_size=300
 max_input_len=50
 embedding_size=300
@@ -97,6 +98,7 @@ vocabulary=<source_vocabulary>
 
 [decoder]
 class=decoders.decoder.Decoder
+name=decoder
 encoders=[<encoder>]
 rnn_size=256
 embedding_size=300

--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -18,7 +18,7 @@ class Decoder(object):
     # it into smaller units would be helpful
     # Some locals may be turned to attributes
 
-    def __init__(self, encoders, vocabulary, data_id, **kwargs):
+    def __init__(self, encoders, vocabulary, data_id, name, **kwargs):
         """Creates a new instance of the decoder
 
         Arguments:
@@ -43,10 +43,10 @@ class Decoder(object):
         self.encoders = encoders
         self.vocabulary = vocabulary
         self.data_id = data_id
+        self.name = name
 
         self.max_output = kwargs.get("max_output_len", 20)
         self.embedding_size = kwargs.get("embedding_size", 200)
-        self.name = kwargs.get("name", "decoder")
         dropout_keep_prob = kwargs.get("dropout_keep_prob", 1.0)
 
         self.use_attention = kwargs.get("use_attention", False)

--- a/neuralmonkey/decoders/monster_decoder.py
+++ b/neuralmonkey/decoders/monster_decoder.py
@@ -21,11 +21,11 @@ from neuralmonkey.checking import assert_type
 from neuralmonkey.vocabulary import Vocabulary, START_TOKEN
 
 class Decoder(object):
-    def __init__(self, encoders, vocabulary, data_id, rnn_size,
+    def __init__(self, encoders, vocabulary, data_id, rnn_size, name,
                  embedding_size=128, use_attention=None, max_output_len=20,
                  scheduled_sampling=None, dropout_keep_p=0.5, copy_net=None,
                  reused_word_embeddings=None, use_noisy_activations=False,
-                 depth=1, name="decoder"):
+                 depth=1):
 
         """A class that collects the part of the computation graph that is
         needed for decoding.

--- a/neuralmonkey/decoders/sequence_classifier.py
+++ b/neuralmonkey/decoders/sequence_classifier.py
@@ -11,8 +11,8 @@ class SequenceClassifier(object):
     exactly one.
     """
 
-    def __init__(self, encoders, vocabulary, data_id,
-                 layers=[], activation=tf.tanh, dropout_keep_p=0.5, name='seq_classifier'):
+    def __init__(self, encoders, vocabulary, data_id, name,
+                 layers=[], activation=tf.tanh, dropout_keep_p=0.5):
         self.encoders = encoders
         self.vocabulary = vocabulary
         self.data_id = data_id

--- a/neuralmonkey/encoders/cnn_encoder.py
+++ b/neuralmonkey/encoders/cnn_encoder.py
@@ -39,12 +39,11 @@ class CNNEncoder(object):
 
     def __init__(self, data_id, convolutions, rnn_layers,
                  image_height, image_width, pixel_dim,
-                 concatenate_rnns=False,
+                 name, concatenate_rnns=False,
                  bidirectional=True,
                  batch_normalization=True,
                  local_response_normalization=True,
-                 dropout_keep_p=0.5,
-                 name="cnn_encoder"):
+                 dropout_keep_p=0.5):
 
         """
         Initilizes and configures the computational graph creator.

--- a/neuralmonkey/encoders/image_encoder.py
+++ b/neuralmonkey/encoders/image_encoder.py
@@ -25,7 +25,7 @@ class VectorEncoder(object):
 
 
 class PostCNNImageEncoder(object):
-    def __init__(self, input_shape, output_shape, data_id,
+    def __init__(self, input_shape, output_shape, data_id, name,
                  dropout_keep_p=1.0, attention_type=None):
         assert len(input_shape) == 3
 
@@ -34,9 +34,10 @@ class PostCNNImageEncoder(object):
         self.data_id = data_id
         self.dropout_keep_p = dropout_keep_p
         self.attention_type = attention_type
+        self.name = name
 
 
-        with tf.variable_scope("image_encoder"):
+        with tf.variable_scope(self.name):
             self.dropout_placeholder = tf.placeholder(tf.float32)
             self.image_features = tf.placeholder(tf.float32,
                                                  shape=[None] + input_shape,
@@ -71,4 +72,3 @@ class PostCNNImageEncoder(object):
             res[self.dropout_placeholder] = 1.0
 
         return res
-

--- a/neuralmonkey/encoders/sentence_encoder.py
+++ b/neuralmonkey/encoders/sentence_encoder.py
@@ -12,9 +12,9 @@ from neuralmonkey.vocabulary import Vocabulary
 
 class SentenceEncoder(object):
     def __init__(self, max_input_len, vocabulary, data_id, embedding_size,
-                 rnn_size, dropout_keep_p=0.5, use_noisy_activations=False,
-                 use_pervasive_dropout=False, attention_type=None,
-                 attention_fertility=3, name="sentence_encoder",
+                 rnn_size, name, dropout_keep_p=0.5,
+                 use_noisy_activations=False, use_pervasive_dropout=False,
+                 attention_type=None, attention_fertility=3,
                  parent_encoder=None):
 
         self.name = name

--- a/neuralmonkey/tests/test_decoder.py
+++ b/neuralmonkey/tests/test_decoder.py
@@ -11,7 +11,7 @@ from neuralmonkey.vocabulary import Vocabulary
 class TestDecoder(unittest.TestCase):
 
     def test_init(self):
-        decoder = Decoder([], Vocabulary(), "foo")
+        decoder = Decoder([], Vocabulary(), "foo", "test-decoder")
         self.assertIsNotNone(decoder)
 
 if __name__ == "__main__":

--- a/tests/small-beam.ini
+++ b/tests/small-beam.ini
@@ -68,6 +68,7 @@ random_seed=1234
 ; be defines, if they are not, the default value from the __init__ method is
 ; used. Notice the vocabulary is aquired via the language string.
 class=encoders.sentence_encoder.SentenceEncoder
+name=sentence_encoder
 rnn_size=256
 max_input_len=20
 embedding_size=200
@@ -78,6 +79,7 @@ vocabulary=en
 
 [decoder]
 class=decoders.decoder.Decoder
+name=decoder
 encoders=[<encoder>]
 rnn_size=256
 embedding_size=256

--- a/tests/small.ini
+++ b/tests/small.ini
@@ -77,6 +77,7 @@ overwrite=True
 ; be defined.  Otherwise, the default value from the __init__ method is
 ; used. Notice the vocabulary is aquired via the language string.
 class=encoders.sentence_encoder.SentenceEncoder
+name=sentence_encoder
 rnn_size=256
 max_input_len=10
 embedding_size=200
@@ -95,6 +96,7 @@ overwrite=True
 
 [decoder]
 class=decoders.decoder.Decoder
+name=decoder
 encoders=[<encoder>]
 rnn_size=256
 embedding_size=256

--- a/tests/vocab.ini
+++ b/tests/vocab.ini
@@ -40,6 +40,7 @@ max_size=25000
 
 [encoder]
 class=encoders.sentence_encoder.SentenceEncoder
+name=sentence_encoder
 rnn_size=231
 max_input_len=17
 embedding_size=203
@@ -58,6 +59,7 @@ max_size=25000
 
 [decoder]
 class=decoders.decoder.Decoder
+name=decoder
 encoders=[<encoder>]
 project_encoder_outputs=True
 rnn_size=211


### PR DESCRIPTION
Addresses the bug #25