### PR TITLE
Deprecate config.utils

### DIFF
--- a/docs/source/machine_translation.rst
+++ b/docs/source/machine_translation.rst
@@ -133,13 +133,13 @@ For training, we prepare two datasets. Since we are using BPE, we need to
 .. code-block:: ini
 
   [train_data]
-  class=config.utils.dataset_from_files
+  class=dataset.load_dataset_from_files
   s_source="exp-nm-mt/data/train/Batch1a_en.txt.gz"
   s_target="exp-nm-mt/data/train/Batch1a_cs.txt.gz"
   preprocessors=[("source", "source_bpe", <bpe_preprocess>), ("target", "target_bpe", <bpe_preprocess>)]
 
   [val_data]
-  class=config.utils.dataset_from_files
+  class=dataset.load_dataset_from_files
   s_source="exp-nm-mt/data/dev/Batch2a_en.txt.gz"
   s_target="exp-nm-mt/data/dev/Batch2a_cs.txt.gz"
   preprocessors=[("source", "source_bpe", <bpe_preprocess>), ("target", "target_bpe", <bpe_preprocess>)]
@@ -279,7 +279,7 @@ As for the evaluation, you need to create ``translation_run.ini``:
   test_datasets=[<eval_data>]
 
   [eval_data]
-  class=config.utils.dataset_from_files
+  class=dataset.load_dataset_from_files
   s_source="exp-nm-mt/data/test/Batch3a_en.txt.gz"
 .. TUTCHECK exp-nm-mt/translation_run.ini
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -226,13 +226,13 @@ The configuration of the datasets looks like this:
 .. code-block:: ini
 
   [train_dataset]
-  class=config.utils.dataset_from_files
+  class=dataset.load_dataset_from_files
   s_source="exp-nm-ape/data/train/train.src"
   s_translated="exp-nm-ape/data/train/train.mt"
   s_edits="exp-nm-ape/data/train/train.edits"
 
   [val_dataset]
-  class=config.utils.dataset_from_files
+  class=dataset.load_dataset_from_files
   s_source="exp-nm-ape/data/dev/dev.src"
   s_translated="exp-nm-ape/data/dev/dev.mt"
   s_edits="exp-nm-ape/data/dev/dev.edits"
@@ -589,7 +589,7 @@ configuration. We will call this file ``post-edit_run.ini``:
   test_datasets=[<eval_data>]
 
   [eval_data]
-  class=config.utils.dataset_from_files
+  class=dataset.load_dataset_from_files
   s_source="exp-nm-ape/data/test/test.src"
   s_translated="exp-nm-ape/data/test/test.mt"
   s_greedy_edits_out="exp-nm-ape/test_output.edits"

--- a/examples/factored.ini
+++ b/examples/factored.ini
@@ -36,13 +36,13 @@ class=evaluators.bleu.BLEUEvaluator
 ; training or validation respectively.
 
 [train_data]
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source=examples/data/pcedt2/train.forms-en.txt
 s_tags=examples/data/pcedt2/train.tags-en.txt
 s_target=examples/data/pcedt2/train.forms-cs.txt
 
 [val_data]
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source=examples/data/pcedt2/val.forms-en.txt
 s_tags=examples/data/pcedt2/val.tags-en.txt
 s_target=examples/data/pcedt2/val.forms-cs.txt

--- a/examples/language_model.ini
+++ b/examples/language_model.ini
@@ -51,13 +51,13 @@ class=evaluators.perplexity.Perplexity
 ; defined here, because they are used identifiers while preparing vocabularies.
 ; Dataset is not a standard class, it treats the __init__ methods arguements as
 ; a dictionary, therefore the data series names can be any strings.
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_target=examples/data/train.de
 
 [val_data]
 ; Validation data, the languages are not necessary here, encoders and decoder
 ; acces the data series via the string identifiers defined here.
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_target=examples/data/val.de
 
 [decoder_vocabulary]

--- a/examples/multiobjective.ini
+++ b/examples/multiobjective.ini
@@ -28,14 +28,14 @@ n=4
 ; source or target, as both are confusing.
 
 [train_data]
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source=examples/data/pcedt2/train.forms-en.txt
 s_tags=examples/data/pcedt2/train.tags-en.txt
 s_target=examples/data/pcedt2/train.forms-cs.txt
 ;preprocessor=<bpe_preprocess>
 
 [val_data]
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source=examples/data/pcedt2/val.forms-en.txt
 s_tags=examples/data/pcedt2/val.tags-en.txt
 s_target=examples/data/pcedt2/val.forms-cs.txt

--- a/examples/tagging.ini
+++ b/examples/tagging.ini
@@ -62,7 +62,7 @@ n=4
 ; the data series names can be any string, prefixed with "s_". To specify the
 ; output file for a series, use "s_" prefix and "_out" suffix, e.g.
 ; "s_target_out"
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source=examples/data/pcedt2/train.forms-en.txt
 ; Tags are in the source language, but we deal with them as outputs, so we don't call them
 ; source or target, as both are confusing.
@@ -72,7 +72,7 @@ s_tags=examples/data/pcedt2/train.tags-en.txt
 [val_data]
 ; Validation data, the languages are not necessary here, encoders and decoders
 ; access the data series via the string identifiers defined here.
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source=examples/data/pcedt2/val.forms-en.txt
 ; Tags are in the source language, but we deal with them as outputs, so we don't call them
 ; source or target, as both are confusing.

--- a/examples/translation.ini
+++ b/examples/translation.ini
@@ -57,13 +57,13 @@ n=4
 ; dictionary, therefore the data series names can be any string,
 ; prefixed with "s_". To specify the output file for a series, use
 ; "s_" prefix and "_out" suffix, e.g.  "s_target_out"
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source=examples/data/train.en
 s_target=examples/data/train.de
 preprocessor=<bpe_preprocess>
 
 [val_data]
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source=examples/data/val.en
 s_target=examples/data/val.de
 preprocessor=<bpe_preprocess>

--- a/neuralmonkey/config/utils.py
+++ b/neuralmonkey/config/utils.py
@@ -2,18 +2,32 @@
 the configuration file because calling the functions or the class constructors
 directly would be inconvinent or impossible.
 """
-# tests: lint, mypy
+
 import tensorflow as tf
 
+
+from neuralmonkey.logging import log
 import neuralmonkey.vocabulary as vocabulary
 import neuralmonkey.dataset as dataset
 
+
+def deprecated(func):
+    def dep_func(*args, **kwargs):
+        log("Warning! Use of deprecated function from "
+            + "'neuralmonkey.config.utils'. " +
+            "Use '{}' instead.".format(func.__module__[13:]
+                                       + '.' + func.__name__),
+            color='red')
+        return func(*args, **kwargs)
+    return dep_func
+
+
 # pylint: disable=invalid-name
 # for backwards compatibility
-dataset_from_files = dataset.load_dataset_from_files
-vocabulary_from_file = vocabulary.from_file
-vocabulary_from_bpe = vocabulary.from_bpe
-vocabulary_from_dataset = vocabulary.from_dataset
+dataset_from_files = deprecated(dataset.load_dataset_from_files)
+vocabulary_from_file = deprecated(vocabulary.from_file)
+vocabulary_from_bpe = deprecated(vocabulary.from_bpe)
+vocabulary_from_dataset = deprecated(vocabulary.from_dataset)
 initialize_vocabulary = vocabulary.initialize_vocabulary
 
 

--- a/tests/alignment.ini
+++ b/tests/alignment.ini
@@ -32,7 +32,7 @@ class=evaluators.bleu.BLEUEvaluator
 ; the data series names can be any string, prefixed with "s_". To specify the
 ; output file for a series, use "s_" prefix and "_out" suffix, e.g.
 ; "s_target_out"
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source="tests/data/train.tc.en"
 s_target="tests/data/train.tc.de"
 s_aligiza="tests/data/train.tc.ali"
@@ -46,7 +46,7 @@ target_len=8
 [val_data]
 ; Validation data, the languages are not necessary here, encoders and decoders
 ; access the data series via the string identifiers defined here.
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source="tests/data/val.tc.en"
 s_target="tests/data/val.tc.de"
 
@@ -54,12 +54,12 @@ s_target="tests/data/val.tc.de"
 [val_data_no_target]
 ; Validation data, the languages are not necessary here, encoders and decoders
 ; access the data series via the string identifiers defined here.
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source="tests/data/val.tc.en"
 
 
 [encoder_vocabulary]
-class=config.utils.vocabulary_from_dataset
+class=vocabulary.from_dataset
 datasets=[<train_data>]
 series_ids=["source"]
 max_size=60
@@ -77,7 +77,7 @@ data_id="source"
 vocabulary=<encoder_vocabulary>
 
 [decoder_vocabulary]
-class=config.utils.vocabulary_from_dataset
+class=vocabulary.from_dataset
 datasets=[<train_data>]
 series_ids=["target"]
 max_size=70

--- a/tests/bahdanau.ini
+++ b/tests/bahdanau.ini
@@ -32,14 +32,14 @@ class=evaluators.bleu.BLEUEvaluator
 ; the data series names can be any string, prefixed with "s_". To specify the
 ; output file for a series, use "s_" prefix and "_out" suffix, e.g.
 ; "s_target_out"
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source="tests/data/train.tc.en"
 s_target="tests/data/train.tc.de"
 
 [val_data]
 ; Validation data, the languages are not necessary here, encoders and decoders
 ; access the data series via the string identifiers defined here.
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source="tests/data/val.tc.en"
 s_target="tests/data/val.tc.de"
 
@@ -47,12 +47,12 @@ s_target="tests/data/val.tc.de"
 [val_data_no_target]
 ; Validation data, the languages are not necessary here, encoders and decoders
 ; access the data series via the string identifiers defined here.
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source="tests/data/val.tc.en"
 
 
 [encoder_vocabulary]
-class=config.utils.vocabulary_from_dataset
+class=vocabulary.from_dataset
 datasets=[<train_data>]
 series_ids=["source"]
 max_size=60
@@ -70,7 +70,7 @@ data_id="source"
 vocabulary=<encoder_vocabulary>
 
 [decoder_vocabulary]
-class=config.utils.vocabulary_from_dataset
+class=vocabulary.from_dataset
 datasets=[<train_data>]
 series_ids=["target"]
 max_size=70

--- a/tests/bpe.ini
+++ b/tests/bpe.ini
@@ -29,20 +29,20 @@ num_sessions=1
 class=evaluators.bleu.BLEUEvaluator
 
 [train_data]
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source="tests/data/train.tc.en"
 s_target="tests/data/train.tc.de"
 preprocessors=[("source", "source_bpe", <bpe_preprocess>), ("target", "target_bpe", <bpe_preprocess>)]
 lazy=True
 
 [val_data]
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source="tests/data/val.tc.en"
 s_target="tests/data/val.tc.de"
 preprocessors=[("source", "source_bpe", <bpe_preprocess>), ("target", "target_bpe", <bpe_preprocess>)]
 
 [val_data_no_target]
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source="tests/data/val.tc.en"
 preprocessors=[("source", "source_bpe", <bpe_preprocess>)]
 

--- a/tests/captioning.ini
+++ b/tests/captioning.ini
@@ -35,18 +35,18 @@ pad_w=224
 mode="RGB"
 
 [train_data]
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_target="tests/data/flickr30k/train.en"
 s_images=("tests/data/flickr30k/train_images.txt", <image_reader>)
 lazy=True
 
 [val_data]
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_target="tests/data/flickr30k/val.en"
 s_images=("tests/data/flickr30k/val_images.txt", <image_reader>)
 
 [val_data_no_target]
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_images=("tests/data/flickr30k/val_images.txt", <image_reader>)
 
 [imagenet]
@@ -58,7 +58,7 @@ output_layer="alexnet_v2/conv5"
 
 
 [decoder_vocabulary]
-class=config.utils.vocabulary_from_dataset
+class=vocabulary.from_dataset
 datasets=[<train_data>]
 series_ids=["target"]
 max_size=70

--- a/tests/factored.ini
+++ b/tests/factored.ini
@@ -21,19 +21,19 @@ validation_period=20
 class=evaluators.bleu.BLEUEvaluator
 
 [train_data]
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source="tests/data/multi/train.forms-en.txt"
 s_tags="tests/data/multi/train.tags-en.txt"
 s_target="tests/data/multi/train.forms-cs.txt"
 
 [val_data]
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source="tests/data/multi/val.forms-en.txt"
 s_tags="tests/data/multi/val.tags-en.txt"
 s_target="tests/data/multi/val.forms-cs.txt"
 
 [surface_source_vocabulary]
-class=config.utils.vocabulary_from_dataset
+class=vocabulary.from_dataset
 datasets=[<train_data>]
 series_ids=["source"]
 max_size=5000
@@ -41,7 +41,7 @@ save_file="tests/tmp-test-output/surface_vocabulary.pickle"
 overwrite=True
 
 [tag_vocabulary]
-class=config.utils.vocabulary_from_dataset
+class=vocabulary.from_dataset
 datasets=[<train_data>]
 series_ids=["tags"]
 max_size=5000
@@ -49,7 +49,7 @@ save_file="tests/tmp-test-output/tag_vocabulary.pickle"
 overwrite=True
 
 [surface_target_vocabulary]
-class=config.utils.vocabulary_from_dataset
+class=vocabulary.from_dataset
 datasets=[<train_data>]
 series_ids=["target"]
 max_size=5000

--- a/tests/post-edit.ini
+++ b/tests/post-edit.ini
@@ -9,14 +9,14 @@ source_id="source"
 edits_id="edits"
 
 [train_dataset]
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source="tests/data/postedit/train.src"
 s_translated="tests/data/postedit/train.mt"
 s_target="tests/data/postedit/train.pe"
 pre_edits=<preprocess>
 
 [val_dataset]
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source="tests/data/postedit/dev.src"
 s_translated="tests/data/postedit/dev.mt"
 s_target="tests/data/postedit/dev.pe"

--- a/tests/small.ini
+++ b/tests/small.ini
@@ -32,7 +32,7 @@ class=evaluators.bleu.BLEUEvaluator
 ; the data series names can be any string, prefixed with "s_". To specify the
 ; output file for a series, use "s_" prefix and "_out" suffix, e.g.
 ; "s_target_out"
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source="tests/data/train.tc.en"
 s_target="tests/data/train.tc.de"
 preprocessors=[("source", "source_chars", processors.helpers.preprocess_char_based)]
@@ -41,13 +41,13 @@ lazy=True
 [val_data]
 ; Validation data, the languages are not necessary here, encoders and decoders
 ; access the data series via the string identifiers defined here.
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source="tests/data/val.tc.en"
 s_target="tests/data/val.tc.de"
 preprocessors=[("source", "source_chars", processors.helpers.preprocess_char_based)]
 
 [encoder_vocabulary]
-class=config.utils.vocabulary_from_dataset
+class=vocabulary.from_dataset
 datasets=[<train_data>]
 series_ids=["source"]
 max_size=60
@@ -66,7 +66,7 @@ data_id="source"
 vocabulary=<encoder_vocabulary>
 
 [decoder_vocabulary]
-class=config.utils.vocabulary_from_dataset
+class=vocabulary.from_dataset
 datasets=[<train_data>]
 series_ids=["target"]
 max_size=70

--- a/tests/str.ini
+++ b/tests/str.ini
@@ -32,7 +32,7 @@ pad_w=310
 mode="F"
 
 [train_data]
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_images=("tests/data/str/train_files.txt", <image_reader>)
 s_target="tests/data/str/train_words.txt"
 preprocessors=[("target", "target_chars", processors.helpers.preprocess_char_based)]
@@ -41,7 +41,7 @@ lazy=False
 [val_data]
 ; Validation data, the languages are not necessary here, encoders and decoders
 ; access the data series via the string identifiers defined here.
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_images=("tests/data/str/val_files.txt", <image_reader>)
 s_target="tests/data/str/val_words.txt"
 preprocessors=[("target", "target_chars", processors.helpers.preprocess_char_based)]
@@ -49,7 +49,7 @@ preprocessors=[("target", "target_chars", processors.helpers.preprocess_char_bas
 [val_data_no_target]
 ; Validation data, the languages are not necessary here, encoders and decoders
 ; access the data series via the string identifiers defined here.
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_images=("tests/data/str/val_files.txt", <image_reader>)
 
 [encoder]
@@ -62,7 +62,7 @@ pixel_dim=1
 convolutions=[(3, 3, None), (3, 3, None)]
 
 [decoder_vocabulary]
-class=config.utils.vocabulary_from_dataset
+class=vocabulary.from_dataset
 datasets=[<train_data>]
 series_ids=["target_chars"]
 max_size=70

--- a/tests/test_data.ini
+++ b/tests/test_data.ini
@@ -2,12 +2,12 @@
 test_datasets=[<val_data>,<val_data_no_target>]
 
 [val_data]
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source="tests/data/val10.tc.en"
 s_target="tests/data/val10.tc.de"
 s_target_out="tests/tmpout-val10.tc.de"
 
 [val_data_no_target]
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source="tests/data/val10.tc.en"
 s_target_out="tests/tmpout-val10.tc.de"

--- a/tests/test_ensemble_data.ini
+++ b/tests/test_ensemble_data.ini
@@ -3,7 +3,7 @@ test_datasets=[<val_data>]
 variables=["tests/tmp-test-output/variables.data.0", "tests/tmp-test-output/variables.data.1", "tests/tmp-test-output/variables.data.2"]
 
 [val_data]
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source="tests/data/val.tc.en"
 s_target="tests/data/val.tc.de"
 s_target_out="tests/tmp-test-output/ensemble_out.txt"

--- a/tests/vocab.ini
+++ b/tests/vocab.ini
@@ -23,12 +23,12 @@ num_threads=1
 class=evaluators.bleu.BLEUEvaluator
 
 [train_data]
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source="tests/data/train.tc.en"
 s_target="tests/data/train.tc.de"
 
 [val_data]
-class=config.utils.dataset_from_files
+class=dataset.load_dataset_from_files
 s_source="tests/data/val.tc.en"
 s_target="tests/data/val.tc.de"
 


### PR DESCRIPTION
Deprecate functions from `config.utils` and use `dictionary` and `vocabulary` modules directly.