### PR TITLE
Coders base class

### DIFF
--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -1,12 +1,14 @@
 # tests: lint
 
-from typing import List, Callable, Optional, Union, Any, Tuple
+from typing import cast, Iterable, List, Callable, Optional, Union, Any, Tuple
 import math
 
 import tensorflow as tf
 import numpy as np
 
+from neuralmonkey.dataset import Dataset
 from neuralmonkey.vocabulary import Vocabulary, START_TOKEN
+from neuralmonkey.model.model_part import ModelPart, FeedDict
 from neuralmonkey.logging import log
 from neuralmonkey.nn.utils import dropout
 from neuralmonkey.encoders.attentive import Attentive
@@ -19,7 +21,7 @@ from neuralmonkey.decoders.output_projection import no_deep_output
 # pylint: disable=too-many-instance-attributes,too-few-public-methods
 # Big decoder cannot be simpler. Not sure if refactoring
 # it into smaller units would be helpful
-class Decoder(object):
+class Decoder(ModelPart):
     """A class that manages parts of the computation graph that are
     used for the decoding.
     """
@@ -42,8 +44,10 @@ class Decoder(object):
                  use_attention: bool=False,
                  embeddings_encoder: Optional[Any]=None,
                  rnn_cell: str='GRU',
-                 attention_on_input: bool=True) -> None:
-        """Creates a refactored version of monster decoder.
+                 attention_on_input: bool=True,
+                 save_checkpoint: Optional[str]=None,
+                 load_checkpoint: Optional[str]=None) -> None:
+        """Create a refactored version of monster decoder.
 
         Arguments:
             encoders: Input encoders of the decoder
@@ -68,12 +72,12 @@ class Decoder(object):
             attention_on_input: Flag whether attention from previous decoding
                 step should be combined with the input in the next step.
         """
+        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
         log("Initializing decoder, name: '{}'".format(name))
 
         self.encoders = encoders
         self.vocabulary = vocabulary
         self.data_id = data_id
-        self.name = name
         self.max_output_len = max_output_len
         self.dropout_keep_prob = dropout_keep_prob
         self.embedding_size = embedding_size
@@ -422,14 +426,16 @@ class Decoder(object):
                 collections=["summary_val_plots"],
                 max_images=256)
 
-    def feed_dict(self, dataset, train=False):
+    def feed_dict(self, dataset: Dataset, train: bool=False) -> FeedDict:
         """Populate the feed dictionary for the decoder object
 
         Arguments:
             dataset: The dataset to use for the decoder.
             train: Boolean flag, telling whether this is a training run
         """
-        sentences = dataset.get_series(self.data_id, allow_none=True)
+        sentences = list(
+            cast(Iterable[List[str]],
+                 dataset.get_series(self.data_id, allow_none=True)))
         if sentences is None and train:
             raise ValueError("When training, you must feed "
                              "reference sentences")

--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -433,9 +433,13 @@ class Decoder(ModelPart):
             dataset: The dataset to use for the decoder.
             train: Boolean flag, telling whether this is a training run
         """
-        sentences = list(
-            cast(Iterable[List[str]],
-                 dataset.get_series(self.data_id, allow_none=True)))
+        sentences = cast(Iterable[List[str]],
+                         dataset.get_series(self.data_id, allow_none=True))
+        if sentences is not None:
+            sentences_list = list(sentences)
+        else:
+            sentences_list = None
+
         if sentences is None and train:
             raise ValueError("When training, you must feed "
                              "reference sentences")
@@ -450,11 +454,11 @@ class Decoder(ModelPart):
         if sentences is not None:
             # train_mode=False, since we don't want to <unk>ize target words!
             inputs, weights = self.vocabulary.sentences_to_tensor(
-                sentences, self.max_output_len, train_mode=False,
+                sentences_list, self.max_output_len, train_mode=False,
                 add_start_symbol=False, add_end_symbol=True)
 
-            assert inputs.shape == (self.max_output_len, len(sentences))
-            assert weights.shape == (self.max_output_len, len(sentences))
+            assert inputs.shape == (self.max_output_len, len(sentences_list))
+            assert weights.shape == (self.max_output_len, len(sentences_list))
 
             res[self.train_inputs] = inputs
             res[self.train_padding] = weights

--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -435,21 +435,19 @@ class Decoder(ModelPart):
         """
         sentences = cast(Iterable[List[str]],
                          dataset.get_series(self.data_id, allow_none=True))
-        if sentences is not None:
-            sentences_list = list(sentences)
-        else:
-            sentences_list = None
 
         if sentences is None and train:
             raise ValueError("When training, you must feed "
                              "reference sentences")
 
-        res = {}
-        res[self.train_mode] = train
+        sentences_list = list(sentences) if sentences is not None else None
+
+        fd = {}  # type: FeedDict
+        fd[self.train_mode] = train
 
         go_symbol_idx = self.vocabulary.get_word_index(START_TOKEN)
-        res[self.go_symbols] = np.full([1, len(dataset)], go_symbol_idx,
-                                       dtype=np.int32)
+        fd[self.go_symbols] = np.full([1, len(dataset)], go_symbol_idx,
+                                      dtype=np.int32)
 
         if sentences is not None:
             # train_mode=False, since we don't want to <unk>ize target words!
@@ -460,7 +458,7 @@ class Decoder(ModelPart):
             assert inputs.shape == (self.max_output_len, len(sentences_list))
             assert weights.shape == (self.max_output_len, len(sentences_list))
 
-            res[self.train_inputs] = inputs
-            res[self.train_padding] = weights
+            fd[self.train_inputs] = inputs
+            fd[self.train_padding] = weights
 
-        return res
+        return fd

--- a/neuralmonkey/decoders/sequence_classifier.py
+++ b/neuralmonkey/decoders/sequence_classifier.py
@@ -1,4 +1,4 @@
-from typing import cast, Any, Iterable, Optional, List
+from typing import cast, Any, Callable, Iterable, Optional, List
 
 import tensorflow as tf
 
@@ -25,7 +25,7 @@ class SequenceClassifier(ModelPart):
                  vocabulary: Vocabulary,
                  data_id: str,
                  layers: Optional[List[int]]=None,
-                 activation=tf.tanh,
+                 activation: Callable[[tf.Tensor], tf.Tensor]=tf.tanh,
                  dropout_keep_prob: float=0.5,
                  save_checkpoint: Optional[str]=None,
                  load_checkpoint: Optional[str]=None) -> None:

--- a/neuralmonkey/decoders/sequence_classifier.py
+++ b/neuralmonkey/decoders/sequence_classifier.py
@@ -82,13 +82,17 @@ class SequenceClassifier(ModelPart):
         return self.decoded_seq
 
     def feed_dict(self, dataset: Dataset, train: bool=False) -> FeedDict:
-        sentences = list(
-            cast(Iterable[List[str]],
-                 dataset.get_series(self.data_id, allow_none=True)))
+        sentences = cast(Iterable[List[str]],
+                         dataset.get_series(self.data_id, allow_none=True))
+        if sentences is not None:
+            sentences_list = list(sentences)
+        else:
+            sentences_list = None
+
         fd = {}  # type: FeedDict
 
         label_tensors, _ = self.vocabulary.sentences_to_tensor(
-            sentences, self.max_output_len)
+            sentences_list, self.max_output_len)
 
         fd[self.gt_inputs[0]] = label_tensors[0]
 

--- a/neuralmonkey/decoders/sequence_classifier.py
+++ b/neuralmonkey/decoders/sequence_classifier.py
@@ -84,10 +84,8 @@ class SequenceClassifier(ModelPart):
     def feed_dict(self, dataset: Dataset, train: bool=False) -> FeedDict:
         sentences = cast(Iterable[List[str]],
                          dataset.get_series(self.data_id, allow_none=True))
-        if sentences is not None:
-            sentences_list = list(sentences)
-        else:
-            sentences_list = None
+
+        sentences_list = list(sentences) if sentences is not None else None
 
         fd = {}  # type: FeedDict
 

--- a/neuralmonkey/decoders/sequence_classifier.py
+++ b/neuralmonkey/decoders/sequence_classifier.py
@@ -1,5 +1,10 @@
+from typing import cast, Any, Iterable, Optional, List
+
 import tensorflow as tf
 
+from neuralmonkey.dataset import Dataset
+from neuralmonkey.vocabulary import Vocabulary
+from neuralmonkey.model.model_part import ModelPart, FeedDict
 from neuralmonkey.nn.mlp import MultilayerPerceptron
 
 # tests: lint, mypy
@@ -7,23 +12,31 @@ from neuralmonkey.nn.mlp import MultilayerPerceptron
 # pylint: disable=too-many-instance-attributes
 
 
-class SequenceClassifier(object):
-    """
-    This is a implementation of a simple MLP classifier over encoders. The API
-    pretends it is an RNN decoder which always generates a sequence of length
-    exactly one.
-    """
-    # pylint: disable=dangerous-default-value
+class SequenceClassifier(ModelPart):
+    """A simple MLP classifier over encoders.
 
-    def __init__(self, encoders, vocabulary, data_id, name,
-                 layers=[], activation=tf.tanh, dropout_keep_prob=0.5):
+    The API pretends it is an RNN decoder which always generates a sequence of
+    length exactly one.
+    """
+    # pylint: disable=too-many-arguments
+    def __init__(self,
+                 name: str,
+                 encoders: List[Any],
+                 vocabulary: Vocabulary,
+                 data_id: str,
+                 layers: Optional[List[int]]=None,
+                 activation=tf.tanh,
+                 dropout_keep_prob: float=0.5,
+                 save_checkpoint: Optional[str]=None,
+                 load_checkpoint: Optional[str]=None) -> None:
+        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
+
         self.encoders = encoders
         self.vocabulary = vocabulary
         self.data_id = data_id
         self.layers = layers
         self.activation = activation
         self.dropout_keep_prob = dropout_keep_prob
-        self.name = name
         self.max_output_len = 1
 
         with tf.variable_scope(name):
@@ -54,6 +67,7 @@ class SequenceClassifier(object):
             tf.scalar_summary(
                 'train_optimization_cost',
                 self.cost, collections=["summary_train"])
+    # pylint: enable=too-many-arguments
 
     @property
     def train_loss(self):
@@ -67,9 +81,11 @@ class SequenceClassifier(object):
     def decoded(self):
         return self.decoded_seq
 
-    def feed_dict(self, dataset, train=False):
-        sentences = dataset.get_series(self.data_id, allow_none=True)
-        fd = {}
+    def feed_dict(self, dataset: Dataset, train: bool=False) -> FeedDict:
+        sentences = list(
+            cast(Iterable[List[str]],
+                 dataset.get_series(self.data_id, allow_none=True)))
+        fd = {}  # type: FeedDict
 
         label_tensors, _ = self.vocabulary.sentences_to_tensor(
             sentences, self.max_output_len)

--- a/neuralmonkey/decoders/sequence_labeler.py
+++ b/neuralmonkey/decoders/sequence_labeler.py
@@ -85,13 +85,13 @@ class SequenceLabeler(ModelPart):
     def feed_dict(self, dataset: Dataset, train: bool=False) -> FeedDict:
         fd = {}  # type: FeedDict
 
-        sentences = list(
-            cast(Iterable[List[str]],
-                 dataset.get_series(self.data_id, allow_none=True)))
+        sentences = cast(Iterable[List[str]],
+                         dataset.get_series(self.data_id, allow_none=True))
 
         if sentences is not None:
+            sentences_list = list(sentences) if sentences is not None else None
             inputs, weights = self.vocabulary.sentences_to_tensor(
-                sentences, self.max_output_len)
+                sentences_list, self.max_output_len)
 
             assert len(weights) == len(self.train_weights)
             assert len(inputs) == len(self.train_targets)

--- a/neuralmonkey/decoders/word_alignment_decoder.py
+++ b/neuralmonkey/decoders/word_alignment_decoder.py
@@ -1,22 +1,31 @@
 import numpy as np
 import tensorflow as tf
 
+from neuralmonkey.dataset import Dataset
+from neuralmonkey.encoders.sentence_encoder import SentenceEncoder
+from neuralmonkey.decoders.decoder import Decoder
 from neuralmonkey.logging import log
+from neuralmonkey.model.model_part import ModelPart, FeedDict
 
 # tests: mypy
 
 
-class WordAlignmentDecoder(object):
+class WordAlignmentDecoder(ModelPart):
     """
     A decoder that computes soft alignment from an attentive encoder. Loss is
     computed as cross-entropy against a reference alignment.
     """
 
-    def __init__(self, encoder, decoder, data_id, name):
+    def __init__(self,
+                 encoder: SentenceEncoder,
+                 decoder: Decoder,
+                 data_id: str,
+                 name: str) -> None:
+        ModelPart.__init__(self, name, None, None)
+
         self.encoder = encoder
         self.decoder = decoder
         self.data_id = data_id
-        self.name = name
 
         self.ref_alignment = tf.placeholder(
             tf.float32,
@@ -55,10 +64,10 @@ class WordAlignmentDecoder(object):
         return alignment, loss
 
     @property
-    def cost(self):
+    def cost(self) -> tf.Tensor:
         return self.train_loss
 
-    def feed_dict(self, dataset, train=False):
+    def feed_dict(self, dataset: Dataset, train: bool=False) -> FeedDict:
         fd = {}
 
         alignment = dataset.get_series(self.data_id, allow_none=True)

--- a/neuralmonkey/encoders/cnn_encoder.py
+++ b/neuralmonkey/encoders/cnn_encoder.py
@@ -1,55 +1,55 @@
-"""
-Module conatining an image encoder proceesing the image with
-a CNN, followed by a sequential processing by RNN.
-"""
+"""CNN for image processing."""
+
+from typing import List, Tuple, Type, Optional
 
 import numpy as np
 import tensorflow as tf
+
 from neuralmonkey.checking import assert_shape
+from neuralmonkey.dataset import Dataset
 from neuralmonkey.encoders.attentive import Attentive
 from neuralmonkey.decoding_function import Attention
+from neuralmonkey.model.model_part import ModelPart, FeedDict
 
 # tests: lint, mypy
 
 # pylint: disable=too-many-instance-attributes, too-few-public-methods
 
 
-class CNNEncoder(Attentive):
-    """
+class CNNEncoder(ModelPart, Attentive):
+    """An image encoder.
 
-    An image encoder. It projects the input image through a serie of
-    convolutioal operations. The projected image is vertically cut and fed to
-    stacked RNN layers which encode the image into a single vector.
+    It projects the input image through a serie of convolutioal operations. The
+    projected image is vertically cut and fed to stacked RNN layers which
+    encode the image into a single vector.
 
     Attributes:
 
         input_op: Placeholder for the batch of input images
-
         padding_masks: Placeholder for matrices capturing telling where the
             image has been padded.
-
         image_processing_layers: List of TensorFlow operator that are
             visualizable image transformations.
-
         encoded: Operator that returns a batch of ecodede image (intended
             as an input for the decoder).
-
         attention_tensor: Tensor computing a batch of attention
             matrices for the decoder.
-
         is_training: Placeholder for boolean telleing whether the training
             is running.
-
     """
 
     # pylint: disable=too-many-arguments, too-many-locals
-    def __init__(self, data_id, convolutions,
-                 image_height, image_width, pixel_dim,
-                 name,
-                 batch_normalization=True,
-                 local_response_normalization=True,
-                 dropout_keep_prob=0.5,
-                 attention_type=Attention):
+    def __init__(self,
+                 name: str,
+                 data_id: str,
+                 convolutions: List[Tuple[int, int, Optional[int]]],
+                 image_height: int, image_width: int, pixel_dim: int,
+                 batch_normalization: bool=True,
+                 local_response_normalization: bool=True,
+                 dropout_keep_prob: float=0.5,
+                 attention_type: Type=Attention,
+                 save_checkpoint: Optional[str]=None,
+                 load_checkpoint: Optional[str]=None) -> None:
         """Initialize a convolutional network for image processing.
 
         Args:
@@ -70,7 +70,8 @@ class CNNEncoder(Attentive):
                 dropout keeping probability
 
         """
-        super().__init__(attention_type)
+        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
+        Attentive.__init__(self, attention_type)
 
         self.convolutions = convolutions
         self.data_id = data_id
@@ -153,14 +154,14 @@ class CNNEncoder(Attentive):
                 tf.reduce_prod(last_padding_masks, [1]), [2])
 
     @property
-    def _attention_tensor(self):
+    def _attention_tensor(self) -> tf.Tensor:
         return self.__attention_tensor
 
     @property
-    def _attention_mask(self):
+    def _attention_mask(self) -> tf.Tensor:
         return self.__attention_mask
 
-    def feed_dict(self, dataset, train=False):
+    def feed_dict(self, dataset: Dataset, train: bool=False) -> FeedDict:
         # if it is from the pickled file, it is list, not numpy tensor,
         # so convert it as as a prevention
         images = np.array(dataset.get_series(self.data_id))

--- a/neuralmonkey/encoders/cnn_encoder.py
+++ b/neuralmonkey/encoders/cnn_encoder.py
@@ -79,7 +79,6 @@ class CNNEncoder(ModelPart, Attentive):
         self.image_width = image_width
         self.pixel_dim = pixel_dim
         self.dropout_keep_prob = dropout_keep_prob
-        self.name = name
 
         with tf.variable_scope(name):
             self.dropout_placeholder = tf.placeholder(
@@ -100,7 +99,7 @@ class CNNEncoder(ModelPart, Attentive):
             last_n_channels = pixel_dim
 
             self.is_training = tf.placeholder(tf.bool, name="is_training")
-            self.image_processing_layers = []
+            self.image_processing_layers = []  # type: List[tf.Tensor]
 
             with tf.variable_scope("convolutions"):
                 for i, (filter_size,
@@ -122,9 +121,9 @@ class CNNEncoder(ModelPart, Attentive):
                                 [1, 2, 2, 1], "SAME")
                             self.image_processing_layers.append(last_layer)
                             assert image_height % 2 == 0
-                            image_height /= 2
+                            image_height //= 2
                             assert image_width % 2 == 0
-                            image_width /= 2
+                            image_width //= 2
 
                         if local_response_normalization:
                             last_layer = tf.nn.local_response_normalization(

--- a/neuralmonkey/encoders/sentence_encoder.py
+++ b/neuralmonkey/encoders/sentence_encoder.py
@@ -5,6 +5,7 @@ from typing import Optional, Dict, Any, Tuple
 import tensorflow as tf
 
 from neuralmonkey.encoders.attentive import Attentive
+from neuralmonkey.model.model_part import ModelPart
 from neuralmonkey.logging import log
 from neuralmonkey.nn.noisy_gru_cell import NoisyGRUCell
 from neuralmonkey.nn.ortho_gru_cell import OrthoGRUCell
@@ -19,7 +20,7 @@ RNNCellTuple = Tuple[tf.nn.rnn_cell.RNNCell, tf.nn.rnn_cell.RNNCell]
 
 
 # pylint: disable=too-many-instance-attributes
-class SentenceEncoder(Attentive):
+class SentenceEncoder(ModelPart, Attentive):
     """A class that manages parts of the computation graph that are
     used for encoding of input sentences. It uses a bidirectional RNN.
 
@@ -29,9 +30,9 @@ class SentenceEncoder(Attentive):
 
     # pylint: disable=too-many-arguments,too-many-locals
     def __init__(self,
+                 name: str,
                  vocabulary: Vocabulary,
                  data_id: str,
-                 name: str,
                  max_input_len: int,
                  embedding_size: int,
                  rnn_size: int,
@@ -39,7 +40,9 @@ class SentenceEncoder(Attentive):
                  attention_type: Optional[AttType]=None,
                  attention_fertility: int=3,
                  use_noisy_activations: bool=False,
-                 parent_encoder: Optional["SentenceEncoder"]=None) -> None:
+                 parent_encoder: Optional["SentenceEncoder"]=None,
+                 save_checkpoint: Optional[str]=None,
+                 load_checkpoint: Optional[str]=None) -> None:
         """Createes a new instance of the sentence encoder
 
         Arguments:
@@ -62,12 +65,12 @@ class SentenceEncoder(Attentive):
             attention_fertility: Fertility parameter used with
                 CoverageAttention (default 3).
         """
-        super().__init__(
-            attention_type, attention_fertility=attention_fertility)
+        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
+        Attentive.__init__(
+            self, attention_type, attention_fertility=attention_fertility)
 
         self.vocabulary = vocabulary
         self.data_id = data_id
-        self.name = name
 
         self.max_input_len = max_input_len
         self.embedding_size = embedding_size

--- a/neuralmonkey/encoders/sentence_encoder.py
+++ b/neuralmonkey/encoders/sentence_encoder.py
@@ -92,10 +92,11 @@ class SentenceEncoder(ModelPart, Attentive):
                 fw_cell, bw_cell, embedded_inputs, self.sentence_lengths,
                 dtype=tf.float32)
 
+            self.hidden_states = tf.concat(2, outputs_bidi_tup)
+
             with tf.variable_scope('attention_tensor'):
-                self.__attention_tensor = tf.concat(2, outputs_bidi_tup)
                 self.__attention_tensor = self._dropout(
-                    self.__attention_tensor)
+                    self.hidden_states)
 
             self.encoded = tf.concat(1, encoded_tup)
 

--- a/neuralmonkey/encoders/sentence_encoder.py
+++ b/neuralmonkey/encoders/sentence_encoder.py
@@ -1,11 +1,11 @@
 # tests: lint, mypy
 
-from typing import Optional, Dict, Any, Tuple
+from typing import Optional, Any, Tuple
 
 import tensorflow as tf
 
 from neuralmonkey.encoders.attentive import Attentive
-from neuralmonkey.model.model_part import ModelPart
+from neuralmonkey.model.model_part import ModelPart, FeedDict
 from neuralmonkey.logging import log
 from neuralmonkey.nn.noisy_gru_cell import NoisyGRUCell
 from neuralmonkey.nn.ortho_gru_cell import OrthoGRUCell
@@ -14,7 +14,6 @@ from neuralmonkey.vocabulary import Vocabulary
 
 # pylint: disable=invalid-name
 AttType = Any  # Type[] or union of types do not work here
-FeedDict = Dict[tf.Tensor, Any]
 RNNCellTuple = Tuple[tf.nn.rnn_cell.RNNCell, tf.nn.rnn_cell.RNNCell]
 # pylint: enable=invalid-name
 

--- a/neuralmonkey/learning_utils.py
+++ b/neuralmonkey/learning_utils.py
@@ -92,6 +92,7 @@ def training_loop(tf_manager: TensorFlowManager,
         saved_scores = [-np.inf for _ in range(save_n_best_vars)]
         best_score = -np.inf
 
+    tf_manager.initialize_model_parts(runners + [trainer])
     tf_manager.save(variables_files[0])
 
     if os.path.islink(link_best_vars):

--- a/neuralmonkey/model/model_part.py
+++ b/neuralmonkey/model/model_part.py
@@ -1,0 +1,56 @@
+"""Basic functionality of all model parts."""
+
+from abc import ABCMeta, abstractproperty
+from typing import Optional
+
+import tensorflow as tf
+
+from neuralmonkey.logging import log
+
+
+class ModelPart(metaclass=ABCMeta):
+    """Base class of all model parts."""
+    def __init__(self,
+                 name: str,
+                 save_checkpoint: Optional[str]=None,
+                 load_checkpoint: Optional[str]=None):
+        self._name = name
+        self._save_checkpoint = save_checkpoint
+        self._load_checkpoint = load_checkpoint
+
+        self.__saver = None
+
+    @property
+    def name(self):
+        """Name of the model part and its variable scope."""
+        return self._name
+
+    @abstractproperty
+    def feed_dict(self, dataset):
+        """Prepare feed dicts for part's placeholders from a dataset."""
+        raise NotImplementedError("Abstract base class.")
+
+    def __init_saver(self):
+        if not self.__saver:
+            with tf.variable_scope(self._name, reuse=True):
+                parts_variables = tf.get_collection(
+                    tf.GraphKeys.VARIABLES, scope=self._name)
+                self.__saver = tf.train.Saver(var_list=parts_variables)
+
+    def save(self, session):
+        """Save model part to a checkpoint file."""
+        if self._save_checkpoint:
+            self.__init_saver()
+            self.__saver.save(session, self._save_checkpoint)
+
+            log("Variables of '{}' saved to '{}'".format(
+                self.name, self._save_checkpoint))
+
+    def load(self, session):
+        """Load model part from a checkpoint file."""
+        if self._load_checkpoint:
+            self.__init_saver()
+            self.__saver.restore(session, self._load_checkpoint)
+
+            log("Variables of '{}' loaded from '{}'".format(
+                self.name, self._save_checkpoint))

--- a/neuralmonkey/model/model_part.py
+++ b/neuralmonkey/model/model_part.py
@@ -23,7 +23,7 @@ class ModelPart(metaclass=ABCMeta):
         self._save_checkpoint = save_checkpoint
         self._load_checkpoint = load_checkpoint
 
-        self.__saver = None  # type: Optional[tf.train.Saver]
+        self._saver = None  # type: Optional[tf.train.Saver]
 
     @property
     def name(self):
@@ -34,18 +34,18 @@ class ModelPart(metaclass=ABCMeta):
         """Prepare feed dicts for part's placeholders from a dataset."""
         raise NotImplementedError("Abstract base class.")
 
-    def __init_saver(self) -> None:
-        if not self.__saver:
+    def _init_saver(self) -> None:
+        if not self._saver:
             with tf.variable_scope(self._name, reuse=True):
                 parts_variables = tf.get_collection(
                     tf.GraphKeys.VARIABLES, scope=self._name)
-                self.__saver = tf.train.Saver(var_list=parts_variables)
+                self._saver = tf.train.Saver(var_list=parts_variables)
 
     def save(self, session: tf.Session) -> None:
         """Save model part to a checkpoint file."""
         if self._save_checkpoint:
-            self.__init_saver()
-            self.__saver.save(session, self._save_checkpoint)
+            self._init_saver()
+            self._saver.save(session, self._save_checkpoint)
 
             log("Variables of '{}' saved to '{}'".format(
                 self.name, self._save_checkpoint))
@@ -53,8 +53,8 @@ class ModelPart(metaclass=ABCMeta):
     def load(self, session: tf.Session) -> None:
         """Load model part from a checkpoint file."""
         if self._load_checkpoint:
-            self.__init_saver()
-            self.__saver.restore(session, self._load_checkpoint)
+            self._init_saver()
+            self._saver.restore(session, self._load_checkpoint)
 
             log("Variables of '{}' loaded from '{}'".format(
-                self.name, self._save_checkpoint))
+                self.name, self._load_checkpoint))

--- a/neuralmonkey/model/model_part.py
+++ b/neuralmonkey/model/model_part.py
@@ -1,11 +1,16 @@
 """Basic functionality of all model parts."""
 
 from abc import ABCMeta, abstractproperty
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import tensorflow as tf
 
+from neuralmonkey.dataset import Dataset
 from neuralmonkey.logging import log
+
+# pylint: disable=invalid-name
+FeedDict = Dict[tf.Tensor, Any]
+# pylint: disable=invalid-name
 
 
 class ModelPart(metaclass=ABCMeta):
@@ -13,12 +18,12 @@ class ModelPart(metaclass=ABCMeta):
     def __init__(self,
                  name: str,
                  save_checkpoint: Optional[str]=None,
-                 load_checkpoint: Optional[str]=None):
+                 load_checkpoint: Optional[str]=None) -> None:
         self._name = name
         self._save_checkpoint = save_checkpoint
         self._load_checkpoint = load_checkpoint
 
-        self.__saver = None
+        self.__saver = None  # type: Optional[tf.train.Saver]
 
     @property
     def name(self):
@@ -26,18 +31,18 @@ class ModelPart(metaclass=ABCMeta):
         return self._name
 
     @abstractproperty
-    def feed_dict(self, dataset):
+    def feed_dict(self, dataset: Dataset, train: bool) -> FeedDict:
         """Prepare feed dicts for part's placeholders from a dataset."""
         raise NotImplementedError("Abstract base class.")
 
-    def __init_saver(self):
+    def __init_saver(self) -> None:
         if not self.__saver:
             with tf.variable_scope(self._name, reuse=True):
                 parts_variables = tf.get_collection(
                     tf.GraphKeys.VARIABLES, scope=self._name)
                 self.__saver = tf.train.Saver(var_list=parts_variables)
 
-    def save(self, session):
+    def save(self, session: tf.Session) -> None:
         """Save model part to a checkpoint file."""
         if self._save_checkpoint:
             self.__init_saver()
@@ -46,7 +51,7 @@ class ModelPart(metaclass=ABCMeta):
             log("Variables of '{}' saved to '{}'".format(
                 self.name, self._save_checkpoint))
 
-    def load(self, session):
+    def load(self, session: tf.Session) -> None:
         """Load model part from a checkpoint file."""
         if self._load_checkpoint:
             self.__init_saver()

--- a/neuralmonkey/model/model_part.py
+++ b/neuralmonkey/model/model_part.py
@@ -1,6 +1,6 @@
 """Basic functionality of all model parts."""
 
-from abc import ABCMeta, abstractproperty
+from abc import ABCMeta
 from typing import Any, Dict, Optional
 
 import tensorflow as tf
@@ -30,7 +30,6 @@ class ModelPart(metaclass=ABCMeta):
         """Name of the model part and its variable scope."""
         return self._name
 
-    @abstractproperty
     def feed_dict(self, dataset: Dataset, train: bool) -> FeedDict:
         """Prepare feed dicts for part's placeholders from a dataset."""
         raise NotImplementedError("Abstract base class.")

--- a/neuralmonkey/tests/test_model_part.py
+++ b/neuralmonkey/tests/test_model_part.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Test ModelPart class."""
+
+import os
+import tempfile
+import unittest
+
+import numpy as np
+import tensorflow as tf
+
+from neuralmonkey.vocabulary import Vocabulary
+from neuralmonkey.encoders.sentence_encoder import SentenceEncoder
+
+
+class Test(unittest.TestCase):
+    """Test capabilities of model part."""
+    def test_save_and_load(self):
+        """Try to save and load encoder."""
+        vocabulary = Vocabulary()
+        vocabulary.add_word("a")
+        vocabulary.add_word("b")
+
+        checkpoint_file = tempfile.NamedTemporaryFile(delete=False)
+        checkpoint_file.close()
+
+        encoder = SentenceEncoder(
+            "enc", Vocabulary(), "data_id", 10, 20, 30,
+            save_checkpoint=checkpoint_file.name,
+            load_checkpoint=checkpoint_file.name)
+
+        encoders_variables = tf.get_collection(
+            tf.GraphKeys.VARIABLES, scope="enc")
+
+        sess_1 = tf.Session()
+        sess_1.run(tf.initialize_all_variables())
+        encoder.save(sess_1)
+
+        sess_2 = tf.Session()
+        sess_2.run(tf.initialize_all_variables())
+        encoder.load(sess_2)
+
+        values_in_sess_1 = sess_1.run(encoders_variables)
+        values_in_sess_2 = sess_2.run(encoders_variables)
+
+        self.assertTrue(
+            all(np.all(v1 == v2) for v1, v2 in
+                zip(values_in_sess_1, values_in_sess_2)))
+
+        os.remove(checkpoint_file.name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/neuralmonkey/tf_manager.py
+++ b/neuralmonkey/tf_manager.py
@@ -159,6 +159,14 @@ class TensorFlowManager(object):
             log("Loading variables from {}".format(file_name))
             self.saver.restore(sess, file_name)
 
+    def initialize_model_parts(self, runners) -> None:
+        """Initialize model parts variables from their checkpoints."""
+
+        all_coders = set.union(*[rnr.all_coders for rnr in runners])
+        for coder in all_coders:
+            for session in self.sessions:
+                coder.load(session)
+
 
 def _feed_dicts(dataset, coders, train=False):
     """


### PR DESCRIPTION
This PR introduces a common predecessor `ModelPart` for all model parts (addresses #117) and introduces a basic mechanism for saving and loading the model parts (partially addresses #103).

While adding the inheritance from the `ModelPart` I added type annotations for all encoders and decoders except for `CNNEncoder` will be rewritten entirely in #196 and `MultiDecoder` which should be probably deleted.

Every model part is capable of saving a checkpoint with its own variables which can be later load **in the same variable** scope. We urgently need this functionality in order to use pre-trained ImageNet models in multi-modal translation.

@tomasmcz, please have a look at line 407 in `Decoder`. There is an explicit cast of `Iterable[Any]` returned by a dataset to `Iterable[List[str]]` because of mypy. In Java, I would use generics. Do you have an idea, how to solve this in a better way?

**Next steps:** (will become issues after this is merged)
* introduce the pre-trained ImageNet models from `tf.contrib.slim`
* create a better class hierarchy for model parts
* make model parts checkpoints scope-agnostic