### PR TITLE
Optional maxout

### DIFF
--- a/neuralmonkey/decoders/bahdanau_decoder.py
+++ b/neuralmonkey/decoders/bahdanau_decoder.py
@@ -1,0 +1,64 @@
+#tests: lint
+
+import tensorflow as tf
+
+from neuralmonkey.decoders.decoder import Decoder
+from neuralmonkey.nn.projection import maxout
+
+class BahdanauDecoder(Decoder):
+    """This class implements the decoder as described in
+    Bahdanau et al., 2015.
+
+    The BahdanauDecoder brings the deep output with a hidden maxout layer
+    to the computation of the RNN output (formulas for t and t_tilde on page
+    14 of the article.
+    """
+    def __init__(self, encoders, vocabulary, data_id, maxout_size, **kwargs):
+        """Create a new instance of the decoder.
+
+        For the description of the arguments except maxout_size, see
+        docs for neuralmonkey.decoders.decoder.Decoder.
+
+        Arguments:
+            maxout_size: The size of the hidden maxout layer (denoted as l in
+                         the article.
+        """
+        self.maxout_size = maxout_size
+        super().__init__(encoders, vocabulary, data_id, **kwargs)
+
+
+    def _rnn_output_proj_params(self):
+        """Create parameters for projection of RNN outputs to vocabulary
+        indices.
+
+        This method provides the projection parameters betweeen the maxout
+        layer and the final logits.
+        """
+        weights = tf.get_variable(
+            "maxout_to_word_W", [self.maxout_size, self.vocabulary_size])
+        biases = tf.get_variable(
+            "maxout_to_word_b",
+            initializer=tf.zeros_initializer([self.vocabulary_size]))
+
+        return weights, biases
+
+
+    def _get_rnn_output(self, prev_state, prev_output, ctx_tensors):
+        """Compute RNN output out of the previous state and output, and the
+        context tensors returned from attention mechanisms, as described
+        in the article
+
+        This function corresponds to the equations for computation the
+        t_tilde in the Bahdanau et al. (2015) paper, on page 14,
+        with the maxout projection, before the last linear projection.
+
+        Arguments:
+            prev_state: Previous decoder RNN state.
+            prev_output: Embedded output of the previous step.
+            ctx_tensors: Context tensors computed by the attentions.
+
+        Returns:
+            Returns the maxout projection of the concatenated inputs
+        """
+        return maxout([prev_state, prev_output] + ctx_tensors,
+                      self.maxout_size)

--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -261,7 +261,6 @@ class Decoder(object):
 
     def _get_rnn_cell(self):
         """Returns a RNNCell object for this decoder"""
-
         return tf.nn.rnn_cell.GRUCell(self.rnn_size)
 
 
@@ -269,7 +268,6 @@ class Decoder(object):
         """Collect attention objects from encoders."""
         if not self.use_attention:
             return []
-
         return [e.attention_object for e in self.encoders if e.attention_object]
 
 
@@ -298,20 +296,18 @@ class Decoder(object):
         return inputs
 
 
-    def _loop_function(self, previous_state, i):
+    def _loop_function(self, rnn_output):
         """Basic loop function. Projects state to logits, take the
         argmax of the logits, embed the word and perform dropout on the
         embedding vector.
 
         Arguments:
-            previous_state: The state of the decoder
-            i: Unused argument, number of the time step
+            rnn_output: The output of the decoder RNN
         """
-        output_activation = self._logit_function(previous_state)
+        output_activation = self._logit_function(rnn_output)
         previous_word = tf.argmax(output_activation, 1)
         input_embedding = tf.nn.embedding_lookup(self.embedding_matrix,
                                                      previous_word)
-
         return self._dropout(input_embedding)
 
 
@@ -319,7 +315,7 @@ class Decoder(object):
         """Compute logits on the vocabulary given the state
 
         Arguments:
-            state: the state of the decoder
+            rnn_output: the output of the decoder RNN
         """
         return tf.matmul(self._dropout(rnn_output), self.weights) + self.biases
 
@@ -356,7 +352,7 @@ class Decoder(object):
                 tf.get_variable_scope().reuse_variables()
 
                 if runtime_mode:
-                    current_input = self._loop_function(output, step)
+                    current_input = self._loop_function(output)
                 else:
                     current_input = inputs[step]
 

--- a/neuralmonkey/decoding_function.py
+++ b/neuralmonkey/decoding_function.py
@@ -7,40 +7,11 @@ See http://arxiv.org/abs/1606.07481
 #tests: lint
 
 import tensorflow as tf
-
 from neuralmonkey.nn.projection import linear
-
-# def decode_step(prev_output, prev_state, attention_objects,
-#                 rnn_cell, maxout_size):
-#     """This function implements equations in section A.2.2 of the
-#     Bahdanau et al. (2015) paper, on pages 13 and 14.
-
-#     Arguments:
-#         prev_output: Previous decoded output (denoted by y_i-1)
-#         prev_state: Previous state (denoted by s_i-1)
-#         attention_objects: Objects that do attention
-#         rnn_cell: The RNN cell to use (should be GRU)
-#         maxout_size: The size of the maxout hidden layer (denoted by l)
-
-#     Returns:
-#         Tuple of the new output and state
-#     """
-#     ## compute c_i:
-#     contexts = [a.attention(prev_state) for a in attention_objects]
-
-#     # TODO dropouts??
-
-#     ## compute t_i:
-#     output = maxout([prev_state, prev_output] + contexts, maxout_size)
-
-#     ## compute s_i based on y_i-1, c_i and s_i-1
-#     _, state = rnn_cell(tf.concat(1, [prev_output] + contexts), prev_state)
-
-#     return output, state
 
 
 class Attention(object):
-    #pylint: disable=unused-argument,too-many-instance-attributes
+    #pylint: disable=unused-argument,too-many-instance-attributes,too-many-arguments
     # For maintaining the same API as in CoverageAttention
     def __init__(self, attention_states, scope, dropout_placeholder,
                  input_weights=None, max_fertility=None):

--- a/tests/bahdanau.ini
+++ b/tests/bahdanau.ini
@@ -30,7 +30,6 @@ class=evaluators.bleu.BLEUEvaluator
 class=config.utils.dataset_from_files
 s_source=tests/data/train.tc.en
 s_target=tests/data/train.tc.de
-lazy=True
 
 [val_data]
 ; Validation data, the languages are not necessary here, encoders and decoders
@@ -43,17 +42,16 @@ s_target=tests/data/val.tc.de
 class=config.utils.vocabulary_from_dataset
 datasets=[<train_data>]
 series_ids=[source]
-max_size=5000
+max_size=60
 save_file=tests/tmp-test-output/encoder_vocabulary.pickle
 overwrite=True
 
 [encoder]
 class=encoders.sentence_encoder.SentenceEncoder
 name=sentence_encoder
-rnn_size=256
+rnn_size=7
 max_input_len=10
-embedding_size=200
-dropout_keep_p=0.5
+embedding_size=11
 attention_type=decoding_function.Attention
 data_id=source
 vocabulary=<encoder_vocabulary>
@@ -62,7 +60,7 @@ vocabulary=<encoder_vocabulary>
 class=config.utils.vocabulary_from_dataset
 datasets=[<train_data>]
 series_ids=[target]
-max_size=5000
+max_size=70
 save_file=tests/tmp-test-output/decoder_vocabulary.pickle
 overwrite=True
 
@@ -71,10 +69,10 @@ class=decoders.bahdanau_decoder.BahdanauDecoder
 name=bahdanau_decoder
 encoders=[<encoder>]
 project_encoder_outputs=True
-rnn_size=211
-embedding_size=317
+rnn_size=8
+embedding_size=9
 use_attention=True
-maxout_size=197
+maxout_size=6
 dropout_keep_p=0.5
 data_id=target
 max_output_len=10
@@ -85,14 +83,6 @@ vocabulary=<decoder_vocabulary>
 class=trainers.cross_entropy_trainer.CrossEntropyTrainer
 decoder=<decoder>
 l2_regularization=1.0e-8
-clip_norm=1.0
-optimizer=<adadelta>
-
-[adadelta]
-class=config.utils.adadelta_optimizer
-epsilon=1.0e-6
-rho=0.95
-
 
 [runner]
 ; This block is used for both validation and testing to run the model on

--- a/tests/bahdanau.ini
+++ b/tests/bahdanau.ini
@@ -67,13 +67,14 @@ save_file=tests/tmp-test-output/decoder_vocabulary.pickle
 overwrite=True
 
 [decoder]
-class=decoders.decoder.Decoder
-name=decoder
+class=decoders.bahdanau_decoder.BahdanauDecoder
+name=bahdanau_decoder
 encoders=[<encoder>]
 project_encoder_outputs=True
 rnn_size=211
 embedding_size=317
 use_attention=True
+maxout_size=197
 dropout_keep_p=0.5
 data_id=target
 max_output_len=10

--- a/tests/tests_run.sh
+++ b/tests/tests_run.sh
@@ -3,10 +3,10 @@
 set -ex
 
 bin/neuralmonkey-train tests/vocab.ini
+bin/neuralmonkey-train tests/bahdanau.ini
 
 bin/neuralmonkey-train tests/small.ini
 bin/neuralmonkey-run tests/small.ini tests/test_data.ini
-
 bin/neuralmonkey-server --configuration=tests/small.ini --port=5000 &
 SERVER_PID=$!
 sleep 20
@@ -14,4 +14,4 @@ sleep 20
 curl 127.0.0.1:5000 -H "Content-Type: application/json" -X POST -d '{"source": ["I am the eggman.", "I am the walrus ."]}'
 kill $SERVER_PID
 
-rm -r tests/tmp-test-output
+rm -rf tests/tmp-test-output


### PR DESCRIPTION
- The maxout is thrown away from the original decoder and put in the new BahdanauDecoder. 
- The ``attention_decoder`` function from the ``decoding_funciton`` module is now a part of the Decoder.
- The Decoder contains another method ``_get_rnn_output`` which computes the tensor that is used in each tim step as the input for the final computation of the distribution over the vocabulary.
- Also, all ``tf.Variable`` calls in the Decoder were replaced with ``tf.get_variable``
- The new ``BahdanauDecoder`` inherits from the ``Decoder`` and overrides the ``_get_rnn_output`` and ``_rnn_output_proj_params`` methods.

This PR solves issues #147, #142 (in a way),  #127 (only partially) and maybe more...