### PR TITLE
train_start_offset

### DIFF
--- a/neuralmonkey/learning_utils.py
+++ b/neuralmonkey/learning_utils.py
@@ -141,7 +141,8 @@ def training_loop(tf_manager: TensorFlowManager,
 
                 while skipped_instances < train_start_offset:
                     try:
-                        skipped_instances += len(next(train_batched_datasets))
+                        skipped_instances += len(
+                            next(train_batched_datasets))  # type: ignore
                     except StopIteration:
                         log("Warning: Trying to skip more instances than the "
                             "size of the training data", color="red")

--- a/neuralmonkey/learning_utils.py
+++ b/neuralmonkey/learning_utils.py
@@ -135,8 +135,8 @@ def training_loop(tf_manager: TensorFlowManager,
 
             if epoch_n == 1 and train_start_offset:
                 if not isinstance(train_dataset, LazyDataset):
-                    log("Warning: Not skipping training instances with shuffled "
-                        "in-memory dataset", color="red")
+                    log("Warning: Not skipping training instances with "
+                        "shuffled in-memory dataset", color="red")
                 else:
                     _skip_lines(train_start_offset, train_batched_datasets)
 
@@ -558,7 +558,7 @@ def _skip_lines(start_offset: int,
     skipped_instances = 0
     while skipped_instances < start_offset:
         try:
-            skipped_instances += len( next(batched_datasets))  # type: ignore
+            skipped_instances += len(next(batched_datasets))  # type: ignore
         except StopIteration:
             raise ValueError("Trying to skip more instances than "
                              "the size of the dataset")

--- a/neuralmonkey/train.py
+++ b/neuralmonkey/train.py
@@ -40,6 +40,7 @@ def create_config() -> Configuration:
                         required=False, default=None)
     config.add_argument('val_preview_num_examples', int,
                         required=False, default=15)
+    config.add_argument('train_start_offset', int, required=False, default=0)
     config.add_argument('runners_batch_size', int,
                         required=False, default=None)
     config.add_argument('minimize', bool, required=False, default=False)
@@ -177,5 +178,6 @@ def main() -> None:
         val_preview_output_series=cfg.model.val_preview_output_series,
         val_preview_num_examples=cfg.model.val_preview_num_examples,
         postprocess=cfg.model.postprocess,
+        train_start_offset=cfg.model.train_start_offset,
         runners_batch_size=cfg.model.runners_batch_size,
         minimize_metric=cfg.model.minimize)

--- a/tests/bpe.ini
+++ b/tests/bpe.ini
@@ -17,6 +17,7 @@ val_preview_input_series=["source", "target", "target_bpe"]
 val_preview_output_series=["target_greedy"]
 logging_period=20
 validation_period=60
+train_start_offset=500
 runners_batch_size=5
 test_datasets=[<val_data>,<val_data_no_target>]
 


### PR DESCRIPTION
Add this to your `[main]`:
``` ini
train_start_offset=3044032
```
... and the training begins from the batch after the one that contained the 3044042-th training instance.

Works with lazy datasets only. In-memory datasets are shuffled each epoch which makes the use of this feature pointless.

Ideal feature for continuing experiments with very large datasets, hope @tomkocmi will like it.. :metal: