### PR TITLE
Warnings

### DIFF
--- a/neuralmonkey/checking.py
+++ b/neuralmonkey/checking.py
@@ -4,13 +4,12 @@ This module servers as a library of API checks used as assertions during
 constructing the computational graph.
 """
 
-# tests: lint, mypy
 
 from typing import List, Optional
 
 import tensorflow as tf
 
-from neuralmonkey.logging import log, debug
+from neuralmonkey.logging import log, debug, warning
 
 
 class CheckingException(Exception):
@@ -28,8 +27,8 @@ def check_dataset_and_coders(dataset, runners):
             elif hasattr(c, "data_ids"):
                 data_list.extend([(d, c) for d in c.data_ids])
             else:
-                log(("Warning: Coder: {} does not have"
-                     "a data attribute").format(c))
+                warning(("Coder: {} does not have"
+                         "a data attribute").format(c))
 
     debug("Found series: {}".format(str(data_list)), "checking")
     missing = []

--- a/neuralmonkey/checking.py
+++ b/neuralmonkey/checking.py
@@ -9,7 +9,7 @@ from typing import List, Optional
 
 import tensorflow as tf
 
-from neuralmonkey.logging import log, debug, warning
+from neuralmonkey.logging import log, debug, warn
 
 
 class CheckingException(Exception):
@@ -27,8 +27,8 @@ def check_dataset_and_coders(dataset, runners):
             elif hasattr(c, "data_ids"):
                 data_list.extend([(d, c) for d in c.data_ids])
             else:
-                warning(("Coder: {} does not have"
-                         "a data attribute").format(c))
+                warn(("Coder: {} does not have"
+                      "a data attribute").format(c))
 
     debug("Found series: {}".format(str(data_list)), "checking")
     missing = []

--- a/neuralmonkey/config/utils.py
+++ b/neuralmonkey/config/utils.py
@@ -6,17 +6,17 @@ directly would be inconvinent or impossible.
 import tensorflow as tf
 
 
-from neuralmonkey.logging import warning
+from neuralmonkey.logging import warn
 import neuralmonkey.vocabulary as vocabulary
 import neuralmonkey.dataset as dataset
 
 
 def deprecated(func):
     def dep_func(*args, **kwargs):
-        warning("Use of deprecated function from "
-                + "'neuralmonkey.config.utils'. " +
-                "Use '{}' instead.".format(func.__module__[13:]
-                                           + '.' + func.__name__))
+        warn("Use of deprecated function from "
+             + "'neuralmonkey.config.utils'. " +
+             "Use '{}' instead.".format(func.__module__[13:]
+                                        + '.' + func.__name__))
         return func(*args, **kwargs)
     return dep_func
 

--- a/neuralmonkey/config/utils.py
+++ b/neuralmonkey/config/utils.py
@@ -6,18 +6,17 @@ directly would be inconvinent or impossible.
 import tensorflow as tf
 
 
-from neuralmonkey.logging import log
+from neuralmonkey.logging import warning
 import neuralmonkey.vocabulary as vocabulary
 import neuralmonkey.dataset as dataset
 
 
 def deprecated(func):
     def dep_func(*args, **kwargs):
-        log("Warning! Use of deprecated function from "
-            + "'neuralmonkey.config.utils'. " +
-            "Use '{}' instead.".format(func.__module__[13:]
-                                       + '.' + func.__name__),
-            color='red')
+        warning("Use of deprecated function from "
+                + "'neuralmonkey.config.utils'. " +
+                "Use '{}' instead.".format(func.__module__[13:]
+                                           + '.' + func.__name__))
         return func(*args, **kwargs)
     return dep_func
 

--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -8,7 +8,7 @@ from typeguard import check_argument_types
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.vocabulary import Vocabulary, START_TOKEN
 from neuralmonkey.model.model_part import ModelPart, FeedDict
-from neuralmonkey.logging import log
+from neuralmonkey.logging import log, warning
 from neuralmonkey.nn.utils import dropout
 from neuralmonkey.encoders.attentive import Attentive
 from neuralmonkey.nn.projection import linear
@@ -100,9 +100,8 @@ class Decoder(ModelPart):
 
         if self.embeddings_encoder is not None:
             if self.embedding_size is not None:
-                log("Warning: Overriding the embedding_size parameter with the"
-                    " size of the reused embeddings from the encoder.",
-                    color="red")
+                warning("Overriding the embedding_size parameter with the"
+                        " size of the reused embeddings from the encoder.")
 
             self.embedding_size = (
                 self.embeddings_encoder.embedding_matrix.get_shape()[1].value)

--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -8,7 +8,7 @@ from typeguard import check_argument_types
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.vocabulary import Vocabulary, START_TOKEN
 from neuralmonkey.model.model_part import ModelPart, FeedDict
-from neuralmonkey.logging import log, warning
+from neuralmonkey.logging import log, warn
 from neuralmonkey.nn.utils import dropout
 from neuralmonkey.encoders.attentive import Attentive
 from neuralmonkey.nn.projection import linear
@@ -100,8 +100,8 @@ class Decoder(ModelPart):
 
         if self.embeddings_encoder is not None:
             if self.embedding_size is not None:
-                warning("Overriding the embedding_size parameter with the"
-                        " size of the reused embeddings from the encoder.")
+                warn("Overriding the embedding_size parameter with the"
+                     " size of the reused embeddings from the encoder.")
 
             self.embedding_size = (
                 self.embeddings_encoder.embedding_matrix.get_shape()[1].value)

--- a/neuralmonkey/decoders/encoder_projection.py
+++ b/neuralmonkey/decoders/encoder_projection.py
@@ -2,14 +2,15 @@
 This module contains different variants of projection of encoders into the
 initial state of the decoder.
 """
-# tests: lint
+
+
 from typing import List, Optional, Callable, Any
 
 import tensorflow as tf
 
 from neuralmonkey.nn.utils import dropout
 from neuralmonkey.nn.projection import linear
-from neuralmonkey.logging import log
+from neuralmonkey.logging import log, warning
 
 
 # pylint: disable=unused-argument
@@ -86,8 +87,8 @@ def concat_encoder_projection(
                          "of encoder projection")
 
     if rnn_size is not None:
-        log("Warning: The rnn_size argument is ignored in this type of "
-            "encoder projection", color="red")
+        warning("The rnn_size argument is ignored in this type of "
+                "encoder projection")
 
     encoded_concat = tf.concat(1, [e.encoded for e in encoders])
 

--- a/neuralmonkey/decoders/encoder_projection.py
+++ b/neuralmonkey/decoders/encoder_projection.py
@@ -10,7 +10,7 @@ import tensorflow as tf
 
 from neuralmonkey.nn.utils import dropout
 from neuralmonkey.nn.projection import linear
-from neuralmonkey.logging import log, warning
+from neuralmonkey.logging import log, warn
 
 
 # pylint: disable=unused-argument
@@ -87,8 +87,8 @@ def concat_encoder_projection(
                          "of encoder projection")
 
     if rnn_size is not None:
-        warning("The rnn_size argument is ignored in this type of "
-                "encoder projection")
+        warn("The rnn_size argument is ignored in this type of "
+             "encoder projection")
 
     encoded_concat = tf.concat(1, [e.encoded for e in encoders])
 

--- a/neuralmonkey/decoders/word_alignment_decoder.py
+++ b/neuralmonkey/decoders/word_alignment_decoder.py
@@ -4,10 +4,8 @@ import tensorflow as tf
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.encoders.sentence_encoder import SentenceEncoder
 from neuralmonkey.decoders.decoder import Decoder
-from neuralmonkey.logging import log
+from neuralmonkey.logging import warning
 from neuralmonkey.model.model_part import ModelPart, FeedDict
-
-# tests: mypy
 
 
 class WordAlignmentDecoder(ModelPart):
@@ -73,7 +71,7 @@ class WordAlignmentDecoder(ModelPart):
         alignment = dataset.get_series(self.data_id, allow_none=True)
         if alignment is None:
             if train:
-                log("Warning: training alignment not present", color="red")
+                warning("Training alignment not present!")
 
             alignment = np.zeros((len(dataset),
                                   self.decoder.max_output_len,

--- a/neuralmonkey/decoders/word_alignment_decoder.py
+++ b/neuralmonkey/decoders/word_alignment_decoder.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.encoders.sentence_encoder import SentenceEncoder
 from neuralmonkey.decoders.decoder import Decoder
-from neuralmonkey.logging import warning
+from neuralmonkey.logging import warn
 from neuralmonkey.model.model_part import ModelPart, FeedDict
 
 
@@ -71,7 +71,7 @@ class WordAlignmentDecoder(ModelPart):
         alignment = dataset.get_series(self.data_id, allow_none=True)
         if alignment is None:
             if train:
-                warning("Training alignment not present!")
+                warn("Training alignment not present!")
 
             alignment = np.zeros((len(dataset),
                                   self.decoder.max_output_len,

--- a/neuralmonkey/learning_utils.py
+++ b/neuralmonkey/learning_utils.py
@@ -7,7 +7,7 @@ import numpy as np
 import tensorflow as tf
 from termcolor import colored
 
-from neuralmonkey.logging import log, log_print, warning
+from neuralmonkey.logging import log, log_print, warn
 from neuralmonkey.dataset import Dataset, LazyDataset
 from neuralmonkey.tf_manager import TensorFlowManager
 from neuralmonkey.runners.base_runner import BaseRunner, ExecutionResult
@@ -140,8 +140,8 @@ def training_loop(tf_manager: TensorFlowManager,
 
             if epoch_n == 1 and train_start_offset:
                 if not isinstance(train_dataset, LazyDataset):
-                    warning("Not skipping training instances with "
-                            "shuffled in-memory dataset")
+                    warn("Not skipping training instances with "
+                         "shuffled in-memory dataset")
                 else:
                     _skip_lines(train_start_offset, train_batched_datasets)
 
@@ -505,13 +505,13 @@ def _print_examples(dataset: Dataset,
                                if s in val_preview_output_series]
 
     if not target_series_names:
-        warning("No reference series to preview during validation")
+        warn("No reference series to preview during validation")
 
     if not source_series_names:
-        warning("No source series to preview during validation")
+        warn("No source series to preview during validation")
 
     if not output_series_names:
-        warning("No output series to preview during validation")
+        warn("No output series to preview during validation")
 
     # for further indexing we need to make sure, all relevant
     # dataset series are lists

--- a/neuralmonkey/learning_utils.py
+++ b/neuralmonkey/learning_utils.py
@@ -1,4 +1,3 @@
-# tests: lint, mypy
 # pylint: disable=too-many-lines
 # There are too many lines because of these pylint directives.
 
@@ -8,7 +7,7 @@ import numpy as np
 import tensorflow as tf
 from termcolor import colored
 
-from neuralmonkey.logging import log, log_print
+from neuralmonkey.logging import log, log_print, warning
 from neuralmonkey.dataset import Dataset, LazyDataset
 from neuralmonkey.tf_manager import TensorFlowManager
 from neuralmonkey.runners.base_runner import BaseRunner, ExecutionResult
@@ -141,8 +140,8 @@ def training_loop(tf_manager: TensorFlowManager,
 
             if epoch_n == 1 and train_start_offset:
                 if not isinstance(train_dataset, LazyDataset):
-                    log("Warning: Not skipping training instances with "
-                        "shuffled in-memory dataset", color="red")
+                    warning("Not skipping training instances with "
+                            "shuffled in-memory dataset")
                 else:
                     _skip_lines(train_start_offset, train_batched_datasets)
 
@@ -506,16 +505,13 @@ def _print_examples(dataset: Dataset,
                                if s in val_preview_output_series]
 
     if not target_series_names:
-        log("Warning! No reference series to preview during validation",
-            color="red")
+        warning("No reference series to preview during validation")
 
     if not source_series_names:
-        log("Warning! No source series to preview during validation",
-            color="red")
+        warning("No source series to preview during validation")
 
     if not output_series_names:
-        log("Warning! No output series to preview during validation",
-            color="red")
+        warning("No output series to preview during validation")
 
     # for further indexing we need to make sure, all relevant
     # dataset series are lists

--- a/neuralmonkey/logging.py
+++ b/neuralmonkey/logging.py
@@ -21,6 +21,10 @@ class Logging(object):
     strict_mode = os.environ.get("NEURALMONKEY_STRICT")  # type: str
 
     @staticmethod
+    def _get_time():
+        return time.strftime("%Y-%m-%d %H:%M:%S")
+
+    @staticmethod
     def set_log_file(path):
         """Sets up the file where the logging will be done."""
         Logging.log_file = codecs.open(path, 'w', 'utf-8', buffering=0)
@@ -42,13 +46,13 @@ class Logging(object):
     def log(message, color='yellow'):
         """Logs message with a colored timestamp."""
         log_print("{}: {}".format(colored(
-            time.strftime("%Y-%m-%d %H:%M:%S"), color), message))
+            Logging._get_time(), color), message))
 
     @staticmethod
     def warn(message):
         """Logs a warning."""
         log_print(colored("{}: Warning! {}".format(
-            time.strftime("%Y-%m-%d %H:%M:%S"), message), color='red'))
+            Logging._get_time(), message), color='red'))
         if Logging.strict_mode:
             raise Exception(
                 "Encountered a warning in strict mode: " + message)
@@ -61,7 +65,7 @@ class Logging(object):
         log_print(colored("".join("=" for _ in range(80)), 'green'))
         log_print(colored(title.upper(), 'green'))
         log_print(colored("".join("=" for _ in range(80)), 'green'))
-        log_print("Launched at {}".format(time.strftime("%Y-%m-%d %H:%M:%S")))
+        log_print("Launched at {}".format(Logging._get_time()))
 
         log_print("")
 

--- a/neuralmonkey/logging.py
+++ b/neuralmonkey/logging.py
@@ -20,6 +20,8 @@ class Logging(object):
         os.environ.get("NEURALMONKEY_DEBUG_ENABLE", "none")]  # type: List[str]
     debug_disabled = [
         os.environ.get("NEURALMONKEY_DEBUG_DISABLE", "")]  # type: List[str]
+    strict_mode = [
+        os.environ.get("NEURALMONKEY_STRICT")]  # type: List[str]
 
     @staticmethod
     def set_log_file(path):
@@ -48,6 +50,9 @@ class Logging(object):
     @staticmethod
     def warning(message):
         """Logs a warning."""
+        if Logging.strict_mode != [None]:
+            raise Exception(
+                "Encountered a warning in strict mode: " + message)
         log_print(colored("{}: Warning! {}".format(
             time.strftime("%Y-%m-%d %H:%M:%S"), message), color='red'))
 

--- a/neuralmonkey/logging.py
+++ b/neuralmonkey/logging.py
@@ -46,6 +46,12 @@ class Logging(object):
             time.strftime("%Y-%m-%d %H:%M:%S"), color), message))
 
     @staticmethod
+    def warning(message):
+        """Logs a warning."""
+        log_print(colored("{}: Warning! {}".format(
+            time.strftime("%Y-%m-%d %H:%M:%S"), message), color='red'))
+
+    @staticmethod
     def print_header(title):
         """Prints the title of the experiment and
         the set of arguments it uses.
@@ -82,3 +88,4 @@ class Logging(object):
 log = Logging.log
 log_print = Logging.log_print
 debug = Logging.debug
+warning = Logging.warning

--- a/neuralmonkey/logging.py
+++ b/neuralmonkey/logging.py
@@ -1,5 +1,3 @@
-# tests: lint, mypy
-
 import time
 import codecs
 import sys
@@ -20,8 +18,7 @@ class Logging(object):
         os.environ.get("NEURALMONKEY_DEBUG_ENABLE", "none")]  # type: List[str]
     debug_disabled = [
         os.environ.get("NEURALMONKEY_DEBUG_DISABLE", "")]  # type: List[str]
-    strict_mode = [
-        os.environ.get("NEURALMONKEY_STRICT")]  # type: List[str]
+    strict_mode = os.environ.get("NEURALMONKEY_STRICT")  # type: str
 
     @staticmethod
     def set_log_file(path):
@@ -48,13 +45,13 @@ class Logging(object):
             time.strftime("%Y-%m-%d %H:%M:%S"), color), message))
 
     @staticmethod
-    def warning(message):
+    def warn(message):
         """Logs a warning."""
-        if Logging.strict_mode != [None]:
-            raise Exception(
-                "Encountered a warning in strict mode: " + message)
         log_print(colored("{}: Warning! {}".format(
             time.strftime("%Y-%m-%d %H:%M:%S"), message), color='red'))
+        if Logging.strict_mode:
+            raise Exception(
+                "Encountered a warning in strict mode: " + message)
 
     @staticmethod
     def print_header(title):
@@ -93,4 +90,4 @@ class Logging(object):
 log = Logging.log
 log_print = Logging.log_print
 debug = Logging.debug
-warning = Logging.warning
+warn = Logging.warn

--- a/neuralmonkey/vocabulary.py
+++ b/neuralmonkey/vocabulary.py
@@ -12,7 +12,7 @@ from typing import List, Tuple
 import numpy as np
 from typeguard import check_argument_types
 
-from neuralmonkey.logging import log
+from neuralmonkey.logging import log, warning
 from neuralmonkey.dataset import Dataset, LazyDataset
 
 PAD_TOKEN = "<pad>"
@@ -91,7 +91,7 @@ def from_dataset(datasets: List[Dataset], series_ids: List[str], max_size: int,
 
     for dataset in datasets:
         if isinstance(dataset, LazyDataset):
-            log("Warning: inferring vocabulary from lazy dataset", color="red")
+            warning("Inferring vocabulary from lazy dataset!")
 
         for series_id in series_ids:
             series = dataset.get_series(series_id, allow_none=True)
@@ -181,8 +181,8 @@ def initialize_vocabulary(directory: str, name: str,
     Returns:
         The new vocabulary
     """
-    log("Warning! Use of deprecated initialize_vocabulary method. "
-        "Did you think this through?", color="red")
+    warning("Use of deprecated initialize_vocabulary method. "
+            "Did you think this through?")
 
     file_name = os.path.join(directory, name + ".pickle")
     if os.path.exists(file_name):

--- a/neuralmonkey/vocabulary.py
+++ b/neuralmonkey/vocabulary.py
@@ -12,7 +12,7 @@ from typing import List, Tuple
 import numpy as np
 from typeguard import check_argument_types
 
-from neuralmonkey.logging import log, warning
+from neuralmonkey.logging import log, warn
 from neuralmonkey.dataset import Dataset, LazyDataset
 
 PAD_TOKEN = "<pad>"
@@ -91,7 +91,7 @@ def from_dataset(datasets: List[Dataset], series_ids: List[str], max_size: int,
 
     for dataset in datasets:
         if isinstance(dataset, LazyDataset):
-            warning("Inferring vocabulary from lazy dataset!")
+            warn("Inferring vocabulary from lazy dataset!")
 
         for series_id in series_ids:
             series = dataset.get_series(series_id, allow_none=True)
@@ -181,8 +181,8 @@ def initialize_vocabulary(directory: str, name: str,
     Returns:
         The new vocabulary
     """
-    warning("Use of deprecated initialize_vocabulary method. "
-            "Did you think this through?")
+    warn("Use of deprecated initialize_vocabulary method. "
+         "Did you think this through?")
 
     file_name = os.path.join(directory, name + ".pickle")
     if os.path.exists(file_name):


### PR DESCRIPTION
This PR introduces `Logging.warning(message)` and environmental variable `NEURALMONKEY_STRICT` that turns warnings into errors.

I think we should enable strict mode in tests, because making sure that the correct configuration works is far more important than making sure that an incorrect one does. With strict tests, we make sure that a change somewhere doesn't trigger a warning somewhere else. As for “coverage”, if something that emitted a warning fails to work, we can always say "well, we told you this is probably not what you wanted to do”. 

