### PR TITLE
Beam search with ensembles

### DIFF
--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -162,12 +162,13 @@ class Decoder(ModelPart):
                         for e in self.encoders
                         if isinstance(e, Attentive)}
 
-            train_rnn_outputs, _ = self._attention_decoder(
-                embedded_go_symbols,
-                attention_on_input=attention_on_input,
-                conditional_gru=conditional_gru,
-                train_inputs=embedded_train_inputs,
-                train_mode=True)
+            (train_rnn_outputs,
+             self.train_rnn_states) = self._attention_decoder(
+                 embedded_go_symbols,
+                 attention_on_input=attention_on_input,
+                 conditional_gru=conditional_gru,
+                 train_inputs=embedded_train_inputs,
+                 train_mode=True)
 
             assert not tf.get_variable_scope().reuse
             tf.get_variable_scope().reuse_variables()

--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -231,6 +231,13 @@ class Decoder(ModelPart):
 
             log("Decoder initalized.")
 
+    @property
+    def input_tensors(self) -> List[tf.Tensor]:
+        """Get list of tensor decoder needs to start decoding."""
+        return [self.initial_state] + [
+            a.attention_states for a in
+            self._train_attention_objects.values()]
+
     def _create_input_placeholders(self) -> None:
         """Creates input placeholder nodes in the computation graph"""
         self.train_mode = tf.placeholder(tf.bool, name="decoder_train_mode")

--- a/neuralmonkey/learning_utils.py
+++ b/neuralmonkey/learning_utils.py
@@ -290,7 +290,7 @@ def run_on_dataset(tf_manager: TensorFlowManager,
                     np.save(path, data)
                     log('Result saved as numpy array to "{}"'.format(path))
                 else:
-                    with open(path, 'w') as f_out:
+                    with open(path, 'w', encoding='utf-8') as f_out:
                         f_out.writelines(
                             [" ".join(sent) + "\n" for sent in data])
                     log("Result saved as plain text \"{}\"".format(path))

--- a/neuralmonkey/runners/base_runner.py
+++ b/neuralmonkey/runners/base_runner.py
@@ -5,7 +5,9 @@ import tensorflow as tf
 
 # pylint: disable=invalid-name
 FeedDict = Dict[tf.Tensor, Union[int, float, np.ndarray]]
-NextExecute = Tuple[List[Any], Union[Dict, List], FeedDict]
+NextExecute = Tuple[List[Any],
+                    Union[Dict, List],
+                    Union[FeedDict, List[FeedDict]]]
 ExecutionResult = NamedTuple('ExecutionResult',
                              [('outputs', List[Any]),
                               ('losses', List[float]),

--- a/neuralmonkey/runners/rnn_runner.py
+++ b/neuralmonkey/runners/rnn_runner.py
@@ -10,11 +10,14 @@ separately which allows ensembling from all sessions and do the beam pruning
 before the a next output is emmited.
 """
 
-
+from functools import partial
 from typing import Dict, List, Callable, NamedTuple, Tuple
+import multiprocessing
+
 import numpy as np
 import tensorflow as tf
 
+from neuralmonkey.logging import debug
 from neuralmonkey.runners.base_runner import (BaseRunner, Executable,
                                               ExecutionResult, NextExecute)
 from neuralmonkey.vocabulary import END_TOKEN_INDEX
@@ -28,24 +31,78 @@ ExpandedBeamBatch = NamedTuple('ExpandedBeamBatch',
                                [('beam_batch', BeamBatch),
                                 ('next_logprobs', np.ndarray)])
 ScoringFunction = Callable[[np.ndarray, np.ndarray], np.ndarray]
+# pylint: enable=invalid-name
 
 # pylint: disable=too-many-locals
 
 
-def _n_best_indices(scores: np.ndarray, n: int) -> np.ndarray:
-    if scores.shape[0] <= n:
+def _n_best_indices(scores: np.ndarray, beam_size: int) -> np.ndarray:
+    if scores.shape[0] <= beam_size:
         unsorted_n_best_indices = np.arange(scores.shape[0])
     else:
-        unsorted_n_best_indices = np.argpartition(-scores, n)[:n]
+        unsorted_n_best_indices = np.argpartition(
+            -scores, beam_size)[:beam_size]
     n_best_indices = unsorted_n_best_indices[
         np.argsort(scores[unsorted_n_best_indices])]
     return n_best_indices
 
 
-def _score_expanded(n: int,
+def _score_one_seq_expansion(
+        seq_id: int,
+        beam_size: int,
+        expanded: List[ExpandedBeamBatch],
+        scoring_function: ScoringFunction) -> Tuple[np.ndarray, np.ndarray]:
+    candidate_scores = None
+    candidate_hypotheses = None
+    candidate_logprobs = None
+
+    for expanded_batch in expanded:
+        next_distribution = expanded_batch.next_logprobs[seq_id]
+        if expanded_batch.beam_batch is None:
+            expanded_hypotheses = np.expand_dims(np.arange(
+                len(next_distribution)), axis=1)
+            expanded_logprobs = np.expand_dims(next_distribution, 1)
+        else:
+            hypothesis = expanded_batch.beam_batch.decoded[seq_id]
+            prev_logprobs = expanded_batch.beam_batch.logprobs[seq_id]
+
+            promissing_candidates = np.argpartition(
+                -next_distribution, 2 * beam_size)[:2 * beam_size]
+
+            expanded_hypotheses = np.array(
+                [np.append(hypothesis, index)
+                 for index in promissing_candidates])
+            expanded_logprobs = np.array(
+                [np.append(prev_logprobs, next_distribution[index])
+                 for index in promissing_candidates])
+
+        assert expanded_hypotheses.shape == expanded_logprobs.shape
+        scores = scoring_function(expanded_hypotheses, expanded_logprobs)
+        assert scores.shape[0] == expanded_hypotheses.shape[0]
+        n_best_indices = _n_best_indices(scores, beam_size)
+        candidate_scores = _try_append(
+            candidate_scores, scores[n_best_indices])
+        candidate_hypotheses = _try_append(
+            candidate_hypotheses, expanded_hypotheses[n_best_indices])
+        candidate_logprobs = _try_append(
+            candidate_logprobs, expanded_logprobs[n_best_indices])
+        assert len(candidate_hypotheses.shape) == 2
+
+    n_best_indices = _n_best_indices(candidate_scores, beam_size)
+    n_best_hypotheses = candidate_hypotheses[n_best_indices]
+    n_best_logprobs = candidate_logprobs[n_best_indices]
+
+    assert len(n_best_hypotheses.shape) == 2
+    assert n_best_hypotheses.shape == n_best_logprobs.shape
+
+    return n_best_hypotheses, n_best_logprobs
+
+
+def _score_expanded(beam_size: int,
                     batch_size: int,
                     expanded: List[ExpandedBeamBatch],
-                    scoring_function: ScoringFunction) -> \
+                    scoring_function: ScoringFunction,
+                    cpu_threads: int) -> \
         Tuple[List[np.ndarray], List[np.ndarray]]:
     """Score expanded beams.
 
@@ -55,7 +112,7 @@ def _score_expanded(n: int,
     keep only `n` with the highest scores.
 
     Args:
-        n: Number of best hypotheses.
+        beam_size: Number of best hypotheses.
         batch_size: Number hypothese in the batch.
         expanded: List of expanded hypotheses from the previous beam, organized
             into batches.
@@ -65,51 +122,20 @@ def _score_expanded(n: int,
     Returns:
         Hypotheses indices and logprobs for the next decoding step.
     """
+
     next_beam_hypotheses = []
     next_beam_logprobs = []
     # agregate the expanded hypotheses hypothesis-wise
-    for rank in range(batch_size):
-        candidate_scores = None
-        candidate_hypotheses = None
-        candidate_logprobs = None
+    with multiprocessing.Pool(cpu_threads) as pool:
+        score_with_args = partial(
+            _score_one_seq_expansion,
+            beam_size=beam_size,
+            expanded=expanded,
+            scoring_function=scoring_function)
+        hyps_and_logprobs = pool.map(score_with_args, range(batch_size))
 
-        for expanded_batch in expanded:
-            next_distribution = expanded_batch.next_logprobs[rank]
-            if expanded_batch.beam_batch is None:
-                expanded_hypotheses = np.expand_dims(np.arange(
-                    len(next_distribution)), axis=1)
-                expanded_logprobs = np.expand_dims(next_distribution, 1)
-            else:
-                hypothesis = expanded_batch.beam_batch.decoded[rank]
-                prev_logprobs = expanded_batch.beam_batch.logprobs[rank]
-
-                expanded_hypotheses = np.array(
-                    [np.append(hypothesis, index)
-                     for index, _ in enumerate(next_distribution)])
-                expanded_logprobs = np.array(
-                    [np.append(prev_logprobs, logprob)
-                     for logprob in next_distribution])
-
-            assert expanded_hypotheses.shape == expanded_logprobs.shape
-            scores = scoring_function(expanded_hypotheses, expanded_logprobs)
-            assert scores.shape[0] == expanded_hypotheses.shape[0]
-            n_best_indices = _n_best_indices(scores, n)
-            candidate_scores = _try_append(
-                candidate_scores, scores[n_best_indices])
-            candidate_hypotheses = _try_append(
-                candidate_hypotheses, expanded_hypotheses[n_best_indices])
-            candidate_logprobs = _try_append(
-                candidate_logprobs, expanded_logprobs[n_best_indices])
-            assert len(candidate_hypotheses.shape) == 2
-
-        n_best_indices = _n_best_indices(candidate_scores, n)
-        n_best_hypotheses = candidate_hypotheses[n_best_indices]
-        n_best_logprobs = candidate_logprobs[n_best_indices]
-
-        assert len(n_best_hypotheses.shape) == 2
-        assert n_best_hypotheses.shape == n_best_logprobs.shape
-        next_beam_hypotheses.append(n_best_hypotheses)
-        next_beam_logprobs.append(n_best_logprobs)
+    (next_beam_hypotheses,
+     next_beam_logprobs) = map(list, zip(*hyps_and_logprobs))
     return next_beam_hypotheses, next_beam_logprobs
 
 
@@ -137,22 +163,24 @@ def likelihood_beam_score(decoded, logprobs):
     # pylint: disable=no-member
     avg_logprobs = masked_logprobs.sum(
         axis=1) - np.log(mask_matrix.sum(axis=1))
+    # pylint: enable=no-member
     return avg_logprobs
 
 
-def n_best(n: int,
+def n_best(beam_size: int,
            expanded: List[ExpandedBeamBatch],
-           scoring_function) -> List[BeamBatch]:
+           scoring_function: ScoringFunction,
+           cpu_threads: int) -> List[BeamBatch]:
     """Take n-best from expanded beam search hypotheses.
 
-    To do the scoring we need to "reshape" the hypohteses. Before the scoring
+    To do the scoring we need to "reshape" the hypotheses. Before the scoring
     the hypothesis are split into beam batches by their position in the beam.
     To do the scoring, however, they need to be organized by the instances.
-    After the scoring, only _n_ hypotheses is kept for each isntance. These
+    After the scoring, only _n_ hypotheses is kept for each instance. These
     are again split by their position in the beam.
 
     Args:
-        n: Beam size.
+        beam_size: Beam size.
         expanded: List of batched expanded hypotheses.
         scoring_function: A function
 
@@ -163,11 +191,12 @@ def n_best(n: int,
 
     batch_size = expanded[0].next_logprobs.shape[0]
     next_beam_hypotheses, next_beam_logprobs = _score_expanded(
-        n, batch_size, expanded, scoring_function)
+        beam_size, batch_size, expanded, scoring_function, cpu_threads)
+    debug("Scoring expanded hypotheses done.")
 
     # now cut the beams by hypotheses rank
     beam_batches = []
-    for rank in range(n):
+    for rank in range(beam_size):
         hypotheses = np.array([beam[rank] for beam in next_beam_hypotheses])
         logprobs = np.array([beam[rank] for beam in next_beam_logprobs])
         assert len(hypotheses.shape) == 2
@@ -182,8 +211,10 @@ class RuntimeRnnRunner(BaseRunner):
 
     def __init__(self,
                  output_series: str, decoder,
-                 beam_size: int=1, beam_scoring_f=likelihood_beam_score,
-                 postprocess: Callable[[List[str]], List[str]]=None) -> None:
+                 beam_size: int=1,
+                 beam_scoring_f=likelihood_beam_score,
+                 postprocess: Callable[[List[str]], List[str]]=None,
+                 cpu_threads: int=32) -> None:
         super(RuntimeRnnRunner, self).__init__(output_series, decoder)
 
         self._initial_fetches = [decoder.runtime_rnn_states[0]]
@@ -192,6 +223,7 @@ class RuntimeRnnRunner(BaseRunner):
         self._beam_size = beam_size
         self._beam_scoring_f = beam_scoring_f
         self._postprocess = postprocess
+        self._cpu_threads = cpu_threads
 
     def get_executable(self, compute_losses=False, summaries=True):
 
@@ -201,7 +233,8 @@ class RuntimeRnnRunner(BaseRunner):
                                     beam_size=self._beam_size,
                                     beam_scoring_f=self._beam_scoring_f,
                                     compute_loss=compute_losses,
-                                    postprocess=self._postprocess)
+                                    postprocess=self._postprocess,
+                                    cpu_threads=self._cpu_threads)
 
     @property
     def loss_names(self) -> List[str]:
@@ -215,7 +248,7 @@ class RuntimeRnnExecutable(Executable):
     # pylint: disable=too-many-arguments
     def __init__(self, all_coders, decoder, initial_fetches, vocabulary,
                  beam_scoring_f, postprocess, beam_size=1,
-                 compute_loss=True):
+                 compute_loss=True, cpu_threads=32):
         self._all_coders = all_coders
         self._decoder = decoder
         self._vocabulary = vocabulary
@@ -224,8 +257,9 @@ class RuntimeRnnExecutable(Executable):
         self._beam_size = beam_size
         self._beam_scoring_f = beam_scoring_f
         self._postprocess = postprocess
+        self._cpu_threads = cpu_threads
 
-        self._to_exapand = [None]  # type: List[Option[BeamBatch]]
+        self._to_expand = [None]  # type: List[Option[BeamBatch]]
         self._current_beam_batch = None
         self._expanded = []  # type: List[ExpandedBeamBatch]
         self._time_step = 0
@@ -245,7 +279,7 @@ class RuntimeRnnExecutable(Executable):
 
         to_run = {'logprobs': self._decoder.train_logprobs[self._time_step]}
 
-        self._current_beam_batch = self._to_exapand.pop()
+        self._current_beam_batch = self._to_expand.pop()
 
         if self._current_beam_batch is not None:
             batch_size, output_len = self._current_beam_batch.decoded.shape
@@ -283,14 +317,17 @@ class RuntimeRnnExecutable(Executable):
                                            avg_logprobs)
         self._expanded.append(expanded_batch)
 
-        if not self._to_exapand:
+        if not self._to_expand:
             self._time_step += 1
-            self._to_exapand = n_best(
-                self._beam_size, self._expanded, self._beam_scoring_f)
+            debug("TensorFlow done, aggreagteing results")
+            self._to_expand = n_best(
+                self._beam_size, self._expanded,
+                self._beam_scoring_f, self._cpu_threads)
+            debug("escoring done")
             self._expanded = []
 
         if self._time_step == self._decoder.max_output_len:
-            top_batch = self._to_exapand[-1].decoded.T
+            top_batch = self._to_expand[-1].decoded.T
             decoded_tokens = self._vocabulary.vectors_to_sentences(top_batch)
 
             if self._postprocess is not None:

--- a/neuralmonkey/runners/rnn_runner.py
+++ b/neuralmonkey/runners/rnn_runner.py
@@ -42,13 +42,14 @@ ScoringFunction = Callable[[np.ndarray, np.ndarray], np.ndarray]
 
 
 def _n_best_indices(scores: np.ndarray, beam_size: int) -> np.ndarray:
+    """Indices of the n-best list based on provided scores."""
     if scores.shape[0] <= beam_size:
         unsorted_n_best_indices = np.arange(scores.shape[0])
     else:
         unsorted_n_best_indices = np.argpartition(
             -scores, beam_size)[:beam_size]
     n_best_indices = unsorted_n_best_indices[
-        np.argsort(scores[unsorted_n_best_indices])]
+        np.argsort(-scores[unsorted_n_best_indices])]
     return n_best_indices
 
 
@@ -175,8 +176,7 @@ def _try_append(first: Optional[np.ndarray],
 
 
 def likelihood_beam_score(decoded: np.ndarray, logprobs: np.ndarray) -> float:
-    """Score the beam by normalized probaility."""
-
+    """Score the beam by normalized probability."""
     mask = []
     for hypothesis in decoded:
         before_end = True  # type: bool
@@ -189,8 +189,7 @@ def likelihood_beam_score(decoded: np.ndarray, logprobs: np.ndarray) -> float:
     mask_matrix = np.array(mask)
     masked_logprobs = mask_matrix * logprobs
     # pylint: disable=no-member
-    avg_logprobs = masked_logprobs.sum(
-        axis=1) - np.log(mask_matrix.sum(axis=1))
+    avg_logprobs = masked_logprobs.sum(axis=1) / mask_matrix.sum(axis=1)
     # pylint: enable=no-member
     return avg_logprobs
 

--- a/neuralmonkey/runners/rnn_runner.py
+++ b/neuralmonkey/runners/rnn_runner.py
@@ -19,8 +19,12 @@ import tensorflow as tf
 from neuralmonkey.logging import debug
 from neuralmonkey.model.model_part import ModelPart
 from neuralmonkey.decoders.decoder import Decoder
+# pylint: disable=unused-import
+# used for type annotations
 from neuralmonkey.runners.base_runner import (BaseRunner, Executable,
+                                              FeedDict,
                                               ExecutionResult, NextExecute)
+# pylint: enable=unused-import
 from neuralmonkey.vocabulary import Vocabulary, END_TOKEN_INDEX
 
 
@@ -239,7 +243,7 @@ class RuntimeRnnRunner(BaseRunner):
                  beam_size: int=1,
                  beam_scoring_f=likelihood_beam_score,
                  postprocess: Callable[[List[str]], List[str]]=None,
-                 cpu_threads: int=32) -> None:
+                 cpu_threads: int=1) -> None:
         super(RuntimeRnnRunner, self).__init__(output_series, decoder)
 
         self._initial_fetches = [decoder.runtime_rnn_states[0]]
@@ -334,7 +338,7 @@ class RuntimeRnnExecutable(Executable):
                 additional_feed_dicts.append(fd)
         else:
             to_run['input_tensors'] = self._decoder.input_tensors
-            additional_feed_dicts = {}
+            additional_feed_dicts = {}  # type: ignore
         # pylint: enable=not-an-iterable,redefined-variable-type
 
         # at the end, we should compute loss

--- a/neuralmonkey/runners/rnn_runner.py
+++ b/neuralmonkey/runners/rnn_runner.py
@@ -25,7 +25,8 @@ from neuralmonkey.runners.base_runner import (BaseRunner, Executable,
                                               FeedDict,
                                               ExecutionResult, NextExecute)
 # pylint: enable=unused-import
-from neuralmonkey.vocabulary import Vocabulary, END_TOKEN_INDEX
+from neuralmonkey.vocabulary import (Vocabulary, END_TOKEN_INDEX,
+                                     PAD_TOKEN_INDEX)
 
 
 # pylint: disable=invalid-name
@@ -97,6 +98,10 @@ def _score_one_seq_expansion(
             expanded_hypotheses = np.expand_dims(first_step_best, axis=1)
             expanded_logprobs = np.expand_dims(
                 next_distribution[first_step_best], 1)
+        elif np.any(np.in1d(hypothesis, END_TOKEN_INDEX)):
+            expanded_hypotheses = np.array([np.append(hypothesis,
+                                                      PAD_TOKEN_INDEX)])
+            expanded_logprobs = np.array([np.append(prev_logprobs, 0)])
         else:
             promissing_count = 4 * beam_size
             if promissing_count < len(next_distribution):

--- a/neuralmonkey/runners/rnn_runner.py
+++ b/neuralmonkey/runners/rnn_runner.py
@@ -217,6 +217,7 @@ def likelihood_beam_score(decoded: np.ndarray, logprobs: np.ndarray) -> float:
         mask.append(hyp_mask)
 
     mask_matrix = np.array(mask)
+    assert mask_matrix.shape == logprobs.shape
     masked_logprobs = mask_matrix * logprobs
     # pylint: disable=no-member
     avg_logprobs = masked_logprobs.sum(axis=1) / mask_matrix.sum(axis=1)
@@ -440,7 +441,7 @@ class RuntimeRnnExecutable(Executable):
             self._expanded = []
 
         if self._time_step == self._decoder.max_output_len:
-            top_batch = self._to_expand[-1].decoded.T
+            top_batch = self._to_expand[0].decoded.T
             decoded_tokens = self._vocabulary.vectors_to_sentences(top_batch)
 
             if self._postprocess is not None:

--- a/neuralmonkey/tests/test_rnn_runner.py
+++ b/neuralmonkey/tests/test_rnn_runner.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3.5
+
+import unittest
+import numpy as np
+
+from neuralmonkey.runners.rnn_runner import (_n_best_indices,
+                                             _score_one_seq_expansion,
+                                             likelihood_beam_score)
+
+
+class TestRNNRunner(unittest.TestCase):
+    def test_n_best_indices(self):
+        input_small = np.arange(5)
+        res_small = _n_best_indices(input_small, 10)
+        self.assertTrue(np.all(res_small == [4, 3, 2, 1, 0]))
+        self.assertEqual(res_small.shape, (5,))
+
+        input_bigger = np.hstack((np.arange(100) / 1000, 1 + np.arange(3)))
+        res_bigger = _n_best_indices(input_bigger, 3)
+        self.assertTrue(np.all(res_bigger == [102, 101, 100]))
+        self.assertEqual(res_bigger.shape, (3,))
+
+        empty = _n_best_indices(np.array([]), 10)
+        self.assertEqual(empty.shape, (0,))
+
+    def test_score_one_seq_expansion(self):
+        r"""Test beam expansion scoring.
+                                         / 0 (-2) => score -2
+                  / 0 (-2) => score -2 <
+                 |                       \ 1 (-4) => score -2.7
+        0 (-2) -<
+                 |                       / 0 (-5) => score -3.7
+                  \ 1 (-4) => score -3 <
+                                         \ 1 (-7) => score -4.3
+
+                 / 0 (-5) => score -4 - not in 2nd beam
+        1 (-3) -<
+                 \ 1 (-7) => score -5 - not in 2nd beam
+
+        2 (-4) - not in the first beam
+        3 (-5) - not in the first beam
+        4 (-6) - not in the first beam
+        """
+
+        beam_size = 2
+        scoring_function = likelihood_beam_score
+
+        first_hyp_logprobs = np.array([[-2, -3, -4, -5, -6]])
+        hypotheses, hyp_logprobs = _score_one_seq_expansion(
+            first_hyp_logprobs, [None], [None], beam_size, scoring_function)
+
+        self.assertTrue(np.all(hypotheses == np.array([[0], [1]])))
+        self.assertTrue(np.all(hyp_logprobs == np.array([[-2], [-3]])))
+
+        next_distributions = np.array([[-2, -4],
+                                       [-5, -7]])
+
+        new_hyps, new_logprobs = _score_one_seq_expansion(
+            next_distributions, hypotheses, hyp_logprobs,
+            beam_size, scoring_function)
+
+        self.assertTrue(np.all(np.array([[0, 0], [0, 1]] == new_hyps)))
+        self.assertTrue(np.all(np.array([[-2, -2], [-2, -4]] == new_logprobs)))
+
+        last_hyps, last_logprobs = _score_one_seq_expansion(
+            next_distributions, new_hyps, new_logprobs,
+            beam_size, scoring_function)
+
+        self.assertTrue(np.all(np.array([[0, 0, 0], [0, 0, 1]] == last_hyps)))
+        self.assertTrue(
+            np.all(np.array([[-2, -2, -2], [-2, -2, -4]] == last_logprobs)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bpe.ini
+++ b/tests/bpe.ini
@@ -103,6 +103,7 @@ decoder=<decoder>
 output_series="target"
 postprocess=<bpe_postprocess>
 beam_size=3
+cpu_threads=2
 
 [runner_2]
 class=runners.runner.GreedyRunner


### PR DESCRIPTION
This PR is supposed to make beam search using `RuntimeRnnRunner` faster. The tricks are the following:

* the hypotheses are not expanded by the whole vocabulary but only by `4 * beam_size` hypotheses before the rescoring,
* the rescoring of expanded hypotheses on CPU is done in parallel (there is an `cpu_threads` argument in the runner that controls the number of used threads),
* TF manager was refactored and extended such it can handle additional feed_dicts for each of running sessions separately,
* the runner caches the decoder initial state and also its hidden states.

Unfortunately, caching the decoder's previous state does not seem to have any effect on the beam search speed, so there might a bug (which I hope you'll reveal during the review).