### PR TITLE
Pack list of NumPy arrays into one NumPy array in execution result

### DIFF
--- a/neuralmonkey/runners/base_runner.py
+++ b/neuralmonkey/runners/base_runner.py
@@ -62,6 +62,8 @@ def reduce_execution_results(
         for i, loss in enumerate(result.losses):
             losses_sum[i] += loss
         # TODO aggregate TensorBoard summaries
+    if len(outputs) > 0 and isinstance(outputs[0], np.ndarray):
+        outputs = np.array(outputs)
     losses = [l / max(len(outputs), 1) for l in losses_sum]
     return ExecutionResult(outputs, losses,
                            execution_results[0].scalar_summaries,


### PR DESCRIPTION
This is to make sure that the output passes the check `isinstance(data, np.ndarray)` in [`learning_utils.py`](https://github.com/ufal/neuralmonkey/blob/67f858f1fd7cec3ab9d6e30103efca0bb62d4324/neuralmonkey/learning_utils.py#L341).