### PR TITLE
Variable and graph scopes (adresses #140)

### DIFF
--- a/neuralmonkey/encoders/sentence_encoder.py
+++ b/neuralmonkey/encoders/sentence_encoder.py
@@ -90,8 +90,10 @@ class SentenceEncoder(Attentive):
                 fw_cell, bw_cell, embedded_inputs, self.sentence_lengths,
                 dtype=tf.float32)
 
-            self.__attention_tensor = tf.concat(2, outputs_bidi_tup)
-            self.__attention_tensor = self._dropout(self.__attention_tensor)
+            with tf.variable_scope('attention_tensor'):
+                self.__attention_tensor = tf.concat(2, outputs_bidi_tup)
+                self.__attention_tensor = self._dropout(
+                    self.__attention_tensor)
 
             self.encoded = tf.concat(1, encoded_tup)
 

--- a/neuralmonkey/encoders/sentence_encoder.py
+++ b/neuralmonkey/encoders/sentence_encoder.py
@@ -81,11 +81,11 @@ class SentenceEncoder(Attentive):
 
         with tf.variable_scope(self.name):
             self._create_input_placeholders()
-            self._create_embedding_matrix()
+            with tf.variable_scope('intput_projection'):
+                self._create_embedding_matrix()
+                embedded_inputs = self._embed(self.inputs)  # type: tf.Tensor
 
-            embedded_inputs = self._embed(self.inputs)  # type: tf.Tensor
             fw_cell, bw_cell = self.rnn_cells()  # type: RNNCellTuple
-
             outputs_bidi_tup, encoded_tup = tf.nn.bidirectional_dynamic_rnn(
                 fw_cell, bw_cell, embedded_inputs, self.sentence_lengths,
                 dtype=tf.float32)

--- a/neuralmonkey/encoders/sentence_encoder.py
+++ b/neuralmonkey/encoders/sentence_encoder.py
@@ -81,7 +81,7 @@ class SentenceEncoder(Attentive):
 
         with tf.variable_scope(self.name):
             self._create_input_placeholders()
-            with tf.variable_scope('intput_projection'):
+            with tf.variable_scope('input_projection'):
                 self._create_embedding_matrix()
                 embedded_inputs = self._embed(self.inputs)  # type: tf.Tensor
 

--- a/neuralmonkey/nn/utils.py
+++ b/neuralmonkey/nn/utils.py
@@ -17,10 +17,11 @@ def dropout(variable: tf.Tensor,
     """
     # Maintain clean graph - no dropout op when there is none applied
     # TODO maybe use math.isclose instead of this comparison
-    if keep_prob == 1.0:
-        return variable
+    with tf.variable_scope("dropout"):
+        if keep_prob == 1.0:
+            return variable
 
-    # TODO remove this line as soon as TF .12 is used.
-    train_mode_selector = tf.fill(tf.shape(variable)[:1], train_mode)
-    dropped_value = tf.nn.dropout(variable, keep_prob)
-    return tf.select(train_mode_selector, dropped_value, variable)
+        # TODO remove this line as soon as TF .12 is used.
+        train_mode_selector = tf.fill(tf.shape(variable)[:1], train_mode)
+        dropped_value = tf.nn.dropout(variable, keep_prob)
+        return tf.select(train_mode_selector, dropped_value, variable)

--- a/neuralmonkey/trainers/generic_trainer.py
+++ b/neuralmonkey/trainers/generic_trainer.py
@@ -28,63 +28,77 @@ class GenericTrainer(object):
                  l1_weight=0.0, l2_weight=0.0,
                  clip_norm=False, optimizer=None, global_step=None) -> None:
 
-        self.optimizer = optimizer or tf.train.AdamOptimizer(1e-4)
+        with tf.name_scope("trainer"):
+            self.optimizer = optimizer or tf.train.AdamOptimizer(1e-4)
 
-        with tf.variable_scope('regularization'):
-            regularizable = [v for v in tf.trainable_variables()
-                             if BIAS_REGEX.findall(v.name)]
-            l1_value = sum(tf.reduce_sum(abs(v)) for v in regularizable)
-            l1_cost = l1_weight * l1_value if l1_weight > 0 else 0.0
+            with tf.name_scope('regularization'):
+                regularizable = [v for v in tf.trainable_variables()
+                                 if BIAS_REGEX.findall(v.name)]
+                l1_value = sum(tf.reduce_sum(abs(v)) for v in regularizable)
+                l1_cost = l1_weight * l1_value if l1_weight > 0 else 0.0
 
-            l2_value = sum(tf.reduce_sum(v ** 2) for v in regularizable)
-            l2_cost = l2_weight * l2_value if l2_weight > 0 else 0.0
+                l2_value = sum(tf.reduce_sum(v ** 2) for v in regularizable)
+                l2_cost = l2_weight * l2_value if l2_weight > 0 else 0.0
 
-        # unweighted losses for fetching
-        self.losses = [o.loss for o in objectives] + [l1_value, l2_value]
-        tf.scalar_summary('train_l1', l1_value, collections=["summary_train"])
-        tf.scalar_summary('train_l2', l2_value, collections=["summary_train"])
+            # unweighted losses for fetching
+            self.losses = [o.loss for o in objectives] + [l1_value, l2_value]
+            tf.scalar_summary('train_l1', l1_value,
+                              collections=["summary_train"])
+            tf.scalar_summary('train_l2', l2_value,
+                              collections=["summary_train"])
 
-        # if the objective does not have its own gradients,
-        # just use TF to do the derivative
-        differentiable_loss_sum = sum(
-            (o.weight if o.weight is not None else 1) * o.loss
-            for o in objectives if o.gradients is None) + l1_cost + l2_cost
-        implicit_gradients = self._get_gradients(differentiable_loss_sum)
+            # if the objective does not have its own gradients,
+            # just use TF to do the derivative
+            with tf.name_scope('gradient_collection'):
+                differentiable_loss_sum = sum(
+                    (o.weight if o.weight is not None else 1) * o.loss
+                    for o in objectives
+                    if o.gradients is None) + l1_cost + l2_cost
+                implicit_gradients = self._get_gradients(
+                    differentiable_loss_sum)
 
-        # objectives that have their gradients explictly computed
-        other_gradients = [
-            _scale_gradients(o.gradients, o.weight)
-            for o in objectives if o.gradients is not None]
+                # objectives that have their gradients explictly computed
+                other_gradients = [
+                    _scale_gradients(o.gradients, o.weight)
+                    for o in objectives if o.gradients is not None]
 
-        if other_gradients:
-            gradients = _sum_gradients([implicit_gradients] + other_gradients)
-        else:
-            gradients = implicit_gradients
+                if other_gradients:
+                    gradients = _sum_gradients(
+                        [implicit_gradients] + other_gradients)
+                else:
+                    gradients = implicit_gradients
 
-        if clip_norm:
-            assert clip_norm > 0.0
-            gradients = [(tf.clip_by_norm(grad, clip_norm), var)
-                         for grad, var in gradients]
+            if clip_norm:
+                assert clip_norm > 0.0
+                gradients = [(tf.clip_by_norm(grad, clip_norm), var)
+                             for grad, var in gradients]
 
-        self.all_coders = set.union(*(collect_encoders(obj.decoder)
-                                      for obj in objectives))
+            self.all_coders = set.union(*(collect_encoders(obj.decoder)
+                                          for obj in objectives))
 
-        if global_step is None:
-            global_step = tf.Variable(0, trainable=False, name='global_step')
-        self.global_step = global_step
+            if global_step is None:
+                global_step = tf.Variable(0, trainable=False,
+                                          name='global_step')
+            self.global_step = global_step
 
-        self.train_op = self.optimizer.apply_gradients(
-            gradients, global_step=self.global_step)
+            if global_step is None:
+                global_step = tf.Variable(
+                    0, trainable=False, name='global_step')
+            self.global_step = global_step
 
-        for grad, var in gradients:
-            if grad is not None:
-                tf.histogram_summary('gr_' + var.name,
-                                     grad, collections=["summary_gradients"])
+            self.train_op = self.optimizer.apply_gradients(
+                gradients, global_step=self.global_step)
 
-        self.histogram_summaries = tf.merge_summary(
-            tf.get_collection("summary_gradients"))
-        self.scalar_summaries = tf.merge_summary(
-            tf.get_collection("summary_train"))
+            for grad, var in gradients:
+                if grad is not None:
+                    tf.histogram_summary(
+                        'gr_' + var.name,
+                        grad, collections=["summary_gradients"])
+
+            self.histogram_summaries = tf.merge_summary(
+                tf.get_collection("summary_gradients"))
+            self.scalar_summaries = tf.merge_summary(
+                tf.get_collection("summary_train"))
 
     def _get_gradients(self, tensor: tf.Tensor) -> Gradients:
         gradient_list = self.optimizer.compute_gradients(tensor)


### PR DESCRIPTION
This PR refactors variable and graph scopes in `SentenceEncoder` and `GenericTrainer` such that the TensorBoard graph visualization better illustrates the overall architecture of the models.

There is also a general scope added to `Decoder`, however I expect the scoping to be refined after the #179 is merged.