### PR TITLE
Initial variables

### DIFF
--- a/neuralmonkey/learning_utils.py
+++ b/neuralmonkey/learning_utils.py
@@ -43,6 +43,7 @@ def training_loop(tf_manager: TensorFlowManager,
                   val_preview_output_series: Optional[List[str]]=None,
                   val_preview_num_examples: int=15,
                   runners_batch_size: Optional[int]=None,
+                  initial_variables: Optional[Union[str, List[str]]]=None,
                   postprocess: Postprocess=None,
                   minimize_metric: bool=False):
 
@@ -106,8 +107,13 @@ def training_loop(tf_manager: TensorFlowManager,
         saved_scores = [-np.inf for _ in range(save_n_best_vars)]
         best_score = -np.inf
 
-    tf_manager.initialize_model_parts(runners + [trainer])  # type: ignore
-    tf_manager.save(variables_files[0])
+    if initial_variables is None:
+        # Assume we don't look at coder checkpoints when global
+        # initial variables are supplied
+        tf_manager.initialize_model_parts(runners + [trainer])  # type: ignore
+        tf_manager.save(variables_files[0])
+    else:
+        tf_manager.restore(initial_variables)
 
     if os.path.islink(link_best_vars):
         # if overwriting output dir

--- a/neuralmonkey/train.py
+++ b/neuralmonkey/train.py
@@ -6,6 +6,7 @@ This is a training script for sequence to sequence learning.
 import sys
 import random
 import os
+from typing import List, Union
 from shutil import copyfile
 import numpy as np
 import tensorflow as tf
@@ -46,7 +47,8 @@ def create_config() -> Configuration:
     config.add_argument('postprocess')
     config.add_argument('name', str)
     config.add_argument('random_seed', int, required=False)
-    config.add_argument('initial_variables', str, required=False, default=[])
+    config.add_argument('initial_variables', Union[List[str], str],
+                        required=False, default=None)
     config.add_argument('overwrite_output_dir', bool, required=False,
                         default=False)
 
@@ -178,4 +180,5 @@ def main() -> None:
         val_preview_num_examples=cfg.model.val_preview_num_examples,
         postprocess=cfg.model.postprocess,
         runners_batch_size=cfg.model.runners_batch_size,
+        initial_variables=cfg.model.initial_variables,
         minimize_metric=cfg.model.minimize)


### PR DESCRIPTION
This PR reintroduces entering `initial_variables` to the `[main]` configuration. The value of the initial variables config can be either a string (then it's regarded a file name) or a list of strings (list of filenames; should match with the number of sessions), so hopefully ensembles will work.

As soon as this is merged, I will create a release.