### PR TITLE
Shape assertions

### DIFF
--- a/neuralmonkey/checking.py
+++ b/neuralmonkey/checking.py
@@ -77,8 +77,8 @@ def assert_shape(tensor: tf.Tensor,
 
     Args:
         tensor: Tensor to be chcecked.
-        expected_shape: Expected shape where None stands for None means the
-            same as in TF and -1 means not checking the dimension.
+        expected_shape: Expected shape where `None` means the same as in TF and
+            `-1` means not checking the dimension.
     """
 
     shape_list = tensor.get_shape().as_list()

--- a/neuralmonkey/checking.py
+++ b/neuralmonkey/checking.py
@@ -97,6 +97,34 @@ def assert_shape(tensor: tf.Tensor,
         expected_str = ", ".join(
             "?" if x == -1 else str(x) for x in expected_shape)
         raise CheckingException(
-            "Shape mismatch in dimensions: {}. Shape was {} was [{}]".format(
-                ", ".join(str(d) for d in mismatching_dims),
-                shape_list, expected_str))
+            ("Shape mismatch of {} in dimensions: {}. "
+             "Shape was {}, but should be [{}]").format(
+                 tensor.name,
+                 ", ".join(str(d) for d in mismatching_dims),
+                 shape_list, expected_str))
+
+
+def assert_same_shape(tensor_a: tf.Tensor, tensor_b: tf.Tensor) -> None:
+    """Check if two tensors have the same shape."""
+
+    shape_a = tensor_a.get_shape().as_list()
+    shape_b = tensor_b.get_shape().as_list()
+
+    if len(shape_a) != len(shape_b):
+        raise CheckingException(
+            ("Tensor '{}' has {} dimensions and tensor '{}' has {} "
+             "dimension, but should have the same shape.").format(
+                 tensor_a.name, len(shape_a), tensor_b.name, len(shape_b)))
+
+    mismatching_dims = []
+    for i, (size_a, size_b) in enumerate(zip(shape_a, shape_b)):
+        if size_a != size_b:
+            mismatching_dims.append(i)
+
+    if mismatching_dims:
+        raise CheckingException(
+            ("Shape mismatch of '{}' and '{}' in dimensions: {}. "
+             "Shapes were {} and {}").format(
+                 tensor_a.name, tensor_b.name,
+                 ", ".join(str(d) for d in mismatching_dims),
+                 shape_a, shape_b))

--- a/neuralmonkey/checking.py
+++ b/neuralmonkey/checking.py
@@ -6,6 +6,10 @@ constructing the computational graph.
 
 # tests: lint, mypy
 
+from typing import List, Optional
+
+import tensorflow as tf
+
 from neuralmonkey.logging import log, debug
 
 
@@ -65,3 +69,34 @@ def assert_type(obj, name, value, expected_type, can_be_none=False):
         raise CheckingException(
             'Value of "{}" in "{}"should be "{}" but was "{}" {}'.format(
                 name, caller_type_str, exptected_str, real_type_str, value))
+
+
+def assert_shape(tensor: tf.Tensor,
+                 expected_shape: List[Optional[int]]) -> None:
+    """Check shape of a tensor.
+
+    Args:
+        tensor: Tensor to be chcecked.
+        expected_shape: Expected shape where None stands for None means the
+            same as in TF and -1 means not checking the dimension.
+    """
+
+    shape_list = tensor.get_shape().as_list()
+
+    if len(shape_list) != len(expected_shape):
+        raise CheckingException(
+            "Tensor '{}' with shape {} should have {} dimensions.".format(
+                tensor.name, shape_list, len(expected_shape)))
+
+    mismatching_dims = []
+    for i, (real, expected) in enumerate(zip(shape_list, expected_shape)):
+        if expected != -1 and real != expected:
+            mismatching_dims.append(i)
+
+    if mismatching_dims:
+        expected_str = ", ".join(
+            "?" if x == -1 else str(x) for x in expected_shape)
+        raise CheckingException(
+            "Shape mismatch in dimensions: {}. Shape was {} was [{}]".format(
+                ", ".join(str(d) for d in mismatching_dims),
+                shape_list, expected_str))

--- a/neuralmonkey/encoders/factored_encoder.py
+++ b/neuralmonkey/encoders/factored_encoder.py
@@ -1,6 +1,7 @@
 import tensorflow as tf
 import numpy as np
 
+from neuralmonkey.checking import assert_shape
 from neuralmonkey.encoders.attentive import Attentive
 from neuralmonkey.logging import log
 from neuralmonkey.nn.bidirectional_rnn_layer import BidirectionalRNNLayer
@@ -153,7 +154,7 @@ class FactoredEncoder(Attentive):
                 tf.nn.dropout(i, self.dropout_placeholder)
                 for i in embedded_inputs]
 
-            # Resulting shape is batch x embedding_size
+            assert_shape(dropped_embedded_inputs, [None, embedding_size])
             factors.append(dropped_embedded_inputs)
 
             # Add inputs and weights to self to be able to feed them
@@ -167,6 +168,8 @@ class FactoredEncoder(Attentive):
         # tuples indexed by the time step
         concatenated_factors = [tf.concat(1, related_factors)
                                 for related_factors in zip(*factors)]
+        assert_shape(concatenated_factors[0],
+                     [None, sum(self.embedding_sizes)])
         forward_gru, backward_gru = self._get_birnn_cells()
 
         bidi_layer = BidirectionalRNNLayer(forward_gru, backward_gru,

--- a/neuralmonkey/encoders/factored_encoder.py
+++ b/neuralmonkey/encoders/factored_encoder.py
@@ -154,6 +154,7 @@ class FactoredEncoder(Attentive):
                 tf.nn.dropout(i, self.dropout_placeholder)
                 for i in embedded_inputs]
 
+            # Resulting shape is batch x embedding_size
             assert_shape(dropped_embedded_inputs, [None, embedding_size])
             factors.append(dropped_embedded_inputs)
 

--- a/neuralmonkey/nn/pervasive_dropout_wrapper.py
+++ b/neuralmonkey/nn/pervasive_dropout_wrapper.py
@@ -1,5 +1,7 @@
 import tensorflow as tf
 
+from neuralmonkey.checking import assert_shape
+
 # tests: lint, mypy
 
 
@@ -8,6 +10,7 @@ class PervasiveDropoutWrapper(tf.nn.rnn_cell.RNNCell):
     def __init__(self, cell, mask, scale):
         self._cell = cell
         self._mask = mask
+        assert_shape(mask, [None, cell.sate_size])
         self._scale = scale
 
     @property
@@ -24,4 +27,5 @@ class PervasiveDropoutWrapper(tf.nn.rnn_cell.RNNCell):
         # self._mask is of shape [batch_size, state_size]
         # new_state is of shape [batch_size, state_size] (hopefully)
         new_state_dropped = new_state * self._scale * self._mask
+        assert_shape(new_state_dropped, [None, self._cell.sate_size])
         return output, new_state_dropped


### PR DESCRIPTION
This PR introduces a concept of shape assertions while creating a TF graph. 

I spotted various places where tensor shapes are explained in the comments and few assertions concerning shapes. In case of the comments, it is not guaranteed, however, that they are always up to date. The assertions, on the other hand, both document the code and can never get out of date.  The other benefit is also that we let the graph construction fail with a meaningful error message before it crashes with a very verbose TF exception.

I tried to grep out the places where the assertions and comments already were. If you about any other places in the code that should be (and can be easily) equipped with these assertions, feel free to add them even to this PR.