### PR TITLE
Weighted objectives

### DIFF
--- a/neuralmonkey/trainers/cross_entropy_trainer.py
+++ b/neuralmonkey/trainers/cross_entropy_trainer.py
@@ -1,17 +1,22 @@
-from typing import Any, List
+from typing import Any, List, Optional, Union
+
+import tensorflow as tf
 
 from neuralmonkey.trainers.generic_trainer import GenericTrainer, Objective
 
 # tests: lint, mypy
 
+# pylint: disable=invalid-name
+ObjectiveWeight = List[Union[tf.Tensor, float]]
 
-def xent_objective(decoder) -> Objective:
+def xent_objective(decoder, weight=None) -> Objective:
     """Get XENT objective from decoder with cost."""
     return Objective(
         name="{} - cross-entropy".format(decoder.name),
         decoder=decoder,
         loss=decoder.cost,
-        gradients=None
+        gradients=None,
+        weight=weight,
     )
 
 # pylint: disable=too-few-public-methods
@@ -19,9 +24,21 @@ def xent_objective(decoder) -> Objective:
 
 class CrossEntropyTrainer(GenericTrainer):
 
-    def __init__(self, decoders: List[Any], l1_weight=0., l2_weight=0.,
+    def __init__(self, decoders: List[Any],
+                 decoder_weights: Optional[List[ObjectiveWeight]]=None,
+                 l1_weight=0., l2_weight=0.,
                  clip_norm=False, optimizer=None) -> None:
-        objectives = [xent_objective(dec) for dec in decoders]
+
+        if decoder_weights is None:
+            decoder_weights = [None for _ in decoders]
+
+        if len(decoder_weights) != len(decoders):
+            raise ValueError(
+                "decoder_weights (length {}) do not match decoders (length {})"
+                .format(len(decoder_weights), len(decoders)))
+
+        objectives = [xent_objective(dec, w)
+                      for dec, w in zip(decoders, decoder_weights)]
         super(CrossEntropyTrainer, self).__init__(
             objectives, l1_weight, l2_weight, clip_norm=clip_norm,
             optimizer=optimizer)

--- a/neuralmonkey/trainers/cross_entropy_trainer.py
+++ b/neuralmonkey/trainers/cross_entropy_trainer.py
@@ -1,13 +1,9 @@
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional
 
-import tensorflow as tf
-
-from neuralmonkey.trainers.generic_trainer import GenericTrainer, Objective
+from neuralmonkey.trainers.generic_trainer import (GenericTrainer, Objective,
+                                                   ObjectiveWeight)
 
 # tests: lint, mypy
-
-# pylint: disable=invalid-name
-ObjectiveWeight = List[Union[tf.Tensor, float]]
 
 
 def xent_objective(decoder, weight=None) -> Objective:

--- a/neuralmonkey/trainers/cross_entropy_trainer.py
+++ b/neuralmonkey/trainers/cross_entropy_trainer.py
@@ -9,6 +9,7 @@ from neuralmonkey.trainers.generic_trainer import GenericTrainer, Objective
 # pylint: disable=invalid-name
 ObjectiveWeight = List[Union[tf.Tensor, float]]
 
+
 def xent_objective(decoder, weight=None) -> Objective:
     """Get XENT objective from decoder with cost."""
     return Objective(

--- a/neuralmonkey/trainers/generic_trainer.py
+++ b/neuralmonkey/trainers/generic_trainer.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
 import re
 
 import tensorflow as tf
@@ -10,12 +10,13 @@ from neuralmonkey.runners.base_runner import (collect_encoders, Executable,
 
 # pylint: disable=invalid-name
 Gradients = List[Tuple[tf.Tensor, tf.Variable]]
+ObjectiveWeight = Union[tf.Tensor, float, None]
 Objective = NamedTuple('Objective',
                        [('name', str),
                         ('decoder', Any),
                         ('loss', tf.Tensor),
                         ('gradients', Optional[Gradients]),
-                        ('weight', Optional[tf.Tensor])])
+                        ('weight', ObjectiveWeight)])
 
 BIAS_REGEX = re.compile(r'[Bb]ias')
 
@@ -104,7 +105,9 @@ def _sum_gradients(gradients_list: List[Gradients]) -> Gradients:
     return [(tensor, var) for var, tensor in summed_dict.items()]
 
 
-def _scale_gradients(gradients: Gradients, weight: tf.Tensor) -> Gradients:
+def _scale_gradients(gradients: Gradients,
+                     weight: ObjectiveWeight) -> Gradients:
+
     result = []  # type: Gradients
     for tensor, var in gradients:
         if weight is not None and tensor is not None:

--- a/neuralmonkey/trainers/generic_trainer.py
+++ b/neuralmonkey/trainers/generic_trainer.py
@@ -103,6 +103,7 @@ def _sum_gradients(gradients_list: List[Gradients]) -> Gradients:
                     summed_dict[var] += tensor
     return [(tensor, var) for var, tensor in summed_dict.items()]
 
+
 def _scale_gradients(gradients: Gradients, weight: tf.Tensor) -> Gradients:
     result = []  # type: Gradients
     for tensor, var in gradients:
@@ -112,6 +113,7 @@ def _scale_gradients(gradients: Gradients, weight: tf.Tensor) -> Gradients:
             result.append((tensor, var))
 
     return result
+
 
 class TrainExecutable(Executable):
 


### PR DESCRIPTION
- Each objective in `GenericTrainer` can now optionally have a weight (a scalar `Tensor`) with which its loss is multiplied when computing the gradients.
- In `CrossEntropyTrainer`, the weights for all decoders can be specified by `decoder_weights`.