### PR TITLE
Separate training and runtime attention

### DIFF
--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -335,8 +335,7 @@ class Decoder(object):
         with tf.variable_scope(scope):
 
             ## First decoding step
-            contexts = [a.attention(initial_state, runtime_mode)
-                        for a in att_objects]
+            contexts = [a.attention(initial_state) for a in att_objects]
             output = self.output_projection(inputs[0], initial_state, contexts)
             _, state = cell(tf.concat(1, [inputs[0]] + contexts), initial_state)
 
@@ -355,8 +354,7 @@ class Decoder(object):
                     current_input = inputs[step]
 
                 ## N-th decoding step
-                contexts = [a.attention(state, runtime_mode)
-                            for a in att_objects]
+                contexts = [a.attention(state) for a in att_objects]
                 output = self.output_projection(current_input, state, contexts)
                 _, state = cell(tf.concat(1, [current_input] + contexts), state)
 
@@ -368,7 +366,7 @@ class Decoder(object):
 
             if runtime_mode:
                 for i, a in enumerate(att_objects):
-                    attentions = a.get_attentions_in_time(runtime_mode=True)
+                    attentions = a.attentions_in_time[-len(inputs):]
                     alignments = tf.expand_dims(tf.transpose(
                         tf.pack(attentions), perm=[1, 2, 0]), -1)
 

--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -250,12 +250,8 @@ class Decoder(object):
         if not self.use_attention:
             return []
 
-        if runtime_mode:
-            return [e.attention_object_runtime for e in self.encoders
-                    if e.attention_object_runtime]
-        else:
-            return [e.attention_object_train for e in self.encoders
-                    if e.attention_object_train]
+        return [e.get_attention_object(runtime_mode)
+                for e in self.encoders]
 
     def _embed_inputs(self, inputs):
         """Embed inputs using the decoder"s word embedding matrix

--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -335,7 +335,8 @@ class Decoder(object):
         with tf.variable_scope(scope):
 
             ## First decoding step
-            contexts = [a.attention(initial_state) for a in att_objects]
+            contexts = [a.attention(initial_state, runtime_mode)
+                        for a in att_objects]
             output = self.output_projection(inputs[0], initial_state, contexts)
             _, state = cell(tf.concat(1, [inputs[0]] + contexts), initial_state)
 
@@ -354,7 +355,8 @@ class Decoder(object):
                     current_input = inputs[step]
 
                 ## N-th decoding step
-                contexts = [a.attention(state) for a in att_objects]
+                contexts = [a.attention(state, runtime_mode)
+                            for a in att_objects]
                 output = self.output_projection(current_input, state, contexts)
                 _, state = cell(tf.concat(1, [current_input] + contexts), state)
 
@@ -366,7 +368,7 @@ class Decoder(object):
 
             if runtime_mode:
                 for i, a in enumerate(att_objects):
-                    attentions = a.attentions_in_time[-len(inputs):]
+                    attentions = a.get_attentions_in_time(runtime_mode=True)
                     alignments = tf.expand_dims(tf.transpose(
                         tf.pack(attentions), perm=[1, 2, 0]), -1)
 

--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -245,12 +245,17 @@ class Decoder(object):
         return OrthoGRUCell(self.rnn_size)
 
 
-    def _collect_attention_objects(self):
+    def _collect_attention_objects(self, runtime_mode):
         """Collect attention objects from encoders."""
         if not self.use_attention:
             return []
-        return [e.attention_object for e in self.encoders if e.attention_object]
 
+        if runtime_mode:
+            return [e.attention_object_runtime for e in self.encoders
+                    if e.attention_object_runtime]
+        else:
+            return [e.attention_object_train for e in self.encoders
+                    if e.attention_object_train]
 
     def _embed_inputs(self, inputs):
         """Embed inputs using the decoder"s word embedding matrix
@@ -323,7 +328,7 @@ class Decoder(object):
             scope: The variable scope to use with this function.
         """
         cell = self._get_rnn_cell()
-        att_objects = self._collect_attention_objects()
+        att_objects = self._collect_attention_objects(runtime_mode)
 
         ## Broadcast the initial state to the whole batch if needed
         if len(initial_state.get_shape()) == 1:
@@ -366,9 +371,8 @@ class Decoder(object):
 
             if runtime_mode:
                 for i, a in enumerate(att_objects):
-                    attentions = a.attentions_in_time[-len(inputs):]
                     alignments = tf.expand_dims(tf.transpose(
-                        tf.pack(attentions), perm=[1, 2, 0]), -1)
+                        tf.pack(a.attentions_in_time), perm=[1, 2, 0]), -1)
 
                     tf.image_summary("attention_{}".format(i), alignments,
                                      collections=["summary_val_plots"],

--- a/neuralmonkey/decoding_function.py
+++ b/neuralmonkey/decoding_function.py
@@ -30,8 +30,7 @@ class Attention(object):
                           for runtime decoding.
         """
         self.scope = scope
-        self._train_attentions_in_time = []
-        self._runtime_attentions_in_time = []
+        self.attentions_in_time = []
         self.attention_states = attention_states
         self.input_weights = input_weights
 

--- a/neuralmonkey/decoding_function.py
+++ b/neuralmonkey/decoding_function.py
@@ -15,7 +15,8 @@ class Attention(object):
     # For maintaining the same API as in CoverageAttention
 
     def __init__(self, attention_states, scope,
-                 input_weights=None, max_fertility=None, runtime_mode=False):
+                 input_weights=None, attention_fertility=None,
+                 runtime_mode=False):
         """Create the attention object.
 
         Args:
@@ -24,8 +25,8 @@ class Attention(object):
             scope: The name of the variable scope in the graph used by this
                    attention object.
             input_weights: (Optional) The padding weights on the input.
-            max_fertility: (Optional) For the Coverage attention compatibilty,
-                           maximum fertility of one word.
+            attention_fertility: (Optional) For the Coverage attention
+                compatibilty, maximum fertility of one word.
             runtime_mode: (Optional) Indicates whether the object will be used
                           for runtime decoding.
         """
@@ -109,19 +110,20 @@ class CoverageAttention(Attention):
     # pylint: disable=too-many-arguments
     # Great objects require great number of parameters
     def __init__(self, attention_states, scope,
-                 input_weights=None, max_fertility=5):
+                 input_weights=None, attention_fertility=5):
 
-        super(CoverageAttention, self).__init__(attention_states, scope,
-                                                input_weights=input_weights,
-                                                max_fertility=max_fertility)
+        super(CoverageAttention, self).__init__(
+            attention_states, scope,
+            input_weights=input_weights,
+            attention_fertility=attention_fertility)
 
         self.coverage_weights = tf.get_variable("coverage_matrix",
                                                 [1, 1, 1, self.attn_size])
         self.fertility_weights = tf.get_variable("fertility_matrix",
                                                  [1, 1, self.attn_size])
-        self.max_fertility = max_fertility
+        self.attention_fertility = attention_fertility
 
-        self.fertility = 1e-8 + self.max_fertility * tf.sigmoid(
+        self.fertility = 1e-8 + self.attention_fertility * tf.sigmoid(
             tf.reduce_sum(self.fertility_weights * self.attention_states, [2]))
 
     def get_logits(self, y):

--- a/neuralmonkey/decoding_function.py
+++ b/neuralmonkey/decoding_function.py
@@ -14,8 +14,8 @@ class Attention(object):
     # pylint: disable=unused-argument,too-many-instance-attributes,too-many-arguments
     # For maintaining the same API as in CoverageAttention
 
-    def __init__(self, attention_states, scope, input_weights=None,
-                 max_fertility=None):
+    def __init__(self, attention_states, scope,
+                 input_weights=None, max_fertility=None, runtime_mode=False):
         """Create the attention object.
 
         Args:
@@ -26,6 +26,8 @@ class Attention(object):
             input_weights: (Optional) The padding weights on the input.
             max_fertility: (Optional) For the Coverage attention compatibilty,
                            maximum fertility of one word.
+            runtime_mode: (Optional) Indicates whether the object will be used
+                          for runtime decoding.
         """
         self.scope = scope
         self._train_attentions_in_time = []
@@ -33,7 +35,7 @@ class Attention(object):
         self.attention_states = attention_states
         self.input_weights = input_weights
 
-        with tf.variable_scope(scope):
+        with tf.variable_scope(scope, reuse=runtime_mode):
             self.attn_length = attention_states.get_shape()[1].value
             self.attn_size = attention_states.get_shape()[2].value
 

--- a/neuralmonkey/decoding_function.py
+++ b/neuralmonkey/decoding_function.py
@@ -28,7 +28,8 @@ class Attention(object):
                            maximum fertility of one word.
         """
         self.scope = scope
-        self.attentions_in_time = []
+        self._train_attentions_in_time = []
+        self._runtime_attentions_in_time = []
         self.attention_states = attention_states
         self.input_weights = input_weights
 
@@ -62,10 +63,15 @@ class Attention(object):
             self.v_bias = tf.get_variable(
                 "AttnV_b", [], initializer=tf.constant_initializer(0))
 
-    def attention(self, query_state):
+    def get_attentions_in_time(self, runtime_mode):
+        return self._runtime_attentions_in_time if runtime_mode \
+               else self._train_attentions_in_time
+
+    def attention(self, query_state, runtime_mode):
         """Put attention masks on att_states_reshaped
            using hidden_features and query.
         """
+        attentions_in_time = self.get_attentions_in_time(runtime_mode)
 
         with tf.variable_scope(self.scope + "/Attention") as varscope:
             # Sort-of a hack to get the matrix (bahdanau's W_a) in the linear
@@ -79,7 +85,7 @@ class Attention(object):
             # pylint: disable=invalid-name
             # code copied from tensorflow. Suggestion: rename the variables
             # according to the Bahdanau paper
-            s = self.get_logits(y)
+            s = self.get_logits(y, runtime_mode)
 
             if self.input_weights is None:
                 a = tf.nn.softmax(s)
@@ -88,7 +94,7 @@ class Attention(object):
                 norm = tf.reduce_sum(a_all, 1, keep_dims=True) + 1e-8
                 a = a_all / norm
 
-            self.attentions_in_time.append(a)
+            attentions_in_time.append(a)
 
             # Now calculate the attention-weighted vector d.
             d = tf.reduce_sum(tf.reshape(a, [-1, self.attn_length, 1, 1])
@@ -96,7 +102,7 @@ class Attention(object):
 
             return tf.reshape(d, [-1, self.attn_size])
 
-    def get_logits(self, y):
+    def get_logits(self, y, runtime_mode):
         # Attention mask is a softmax of v^T * tanh(...).
         return tf.reduce_sum(
             self.v * tf.tanh(self.hidden_features + y), [2, 3]) + self.v_bias
@@ -122,9 +128,10 @@ class CoverageAttention(Attention):
         self.fertility = 1e-8 + self.max_fertility * tf.sigmoid(
             tf.reduce_sum(self.fertility_weights * self.attention_states, [2]))
 
-    def get_logits(self, y):
+    def get_logits(self, y, runtime_mode):
+        attentions_in_time = self.get_attentions_in_time(runtime_mode)
         coverage = sum(
-            self.attentions_in_time) / self.fertility * self.input_weights
+            attentions_in_time) / self.fertility * self.input_weights
 
         logits = tf.reduce_sum(
             self.v * tf.tanh(

--- a/neuralmonkey/decoding_function.py
+++ b/neuralmonkey/decoding_function.py
@@ -35,7 +35,7 @@ class Attention(object):
         self.attention_states = attention_states
         self.input_weights = input_weights
 
-        with tf.variable_scope(scope, reuse=runtime_mode):
+        with tf.variable_scope(scope):
             self.attn_length = attention_states.get_shape()[1].value
             self.attn_size = attention_states.get_shape()[2].value
 

--- a/neuralmonkey/encoders/attentive.py
+++ b/neuralmonkey/encoders/attentive.py
@@ -2,17 +2,19 @@
 class Attentive(object):
     def __init__(self, attention_type, **kwargs):
         self._attention_type = attention_type
-        self._attention_tensor = None
-        self._padding = None
-        self.name = None
         self._attention_kwargs = kwargs
 
+        assert hasattr(self, "name")
+        assert hasattr(self, "_padding")
+        assert hasattr(self, "_attention_tensor")
+
     def get_attention_object(self, runtime: bool=False):
+        # pylint: disable=no-member
         if self._attention_type and self._attention_tensor is None:
             raise Exception("Can't get attention: missing attention tensor.")
         if self._attention_type and self.name is None:
-            raise Exception("Can't get attention: missing encoder's.")
-        if self._attention_type and self._padding:
+            raise Exception("Can't get attention: missing encoder's name.")
+        if self._attention_type and self._padding is None:
             raise Exception("Can't get attention: missing input padding.")
 
         return self._attention_type(

--- a/neuralmonkey/encoders/attentive.py
+++ b/neuralmonkey/encoders/attentive.py
@@ -11,11 +11,11 @@ class Attentive(object):
     def get_attention_object(self, runtime: bool=False):
         # pylint: disable=no-member
         if self._attention_type and self._attention_tensor is None:
-            raise Exception("Can't get attention: missing attention tensor.")
+            raise ValueError("Can't get attention: missing attention tensor.")
         if self._attention_type and self.name is None:
-            raise Exception("Can't get attention: missing encoder's name.")
+            raise ValueError("Can't get attention: missing encoder's name.")
         if self._attention_type and self._padding is None:
-            raise Exception("Can't get attention: missing input padding.")
+            raise ValueError("Can't get attention: missing input padding.")
 
         return self._attention_type(
             self._attention_tensor,

--- a/neuralmonkey/encoders/attentive.py
+++ b/neuralmonkey/encoders/attentive.py
@@ -1,0 +1,23 @@
+# pylint: disable=too-few-public-methods
+class Attentive(object):
+    def __init__(self, attention_type, **kwargs):
+        self._attention_type = attention_type
+        self._attention_tensor = None
+        self._padding = None
+        self.name = None
+        self._attention_kwargs = kwargs
+
+    def get_attention_object(self, runtime: bool=False):
+        if self._attention_type and self._attention_tensor is None:
+            raise Exception("Can't get attention: missing attention tensor.")
+        if self._attention_type and self.name is None:
+            raise Exception("Can't get attention: missing encoder's.")
+        if self._attention_type and self._padding:
+            raise Exception("Can't get attention: missing input padding.")
+
+        return self._attention_type(
+            self._attention_tensor,
+            scope="attention_{}".format(self.name),
+            input_weights=self._padding,
+            runtime_mode=runtime,
+            **self._attention_kwargs) if self._attention_type else None

--- a/neuralmonkey/encoders/attentive.py
+++ b/neuralmonkey/encoders/attentive.py
@@ -1,25 +1,31 @@
+import tensorflow as tf
+
 # pylint: disable=too-few-public-methods
 class Attentive(object):
     def __init__(self, attention_type, **kwargs):
         self._attention_type = attention_type
         self._attention_kwargs = kwargs
 
-        assert hasattr(self, "name")
-        assert hasattr(self, "_padding")
-        assert hasattr(self, "_attention_tensor")
-
     def get_attention_object(self, runtime: bool=False):
         # pylint: disable=no-member
-        if self._attention_type and self._attention_tensor is None:
-            raise ValueError("Can't get attention: missing attention tensor.")
-        if self._attention_type and self.name is None:
-            raise ValueError("Can't get attention: missing encoder's name.")
-        if self._attention_type and self._padding is None:
-            raise ValueError("Can't get attention: missing input padding.")
+        if hasattr(self, "name") and self.name:
+            name = self.name
+        else:
+            name = str(self)
 
         return self._attention_type(
             self._attention_tensor,
-            scope="attention_{}".format(self.name),
-            input_weights=self._padding,
+            scope="attention_{}".format(name),
+            input_weights=self._attention_mask,
             runtime_mode=runtime,
             **self._attention_kwargs) if self._attention_type else None
+
+    @property
+    def _attention_tensor(self):
+        """Tensor over which the attention is done."""
+        raise NotImplementedError(
+            "Attentive object is missing attention_tensor.")
+
+    @property
+    def _attention_mask(self):
+        return tf.ones(tf.shape(self._attention_tensor))

--- a/neuralmonkey/encoders/attentive.py
+++ b/neuralmonkey/encoders/attentive.py
@@ -1,12 +1,21 @@
+from abc import ABCMeta, abstractproperty
 import tensorflow as tf
 
 # pylint: disable=too-few-public-methods
-class Attentive(object):
+class Attentive(metaclass=ABCMeta):
+    """A base class fro an attentive part of graph (typically encoder).
+
+    Objects inheriting this class are able to generate an attention object that
+    allows a decoder to perform attention over an attention_object provided by
+    the encoder (e.g., input word representations in case of MT or
+    convolutional maps in case of image captioning).
+    """
     def __init__(self, attention_type, **kwargs):
         self._attention_type = attention_type
         self._attention_kwargs = kwargs
 
     def get_attention_object(self, runtime: bool=False):
+        """Attention object that can be used in decoder."""
         # pylint: disable=no-member
         if hasattr(self, "name") and self.name:
             name = self.name
@@ -20,7 +29,7 @@ class Attentive(object):
             runtime_mode=runtime,
             **self._attention_kwargs) if self._attention_type else None
 
-    @property
+    @abstractproperty
     def _attention_tensor(self):
         """Tensor over which the attention is done."""
         raise NotImplementedError(
@@ -28,4 +37,5 @@ class Attentive(object):
 
     @property
     def _attention_mask(self):
+        """Zero/one masking the attention logits."""
         return tf.ones(tf.shape(self._attention_tensor))

--- a/neuralmonkey/encoders/cnn_encoder.py
+++ b/neuralmonkey/encoders/cnn_encoder.py
@@ -219,7 +219,7 @@ class CNNEncoder(Attentive):
             self._padding = tf.squeeze(
                 tf.reduce_prod(last_padding_masks, [1]), [2])
 
-            super(CNNEncoder, self).__init__(attention_type)
+            super().__init__(attention_type)
 
     def feed_dict(self, dataset, train=False):
         # if it is from the pickled file, it is list, not numpy tensor,

--- a/neuralmonkey/encoders/cnn_encoder.py
+++ b/neuralmonkey/encoders/cnn_encoder.py
@@ -214,11 +214,11 @@ class CNNEncoder(Attentive):
 
             self.encoded = encoder_state
 
-            self.__attention_tensor = \
-                tf.reshape(last_layer, [-1, image_width,
-                                        last_n_channels * image_height])
+            self.__attention_tensor = tf.reshape(
+                last_layer, [-1, image_width,
+                             last_n_channels * image_height])
 
-            self.__attention_weights = tf.squeeze(
+            self.__attention_mask = tf.squeeze(
                 tf.reduce_prod(last_padding_masks, [1]), [2])
 
     @property
@@ -227,7 +227,7 @@ class CNNEncoder(Attentive):
 
     @property
     def _attention_mask(self):
-        return self.__attention_weights
+        return self.__attention_mask
 
     def feed_dict(self, dataset, train=False):
         # if it is from the pickled file, it is list, not numpy tensor,

--- a/neuralmonkey/encoders/cnn_encoder.py
+++ b/neuralmonkey/encoders/cnn_encoder.py
@@ -87,6 +87,7 @@ class CNNEncoder(Attentive):
                 dropout keeping probability
 
         """
+        super().__init__(attention_type)
 
         self.convolutions = convolutions
         self.data_id = data_id
@@ -203,6 +204,7 @@ class CNNEncoder(Attentive):
             encoder_state = rnn_encoder(
                 encoder_ins, last_layer_size, "encoder-forward")
 
+            # pylint: disable=redefined-variable-type
             if bidirectional:
                 backward_encoder_state = rnn_encoder(
                     list(reversed(encoder_ins)),
@@ -212,14 +214,20 @@ class CNNEncoder(Attentive):
 
             self.encoded = encoder_state
 
-            self.attention_tensor = \
+            self.__attention_tensor = \
                 tf.reshape(last_layer, [-1, image_width,
                                         last_n_channels * image_height])
 
-            self._padding = tf.squeeze(
+            self.__attention_weights = tf.squeeze(
                 tf.reduce_prod(last_padding_masks, [1]), [2])
 
-            super().__init__(attention_type)
+    @property
+    def _attention_tensor(self):
+        return self.__attention_tensor
+
+    @property
+    def _attention_mask(self):
+        return self.__attention_weights
 
     def feed_dict(self, dataset, train=False):
         # if it is from the pickled file, it is list, not numpy tensor,

--- a/neuralmonkey/encoders/cnn_encoder.py
+++ b/neuralmonkey/encoders/cnn_encoder.py
@@ -220,10 +220,15 @@ class CNNEncoder(object):
             att_in_weights = tf.squeeze(
                 tf.reduce_prod(last_padding_masks, [1]), [2])
 
-            self.attention_object = Attention(self.attention_tensor,
-                                              scope="attention_{}".format(
-                                                  name),
-                                              input_weights=att_in_weights)
+            def attention_object(runtime=False):
+                return Attention(self.attention_tensor,
+                    scope="attention_{}".format(name),
+                    dropout_placeholder=self.dropout_placeholder,
+                    input_weights=att_in_weights,
+                    runtime_mode=runtime)
+
+            self.attention_object_train = attention_object()
+            self.attention_object_runtime = attention_object(runtime=True)
 
     def feed_dict(self, dataset, train=False):
         # if it is from the pickled file, it is list, not numpy tensor,

--- a/neuralmonkey/encoders/factored_encoder.py
+++ b/neuralmonkey/encoders/factored_encoder.py
@@ -71,8 +71,8 @@ class FactoredEncoder(Attentive):
                 weight_tensor = tf.concat(
                         1, [tf.expand_dims(w, 1) for w in self.padding_weights])
 
-                super(FactoredEncoder, self).__init__(
-                        attention_type, attention_fertility=attention_fertility)
+                super().__init__(
+                    attention_type, attention_fertility=attention_fertility)
 
                 log("Encoder graph constructed.")
 
@@ -176,8 +176,8 @@ class FactoredEncoder(Attentive):
 
     # pylint: disable=too-many-locals
     def feed_dict(self, dataset, train=False):
-        factors = {data_id: dataset.get_series(
-            data_id) for data_id in self.data_ids}
+        factors = {data_id: dataset.get_series(data_id)
+                   for data_id in self.data_ids}
 
         # this method should be responsible for checking if the factored
         # sentences are of the same length

--- a/neuralmonkey/encoders/factored_encoder.py
+++ b/neuralmonkey/encoders/factored_encoder.py
@@ -75,7 +75,7 @@ class FactoredEncoder(Attentive):
 
     @property
     def _attention_mask(self):
-        return self.__attention_weights
+        return self.__attention_mask
 
     @property
     def _attention_tensor(self):
@@ -178,7 +178,7 @@ class FactoredEncoder(Attentive):
                                                 for o in self.outputs_bidi])
         self.__attention_tensor = tf.nn.dropout(self.__attention_tensor,
                                                 self.dropout_placeholder)
-        self.__attention_weights = tf.concat(
+        self.__attention_mask = tf.concat(
             1, [tf.expand_dims(w, 1) for w in self.padding_weights])
 
     # pylint: disable=too-many-locals

--- a/neuralmonkey/encoders/factored_encoder.py
+++ b/neuralmonkey/encoders/factored_encoder.py
@@ -11,13 +11,14 @@ from neuralmonkey.vocabulary import Vocabulary
 
 # tests: lint, mypy
 
+# pylint: disable=too-many-instance-attributes
 class FactoredEncoder(Attentive):
     """Implementation of a generic encoder that processes an arbitrary
     number of input sequences.
     """
 
     def __init__(self, max_input_len, vocabularies, data_ids, embedding_sizes,
-            rnn_size, **kwargs):
+                 rnn_size, **kwargs):
         """Construct a new instance of the factored encoder.
 
         Args:
@@ -68,8 +69,8 @@ class FactoredEncoder(Attentive):
 
             # Attention mechanism
             if attention_type is not None:
-                weight_tensor = tf.concat(
-                        1, [tf.expand_dims(w, 1) for w in self.padding_weights])
+                self._padding = tf.concat(
+                    1, [tf.expand_dims(w, 1) for w in self.padding_weights])
 
                 super().__init__(
                     attention_type, attention_fertility=attention_fertility)
@@ -91,7 +92,7 @@ class FactoredEncoder(Attentive):
             # TODO shape needs recomputing
 
             dropout_mask = tf.floor(tf.random_uniform(shape, 0.0, 1.0)
-                    + self.dropout_placeholder)
+                                    + self.dropout_placeholder)
 
             scale = tf.inv(self.dropout_placeholder)
             cell = PervasiveDropoutWrapper(cell, dropout_mask, scale)

--- a/neuralmonkey/encoders/factored_encoder.py
+++ b/neuralmonkey/encoders/factored_encoder.py
@@ -71,12 +71,17 @@ class FactoredEncoder(object):
                 weight_tensor = tf.concat(
                     1, [tf.expand_dims(w, 1) for w in self.padding_weights])
 
-                self.attention_object = attention_type(
-                    self.attention_tensor,
-                    scope="attention_{}".format(self.name),
-                    dropout_placeholder=self.dropout_placeholder,
-                    input_weights=weight_tensor,
-                    max_fertility=attention_fertility)
+                def attention_object(runtime=False):
+                    return attention_type(
+                        self.attention_tensor,
+                        scope="attention_{}".format(self.name),
+                        dropout_placeholder=self.dropout_placeholder,
+                        input_weights=weight_tensor,
+                        max_fertility=attention_fertility,
+                        runtime_mode=runtime)
+
+                self.attention_object_train = attention_object()
+                self.attention_object_runtime = attention_object(runtime=True)
 
         log("Encoder graph constructed.")
 

--- a/neuralmonkey/encoders/image_encoder.py
+++ b/neuralmonkey/encoders/image_encoder.py
@@ -25,8 +25,6 @@ class VectorEncoder(object):
 
         self.encoded = tf.tanh(tf.matmul(self.flat, project_w) + project_b)
 
-        self.attention_tensor = None
-
     # pylint: disable=unused-argument
     def feed_dict(self, dataset, train=False):
         return {self.image_features: dataset.get_series(self.data_id)}
@@ -37,6 +35,7 @@ class PostCNNImageEncoder(Attentive):
     def __init__(self, input_shape, output_shape, data_id, name,
                  dropout_keep_prob=1.0, attention_type=None):
         assert len(input_shape) == 3
+        super().__init__(attention_type)
 
         self.input_shape = input_shape
         self.output_shape = output_shape
@@ -64,15 +63,15 @@ class PostCNNImageEncoder(Attentive):
 
             self.encoded = tf.tanh(tf.matmul(self.flat, project_w) + project_b)
 
-            self._attention_tensor = \
-                tf.reshape(self.image_features,
-                           [-1, input_shape[0] * input_shape[1],
-                            input_shape[2]],
-                           name="flatten_image")
+            self.__attention_tensor = tf.reshape(
+                self.image_features,
+                [-1, input_shape[0] * input_shape[1],
+                 input_shape[2]],
+                name="flatten_image")
 
-            self._padding = tf.ones(tf.shape(self._attention_tensor))
-
-        super().__init__(attention_type)
+    @property
+    def _attention_tensor(self):
+        return self.__attention_tensor
 
     def feed_dict(self, dataset, train=False):
         res = {self.image_features: dataset.get_series(self.data_id)}

--- a/neuralmonkey/encoders/sentence_encoder.py
+++ b/neuralmonkey/encoders/sentence_encoder.py
@@ -104,7 +104,7 @@ class SentenceEncoder(Attentive):
 
     @property
     def _attention_mask(self):
-        return self.__input_weights
+        return self._input_mask
 
     @property
     def vocabulary_size(self):
@@ -119,12 +119,12 @@ class SentenceEncoder(Attentive):
         self.inputs = tf.placeholder(tf.int32, shape=[None, self.max_input_len],
                                      name="encoder_input")
 
-        self.__input_weights = tf.placeholder(
+        self._input_mask = tf.placeholder(
             tf.float32, shape=[None, self.max_input_len],
             name="encoder_padding")
 
         self.sentence_lengths = tf.to_int32(
-            tf.reduce_sum(self.__input_weights, 1))
+            tf.reduce_sum(self._input_mask, 1))
 
 
     def _create_embedding_matrix(self):
@@ -213,6 +213,6 @@ class SentenceEncoder(Attentive):
         # as sentences_to_tensor returns lists of shape (time, batch),
         # we need to transpose
         fd[self.inputs] = list(zip(*vectors))
-        fd[self.__input_weights] = list(zip(*paddings))
+        fd[self._input_mask] = list(zip(*paddings))
 
         return fd

--- a/neuralmonkey/encoders/sentence_encoder.py
+++ b/neuralmonkey/encoders/sentence_encoder.py
@@ -91,7 +91,7 @@ class SentenceEncoder(Attentive):
                 dtype=tf.float32)
 
             self.__attention_tensor = tf.concat(2, outputs_bidi_tup)
-            self.__attention_tensor = self._dropout(self._attention_tensor)
+            self.__attention_tensor = self._dropout(self.__attention_tensor)
 
             self.encoded = tf.concat(1, encoded_tup)
 

--- a/neuralmonkey/encoders/sentence_encoder.py
+++ b/neuralmonkey/encoders/sentence_encoder.py
@@ -92,7 +92,7 @@ class SentenceEncoder(Attentive):
 
             self.encoded = tf.concat(1, encoded_tup)
 
-        super(SentenceEncoder, self).__init__(
+        super().__init__(
             attention_type, attention_fertility=attention_fertility)
 
         log("Sentence encoder initialized")

--- a/neuralmonkey/encoders/sentence_encoder.py
+++ b/neuralmonkey/encoders/sentence_encoder.py
@@ -91,10 +91,16 @@ class SentenceEncoder(object):
 
             self.encoded = tf.concat(1, encoded_tup)
 
-            self.attention_object = attention_type(
-                self.attention_tensor, scope="attention_{}".format(name),
-                input_weights=self.padding,
-                max_fertility=attention_fertility) if attention_type else None
+            def attention_object(runtime=False):
+                return attention_type(
+                    self.attention_tensor,
+                    scope="attention_{}".format(name),
+                    input_weights=self.padding,
+                    max_fertility=attention_fertility,
+                    runtime_mode=runtime) if attention_type else None
+
+            self.attention_object_train = attention_object()
+            self.attention_object_runtime = attention_object(runtime=True)
 
         log("Sentence encoder initialized")
 
@@ -120,8 +126,7 @@ class SentenceEncoder(object):
 
 
     def _create_embedding_matrix(self):
-        """Create variables and operations for embedding
-        the input words
+        """Create variables and operations for embedding the input words.
 
         If parent encoder is specified, we reuse its embedding matrix
         """


### PR DESCRIPTION
Should fix the issue mentioned [here](https://github.com/ufal/neuralmonkey/pull/121#issuecomment-259075579):

> The problem is that the same `Attention` object is used for constructing both the training and runtime parts of the graph, and therefore `attentions_in_time` contains tensors from both parts. Because I'm using `attentions_in_time` for visualization, I was getting images like this:
>
> ![tensorboard](https://cloud.githubusercontent.com/assets/8046580/20091403/dac7641a-a592-11e6-9777-ce513c1e0bb1.png)