### PR TITLE
Batch size for test and validation

### DIFF
--- a/neuralmonkey/run.py
+++ b/neuralmonkey/run.py
@@ -16,6 +16,7 @@ CONFIG.add_argument('postprocess')
 CONFIG.add_argument('evaluation', list)
 CONFIG.add_argument('runners', list)
 CONFIG.add_argument('threads', int, required=False, default=4)
+CONFIG.add_argument('runners_batch_size', int, required=False, default=None)
 # ignore arguments which are just for training
 CONFIG.ignore_argument('val_dataset')
 CONFIG.ignore_argument('trainer')

--- a/neuralmonkey/train.py
+++ b/neuralmonkey/train.py
@@ -35,6 +35,7 @@ def create_config(config_file):
     config.add_argument('save_n_best', int, required=False, default=1)
     config.add_argument('logging_period', int, required=False, default=20)
     config.add_argument('validation_period', int, required=False, default=500)
+    config.add_argument('runners_batch_size', int, required=False, default=None)
     config.add_argument('minimize', bool, required=False, default=False)
     config.add_argument('postprocess')
     config.add_argument('name', str)

--- a/tests/small.ini
+++ b/tests/small.ini
@@ -15,6 +15,7 @@ postprocess=None
 evaluation=[(target, <bleu>)]
 logging_period=20
 validation_period=60
+runners_batch_size=1
 test_datasets=[<val_data>,<val_data_no_target>]
 
 [tf_manager]


### PR DESCRIPTION
This PR introduces setting batch size for validation and testing. It can be do by setting the `runners_batch_size` field the main section of the configuration.