### PR TITLE
Tf12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: python
 
 env:
   global:
-    - TF=0.12.0rc1-cp35-cp35m
+    - TF=0.12.0-cp35-cp35m
   matrix:
     - TEST_SUITE=lint
     - TEST_SUITE=pycodestyle

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: python
 
 env:
   global:
-    - TF=0.11.0-cp35-cp35m
+    - TF=0.12.0rc0-cp35-cp35m
   matrix:
     - TEST_SUITE=lint
     - TEST_SUITE=pycodestyle

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: python
 
 env:
   global:
-    - TF=0.12.0rc0-cp35-cp35m
+    - TF=0.12.0rc1-cp35-cp35m
   matrix:
     - TEST_SUITE=lint
     - TEST_SUITE=pycodestyle

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -4,4 +4,4 @@ flask
 ansiconv
 numpy
 
-https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-0.11.0-cp35-cp35m-linux_x86_64.whl
+https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-0.12.0rc0-cp35-cp35m-linux_x86_64.whl

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -4,4 +4,4 @@ flask
 ansiconv
 numpy
 
-https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-0.12.0rc1-cp35-cp35m-linux_x86_64.whl
+https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-0.12.0-cp35-cp35m-linux_x86_64.whl

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -4,4 +4,4 @@ flask
 ansiconv
 numpy
 
-https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-0.12.0rc0-cp35-cp35m-linux_x86_64.whl
+https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-0.12.0rc1-cp35-cp35m-linux_x86_64.whl

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ flask
 ansiconv
 numpy
 
-https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.12.0rc1-cp35-cp35m-linux_x86_64.whl
+https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.12.0-cp35-cp35m-linux_x86_64.whl

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ flask
 ansiconv
 numpy
 
-https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.12.0rc0-cp35-cp35m-linux_x86_64.whl
+https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.12.0rc1-cp35-cp35m-linux_x86_64.whl

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ flask
 ansiconv
 numpy
 
-https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.11.0-cp35-cp35m-linux_x86_64.whl
+https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.12.0rc0-cp35-cp35m-linux_x86_64.whl


### PR DESCRIPTION
To move to TF 12 we should fix:

- [ ] deprecated summary functions
- [ ] DataLossError

Also, what's our policy on supported TF versions? Is it stated in documentation somewhere?