### PR TITLE
local variable 'summary_str' referenced before assignment

### DIFF
--- a/neuralmonkey/learning_utils.py
+++ b/neuralmonkey/learning_utils.py
@@ -59,6 +59,10 @@ def training_loop(tf_manager: TensorFlowManager,
             means the generated and dataset series have the same name.
     """
 
+    if validation_period < logging_period:
+        raise AssertionError(
+            "Logging period can't smaller than validation period.")
+
     # TODO DOCUMENT_THIS
     if runners_batch_size is None:
         runners_batch_size = batch_size


### PR DESCRIPTION
In `learning_utils.py`, `summary_str` is set [here](https://github.com/ufal/neuralmonkey/blob/master/neuralmonkey/learning_utils.py#L214) (once per `logging_period`) and used [here](https://github.com/ufal/neuralmonkey/blob/master/neuralmonkey/learning_utils.py#L271) (once per `validation_period`). Therefore, if `validation_period < logging_period`, the latter happens first, resulting in `UnboundLocalError: local variable 'summary_str' referenced before assignment`.