### PR TITLE
allow to set encoder.attention_matrix_size

### DIFF
--- a/neuralmonkey/decoding_function.py
+++ b/neuralmonkey/decoding_function.py
@@ -17,7 +17,8 @@ class Attention(object):
     # For maintaining the same API as in CoverageAttention
 
     def __init__(self, attention_states, scope,
-                 input_weights=None, attention_fertility=None):
+                 input_weights=None, attention_fertility=None,
+                 attention_matrix_size=None):
         """Create the attention object.
 
         Args:
@@ -27,7 +28,10 @@ class Attention(object):
                    attention object.
             input_weights: (Optional) The padding weights on the input.
             attention_fertility: (Optional) For the Coverage attention
-                compatibilty, maximum fertility of one word.
+                compatibility, maximum fertility of one word.
+            attention_matrix_size: (Optional) The size of the hidden layer
+                predicting attention energies (n' in appendix of Bahdanau 2014)
+                Defaults to rnn_size.
         """
         self.scope = scope
         self.logits_in_time = []
@@ -46,7 +50,10 @@ class Attention(object):
                 [-1, self.attn_length, 1, self.attn_size])
 
             # Size of query vectors for attention.
-            self.attention_vec_size = self.attn_size
+            if attention_matrix_size is None:
+                self.attention_vec_size = self.attn_size
+            else:
+                self.attention_vec_size = attention_matrix_size
 
             # This variable corresponds to Bahdanau's U_a in the paper
             k = tf.get_variable(

--- a/neuralmonkey/encoders/attentive.py
+++ b/neuralmonkey/encoders/attentive.py
@@ -5,7 +5,7 @@ import tensorflow as tf
 
 
 class Attentive(metaclass=ABCMeta):
-    """A base class fro an attentive part of graph (typically encoder).
+    """A base class for an attentive part of graph (typically encoder).
 
     Objects inheriting this class are able to generate an attention object that
     allows a decoder to perform attention over an attention_object provided by

--- a/neuralmonkey/encoders/sentence_encoder.py
+++ b/neuralmonkey/encoders/sentence_encoder.py
@@ -38,6 +38,7 @@ class SentenceEncoder(ModelPart, Attentive):
                  dropout_keep_prob: float=1.0,
                  attention_type: Optional[AttType]=None,
                  attention_fertility: int=3,
+                 attention_matrix_size: Optional[int]=None,
                  use_noisy_activations: bool=False,
                  parent_encoder: Optional["SentenceEncoder"]=None,
                  save_checkpoint: Optional[str]=None,
@@ -63,10 +64,14 @@ class SentenceEncoder(ModelPart, Attentive):
                 attention mechanism (default None)
             attention_fertility: Fertility parameter used with
                 CoverageAttention (default 3).
+            attention_matrix_size: (Optional) The size of the hidden layer
+                predicting attention energies (n' in appendix of Bahdanau 2014)
+                Defaults to rnn_size.
         """
         ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
         Attentive.__init__(
-            self, attention_type, attention_fertility=attention_fertility)
+            self, attention_type, attention_fertility=attention_fertility,
+            attention_matrix_size=attention_matrix_size)
 
         self.vocabulary = vocabulary
         self.data_id = data_id


### PR DESCRIPTION
Making the attention matrix larger reportedly helps. I have an experiment running, see TB on victoria:6016.