### PR TITLE
Split config loading and instantiation

### DIFF
--- a/neuralmonkey/config/config_loader.py
+++ b/neuralmonkey/config/config_loader.py
@@ -4,7 +4,6 @@ specified by the experiment configuration
 """
 # tests: lint
 
-import codecs
 import collections
 from inspect import signature, isclass, isfunction
 
@@ -120,9 +119,8 @@ def load_config_file(config_file):
     Arguments:
         config_file: The configuration file
     """
-    file_handle = codecs.open(config_file, 'r', 'utf-8')
-    config_dicts = parsing.parse_file(file_handle)
-    file_handle.close()
+    with open(config_file, 'r', encoding='utf-8') as file:
+        config_dicts = parsing.parse_file(file)
     log("INI file is parsed.")
     return config_dicts
 

--- a/neuralmonkey/config/config_loader.py
+++ b/neuralmonkey/config/config_loader.py
@@ -4,6 +4,7 @@ specified by the experiment configuration
 """
 # tests: lint
 
+import codecs
 import collections
 from inspect import signature, isclass, isfunction
 
@@ -113,19 +114,25 @@ def instantiate_class(name, all_dicts, existing_objects, depth):
     return obj
 
 
-def load_config_file(config_file, ignore_names):
-    """ Loads and builds the model from the configuration
+def load_config_file(config_file):
+    """ Loads the configuration
 
     Arguments:
         config_file: The configuration file
+    """
+    fh = codecs.open(config_file, 'r', 'utf-8')
+    config_dicts = parsing.parse_file(fh)
+    fh.close()
+    log("INI file is parsed.")
+    return config_dicts
+
+def build_config(config_dicts, ignore_names):
+    """ Builds the model from the configuration
+
+    Arguments:
+        config_dicts: The parsed configuration file
         ignore_names: A set of names that should be ignored during the loading.
     """
-    config_dicts = parsing.parse_file(config_file)
-    config_file.close()
-    log("INI file is parsed.")
-
-    # first load the configuration into a dictionary
-
     if "main" not in config_dicts:
         raise Exception("Configuration does not contain the main block.")
 

--- a/neuralmonkey/config/config_loader.py
+++ b/neuralmonkey/config/config_loader.py
@@ -120,9 +120,9 @@ def load_config_file(config_file):
     Arguments:
         config_file: The configuration file
     """
-    fh = codecs.open(config_file, 'r', 'utf-8')
-    config_dicts = parsing.parse_file(fh)
-    fh.close()
+    file_handle = codecs.open(config_file, 'r', 'utf-8')
+    config_dicts = parsing.parse_file(file_handle)
+    file_handle.close()
     log("INI file is parsed.")
     return config_dicts
 

--- a/neuralmonkey/config/configuration.py
+++ b/neuralmonkey/config/configuration.py
@@ -31,15 +31,6 @@ class Configuration(object):
         if cond is not None:
             self.conditions[name] = cond
 
-    def add_section(self, name):
-        # most sections are already consumed by arguments, e.g.
-        #   decoder=<decoder>
-        # but the config can contain other sections and we don't want
-        # _check_loaded_conf to complain about them
-        if name not in self.data_types:
-            self.data_types[name] = object
-            self.defaults[name] = {}
-
     def ignore_argument(self, name):
         self.ignored.add(name)
 
@@ -50,7 +41,6 @@ class Configuration(object):
             arguments = Namespace()
             self.config_dict = load_config_file(path)
 
-            self._check_loaded_conf(self.config_dict)
 
             for name, value in self.config_dict.items():
                 if name in self.conditions and not self.conditions[name](value):
@@ -77,7 +67,7 @@ class Configuration(object):
 
         return arguments
 
-    def build_model():
+    def build_model(self):
         log("Building model based on the config.")
         try:
             build_config(self.config_dict, self.ignored)
@@ -86,7 +76,7 @@ class Configuration(object):
             traceback.print_exc()
             exit(1)
         log("Model built.")
-
+        self._check_loaded_conf(self.config_dict)
 
     def _check_loaded_conf(self, config_dict):
         """ Checks whether there are unexpected or missing fields """
@@ -99,7 +89,6 @@ class Configuration(object):
         if expected_missing:
             raise Exception("Missing mandatory fields: {}"
                             .format(", ".join(expected_missing)))
-
         unexpected = []
         for name in config_dict:
             if name not in expected_fields:

--- a/neuralmonkey/config/configuration.py
+++ b/neuralmonkey/config/configuration.py
@@ -70,6 +70,7 @@ class Configuration(object):
         log("Building model based on the config.")
         try:
             model = build_config(self.config_dict, self.ignored)
+        #pylint: disable=broad-except
         except Exception as exc:
             log("Failed to build model: {}".format(exc), color='red')
             traceback.print_exc()
@@ -83,9 +84,9 @@ class Configuration(object):
                 cond_filename = cond_code.co_filename
                 cond_line_number = cond_code.co_firstlineno
                 raise Exception(
-                        "Value of field '{}' does not satisfy "
-                        "condition defined at {}:{}."
-                        .format(name, cond_filename, cond_line_number))
+                    "Value of field '{}' does not satisfy "
+                    "condition defined at {}:{}."
+                    .format(name, cond_filename, cond_line_number))
 
             setattr(model_n, name, value)
             #arguments.__dict__[name] = value

--- a/neuralmonkey/run.py
+++ b/neuralmonkey/run.py
@@ -89,7 +89,9 @@ def main():
     test_datasets.add_argument('variables')
 
     args = CONFIG.load_file(sys.argv[1])
+    args = CONFIG.build_model()
     datasets_args = test_datasets.load_file(sys.argv[2])
+    datasets_args = test_datasets.build_model()
     initialize_for_running(args.output, args.tf_manager,
                            datasets_args.variables)
 

--- a/neuralmonkey/run.py
+++ b/neuralmonkey/run.py
@@ -89,9 +89,9 @@ def main():
     test_datasets.add_argument('test_datasets')
     test_datasets.add_argument('variables')
 
-    args = CONFIG.load_file(sys.argv[1])
+    CONFIG.load_file(sys.argv[1])
     args = CONFIG.build_model()
-    datasets_args = test_datasets.load_file(sys.argv[2])
+    test_datasets.load_file(sys.argv[2])
     datasets_args = test_datasets.build_model()
     initialize_for_running(args.output, args.tf_manager,
                            datasets_args.variables)

--- a/neuralmonkey/run.py
+++ b/neuralmonkey/run.py
@@ -29,6 +29,7 @@ CONFIG.ignore_argument('initial_variables')
 CONFIG.ignore_argument('validation_period')
 CONFIG.ignore_argument('logging_period')
 CONFIG.ignore_argument('minimize')
+CONFIG.ignore_argument('random_seed')
 CONFIG.ignore_argument('save_n_best')
 CONFIG.ignore_argument('overwrite_output_dir')
 

--- a/neuralmonkey/server.py
+++ b/neuralmonkey/server.py
@@ -63,6 +63,7 @@ def main():
 
     # pylint: disable=no-member
     args = CONFIG.load_file(cli_args.configuration)
+    args = CONFIG.build_model()
     initialize_for_running(args.output, args.tf_manager, None)
     APP.config['args'] = args
     APP.run(port=cli_args.port, host=cli_args.host)

--- a/neuralmonkey/train.py
+++ b/neuralmonkey/train.py
@@ -4,12 +4,11 @@ This is a training script for sequence to sequence learning.
 # tests: lint, mypy
 
 import sys
-import random
+#import random
 import os
 from shutil import copyfile
-import numpy as np
+#import numpy as np
 
-import numpy as np
 import tensorflow as tf
 
 from neuralmonkey.checking import CheckingException, check_dataset_and_coders
@@ -45,7 +44,7 @@ def create_config():
     config.add_argument('overwrite_output_dir', bool, required=False,
                         default=False)
 
-        return config
+    return config
 
 def main():
     if len(sys.argv) != 2:

--- a/neuralmonkey/train.py
+++ b/neuralmonkey/train.py
@@ -18,7 +18,7 @@ from neuralmonkey.learning_utils import training_loop
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.tf_manager import TensorFlowManager
 
-def create_config(config_file):
+def create_config():
     config = Configuration()
 
     # training loop arguments
@@ -39,25 +39,30 @@ def create_config(config_file):
     config.add_argument('minimize', bool, required=False, default=False)
     config.add_argument('postprocess')
     config.add_argument('name', str)
+    config.add_argument('random_seed', int, required=False)
     config.add_argument('initial_variables', str, required=False, default=[])
     config.add_argument('overwrite_output_dir', bool, required=False,
                         default=False)
 
-    return config.load_file(config_file)
+    return config
 
 def main():
     if len(sys.argv) != 2:
         print("Usage: train.py <ini_file>")
         exit(1)
 
-    # random seeds have to be set before anything is created in the graph
-    random.seed(2574600)
-    np.random.seed(2574600)
-    tf.set_random_seed(2574600)
+    # define valid parameters and defaults
+    cfg = create_config()
+    # load the params from the config file, getting also the simple arguments
+    args = cfg.load_file(sys.argv[1])
+    ## various things like randseed or summarywriter should be set up here
+    ## so that graph building can be recorded
+    # build all the objects specified in the config
+    cfg.build_model
 
-    args = create_config(sys.argv[1])
-
-    print("")
+    #pylint: disable=no-member,broad-except
+    if args.random_seed is not None:
+        tf.set_random_seed(args.random_seed)
 
     #pylint: disable=no-member
     if os.path.isdir(args.output) and \

--- a/neuralmonkey/train.py
+++ b/neuralmonkey/train.py
@@ -4,10 +4,10 @@ This is a training script for sequence to sequence learning.
 # tests: lint, mypy
 
 import sys
-#import random
+import random
 import os
 from shutil import copyfile
-#import numpy as np
+import numpy as np
 
 import tensorflow as tf
 
@@ -58,11 +58,14 @@ def main():
     ## various things like randseed or summarywriter should be set up here
     ## so that graph building can be recorded
     # build all the objects specified in the config
-    args = cfg.build_model()
 
-    #pylint: disable=no-member,broad-except
-    if args.random_seed is not None:
-        tf.set_random_seed(args.random_seed)
+    if args.random_seed is None:
+        args.random_seed = 2574600
+    random.seed(args.random_seed)
+    np.random.seed(args.random_seed)
+    tf.set_random_seed(args.random_seed)
+
+    args = cfg.build_model()
 
     #pylint: disable=no-member
     if os.path.isdir(args.output) and \

--- a/neuralmonkey/train.py
+++ b/neuralmonkey/train.py
@@ -44,7 +44,7 @@ def create_config():
     config.add_argument('overwrite_output_dir', bool, required=False,
                         default=False)
 
-    return config
+        return config
 
 def main():
     if len(sys.argv) != 2:
@@ -58,7 +58,7 @@ def main():
     ## various things like randseed or summarywriter should be set up here
     ## so that graph building can be recorded
     # build all the objects specified in the config
-    cfg.build_model
+    cfg.build_model()
 
     #pylint: disable=no-member,broad-except
     if args.random_seed is not None:

--- a/neuralmonkey/train.py
+++ b/neuralmonkey/train.py
@@ -8,7 +8,6 @@ import random
 import os
 from shutil import copyfile
 import numpy as np
-
 import tensorflow as tf
 
 from neuralmonkey.checking import CheckingException, check_dataset_and_coders

--- a/neuralmonkey/train.py
+++ b/neuralmonkey/train.py
@@ -7,6 +7,7 @@ import sys
 import random
 import os
 from shutil import copyfile
+import numpy as np
 
 import numpy as np
 import tensorflow as tf
@@ -58,7 +59,7 @@ def main():
     ## various things like randseed or summarywriter should be set up here
     ## so that graph building can be recorded
     # build all the objects specified in the config
-    cfg.build_model()
+    args = cfg.build_model()
 
     #pylint: disable=no-member,broad-except
     if args.random_seed is not None:

--- a/tests/small.ini
+++ b/tests/small.ini
@@ -17,6 +17,7 @@ logging_period=20
 validation_period=60
 runners_batch_size=1
 test_datasets=[<val_data>,<val_data_no_target>]
+random_seed=1234
 
 [tf_manager]
 class=tf_manager.TensorFlowManager


### PR DESCRIPTION
The first stage of the configuration refactor. This separates the config reading and the object building. It fixes #22.