### PR TITLE
Better logging initialization

### DIFF
--- a/neuralmonkey/logging.py
+++ b/neuralmonkey/logging.py
@@ -14,7 +14,7 @@ class Logging(object):
 
     # 'all' and 'none' are special symbols,
     # others are filtered according the labels
-    debug_enabled = ['all']
+    debug_enabled = ['none']  # type: List[str]
     debug_disabled = []  # type: List[str]
 
     @staticmethod

--- a/neuralmonkey/logging.py
+++ b/neuralmonkey/logging.py
@@ -3,6 +3,8 @@
 import time
 import codecs
 import sys
+import os
+
 # pylint: disable=unused-import
 from typing import Any, Optional
 from termcolor import colored
@@ -14,8 +16,10 @@ class Logging(object):
 
     # 'all' and 'none' are special symbols,
     # others are filtered according the labels
-    debug_enabled = ['none']  # type: List[str]
-    debug_disabled = []  # type: List[str]
+    debug_enabled = [
+        os.environ.get("NEURALMONKEY_DEBUG_ENABLE", "none")]  # type: List[str]
+    debug_disabled = [
+        os.environ.get("NEURALMONKEY_DEBUG_DISABLE", "")]  # type: List[str]
 
     @staticmethod
     def set_log_file(path):

--- a/neuralmonkey/train.py
+++ b/neuralmonkey/train.py
@@ -87,7 +87,6 @@ def main() -> None:
                 .format(cfg.args.output), color='red')
             exit(1)
 
-
     # pylint: disable=broad-except
     if not os.path.isdir(cfg.args.output):
         try:


### PR DESCRIPTION
* This PR solves #93 
* Log directory is created and logging is initialized before model is built.
* This PR also restores the default behavior which diables printing out debug messages.
* Debugging can be controlled via two environment variables, ``NEURALMONKEY_DEBUG_ENABLE`` and ``NEURALMONKEY_DEBUG_DISABLE``, which are handled in logging initializer.

Simplest usage:
``NEURALMONKEY_DEBUG_ENABLE=all bin/neuralmonkey-train tests/small.ini``