### PR TITLE
typeguard

### DIFF
--- a/neuralmonkey/dataset.py
+++ b/neuralmonkey/dataset.py
@@ -21,7 +21,7 @@ PREPROCESSED_SERIES = re.compile("pre_([^_]*)$")
 def load_dataset_from_files(
         name: str=None, lazy: bool=False,
         preprocessors: List[Tuple[str, str, Callable]]=None,
-        **kwargs: str) -> 'Dataset':
+        **kwargs: Dict[str, Any]) -> 'Dataset':
     """Load a dataset from the files specified by the provided arguments.
     Paths to the data are provided in a form of dictionary.
 
@@ -148,7 +148,7 @@ def _get_series_paths_and_readers(
     return series_sources
 
 
-def _get_series_outputs(kwargs: Dict[str, str]) -> Dict[str, str]:
+def _get_series_outputs(kwargs: Dict[str, Any]) -> Dict[str, str]:
     """Get paths to series outputs from the dataset keyword argument specs.
     Output file for a series named 'xxx' is specified by parameter 's_xxx_out'
 

--- a/neuralmonkey/dataset.py
+++ b/neuralmonkey/dataset.py
@@ -1,5 +1,5 @@
 """ Implementation of the dataset class. """
-# tests: lint, mypy
+
 import random
 import re
 import collections
@@ -7,6 +7,7 @@ import collections
 from typing import Any, List, Callable, Iterable, Dict, Tuple
 
 import numpy as np
+from typeguard import check_argument_types
 
 from neuralmonkey.logging import log
 from neuralmonkey.readers.utils import Reader
@@ -46,6 +47,9 @@ def load_dataset_from_files(
     Raises:
         Exception when no input files are provided.
     """
+
+    assert check_argument_types()
+
     series_paths_and_readers = _get_series_paths_and_readers(kwargs)
     series_outputs = _get_series_outputs(kwargs)
 

--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -5,6 +5,7 @@ import math
 
 import tensorflow as tf
 import numpy as np
+from typeguard import check_argument_types
 
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.vocabulary import Vocabulary, START_TOKEN
@@ -74,6 +75,8 @@ class Decoder(ModelPart):
         """
         ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
         log("Initializing decoder, name: '{}'".format(name))
+
+        assert check_argument_types()
 
         self.encoders = encoders
         self.vocabulary = vocabulary

--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -1,10 +1,8 @@
-# tests: lint
-
-from typing import cast, Iterable, List, Callable, Optional, Union, Any, Tuple
 import math
+from typing import cast, Iterable, List, Callable, Optional, Union, Any, Tuple
 
-import tensorflow as tf
 import numpy as np
+import tensorflow as tf
 from typeguard import check_argument_types
 
 from neuralmonkey.dataset import Dataset

--- a/neuralmonkey/encoders/sentence_encoder.py
+++ b/neuralmonkey/encoders/sentence_encoder.py
@@ -3,6 +3,7 @@
 from typing import Optional, Any, Tuple
 
 import tensorflow as tf
+from typeguard import check_argument_types
 
 from neuralmonkey.encoders.attentive import Attentive
 from neuralmonkey.model.model_part import ModelPart, FeedDict
@@ -67,6 +68,8 @@ class SentenceEncoder(ModelPart, Attentive):
         ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
         Attentive.__init__(
             self, attention_type, attention_fertility=attention_fertility)
+
+        assert check_argument_types()
 
         self.vocabulary = vocabulary
         self.data_id = data_id

--- a/neuralmonkey/tf_manager.py
+++ b/neuralmonkey/tf_manager.py
@@ -13,13 +13,12 @@ from typing import Any, List, Union
 # pylint: enable=unused-import
 
 import tensorflow as tf
+from typeguard import check_argument_types
+
 from neuralmonkey.logging import log
 from neuralmonkey.dataset import Dataset
-
 from neuralmonkey.runners.base_runner import (ExecutionResult,
                                               reduce_execution_results)
-
-# tests: pylint,mypy
 
 
 class TensorFlowManager(object):
@@ -48,6 +47,8 @@ class TensorFlowManager(object):
             report_gpu_memory_consumption: Report overall GPU memory at every
                 logging
         """
+
+        assert check_argument_types()
 
         session_cfg = tf.ConfigProto()
         session_cfg.inter_op_parallelism_threads = num_threads

--- a/neuralmonkey/trainers/cross_entropy_trainer.py
+++ b/neuralmonkey/trainers/cross_entropy_trainer.py
@@ -1,10 +1,9 @@
 from typing import Any, List, Optional
 
+from typeguard import check_argument_types
+
 from neuralmonkey.trainers.generic_trainer import (GenericTrainer, Objective,
                                                    ObjectiveWeight)
-
-# tests: lint, mypy
-
 
 def xent_objective(decoder, weight=None) -> Objective:
     """Get XENT objective from decoder with cost."""
@@ -25,6 +24,8 @@ class CrossEntropyTrainer(GenericTrainer):
                  decoder_weights: Optional[List[ObjectiveWeight]]=None,
                  l1_weight=0., l2_weight=0.,
                  clip_norm=False, optimizer=None, global_step=None) -> None:
+
+        assert check_argument_types()
 
         if decoder_weights is None:
             decoder_weights = [None for _ in decoders]

--- a/neuralmonkey/trainers/cross_entropy_trainer.py
+++ b/neuralmonkey/trainers/cross_entropy_trainer.py
@@ -5,6 +5,7 @@ from typeguard import check_argument_types
 from neuralmonkey.trainers.generic_trainer import (GenericTrainer, Objective,
                                                    ObjectiveWeight)
 
+
 def xent_objective(decoder, weight=None) -> Objective:
     """Get XENT objective from decoder with cost."""
     return Objective(

--- a/neuralmonkey/vocabulary.py
+++ b/neuralmonkey/vocabulary.py
@@ -2,13 +2,14 @@
 can be used to obtain a Vocabulary instance.
 """
 
-from typing import List, Tuple
-
 import collections
-import numpy as np
 import os
 import pickle as pickle
 import random
+
+from typing import List, Tuple
+
+import numpy as np
 from typeguard import check_argument_types
 
 from neuralmonkey.logging import log
@@ -83,7 +84,7 @@ def from_dataset(datasets: List[Dataset], series_ids: List[str], max_size: int,
     Returns:
         The new Vocabulary instance.
     """
-    
+
     assert check_argument_types()
 
     vocabulary = Vocabulary(unk_sample_prob=unk_sample_prob)

--- a/neuralmonkey/vocabulary.py
+++ b/neuralmonkey/vocabulary.py
@@ -1,15 +1,15 @@
 """This module implements the Vocabulary class and the helper functions that
 can be used to obtain a Vocabulary instance.
 """
-# tests: lint, mypy
 
 from typing import List, Tuple
 
-import os
 import collections
-import random
-import pickle as pickle
 import numpy as np
+import os
+import pickle as pickle
+import random
+from typeguard import check_argument_types
 
 from neuralmonkey.logging import log
 from neuralmonkey.dataset import Dataset, LazyDataset
@@ -83,6 +83,9 @@ def from_dataset(datasets: List[Dataset], series_ids: List[str], max_size: int,
     Returns:
         The new Vocabulary instance.
     """
+    
+    assert check_argument_types()
+
     vocabulary = Vocabulary(unk_sample_prob=unk_sample_prob)
 
     for dataset in datasets:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ numpy
 pillow
 git+https://github.com/aflc/pyter@857a1552443f139a3
 pygments
+typeguard
 
 https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.11.0-cp35-cp35m-linux_x86_64.whl

--- a/tests/vocab.ini
+++ b/tests/vocab.ini
@@ -31,7 +31,6 @@ s_target="tests/data/train.tc.de"
 class=config.utils.dataset_from_files
 s_source="tests/data/val.tc.en"
 s_target="tests/data/val.tc.de"
-random_seed=1234
 
 [encoder_vocabulary]
 class=config.utils.initialize_vocabulary


### PR DESCRIPTION
Použil bych ten typeguard takhle. Hází to o něco srozumitelnější chybové hlášky než předtím („v parametru "a" jsem chtěl jsem int, ale dostal jsem string“ místo „"xxx" není platný literál pro int“) a především to zabije tu init metodu dřív, než stihne ten argument poslat někam do hlubin NM.