### PR TITLE
PR to initialize discussion about the names in INI

### DIFF
--- a/docs/source/visualization.rst
+++ b/docs/source/visualization.rst
@@ -30,7 +30,6 @@ visible to other computers in the network, set the host to 0.0.0.0)
 Then you can navigate in your browser to `http://localhost:<port>` to view the
 experiment logs.
 
-
 TensorBoard
 -----------
 


### PR DESCRIPTION
In this branch I would like to do all changes that consider naming in the ini files.

[1] from issue #228: we should change the name "data_id" into something meaningful. The naming "input_series" is problematic because you cannot differentiate between singular and plural. Better would be "input_series_id/s" ... As I have looked into the code this naming would not work because sometimes data_id refer to the target series. I would suggest renaming all "data_id/s" into "series_id/s".
I know that this name is already used when referred as a vocabulary series name and if I am correct there should not be any collision. Only collision could be ideological as what it represents. What do you think? Or do you have better name?

If you have any other ideas what would you like to change, please write them here so we can discuss them.