### PR TITLE
Strict tests

### DIFF
--- a/neuralmonkey/decoders/encoder_projection.py
+++ b/neuralmonkey/decoders/encoder_projection.py
@@ -10,7 +10,7 @@ import tensorflow as tf
 
 from neuralmonkey.nn.utils import dropout
 from neuralmonkey.nn.projection import linear
-from neuralmonkey.logging import log, warn
+from neuralmonkey.logging import log
 
 
 # pylint: disable=unused-argument
@@ -87,8 +87,8 @@ def concat_encoder_projection(
                          "of encoder projection")
 
     if rnn_size is not None:
-        warn("The rnn_size argument is ignored in this type of "
-             "encoder projection")
+        assert rnn_size == sum(e.encoded.get_shape()[1].value
+                               for e in encoders)
 
     encoded_concat = tf.concat(1, [e.encoded for e in encoders])
 

--- a/tests/small.ini
+++ b/tests/small.ini
@@ -47,12 +47,8 @@ s_target="tests/data/val.tc.de"
 preprocessors=[("source", "source_chars", processors.helpers.preprocess_char_based)]
 
 [encoder_vocabulary]
-class=vocabulary.from_dataset
-datasets=[<train_data>]
-series_ids=["source"]
-max_size=60
-save_file="tests/tmp-test-output/encoder_vocabulary.pickle"
-overwrite=True
+class=vocabulary.from_file
+path="tests/tmp-vocab/encoder_vocab.pkl"
 
 [encoder]
 class=encoders.sentence_encoder.SentenceEncoder
@@ -66,12 +62,8 @@ data_id="source"
 vocabulary=<encoder_vocabulary>
 
 [decoder_vocabulary]
-class=vocabulary.from_dataset
-datasets=[<train_data>]
-series_ids=["target"]
-max_size=70
-save_file="tests/tmp-test-output/decoder_vocabulary.pickle"
-overwrite=True
+class=vocabulary.from_file
+path="tests/tmp-vocab/decoder_vocab.pkl"
 
 [decoder]
 class=decoders.decoder.Decoder

--- a/tests/tests_run.sh
+++ b/tests/tests_run.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+export NEURALMONKEY_STRICT=1
+
 bin/neuralmonkey-train tests/vocab.ini
 bin/neuralmonkey-train tests/bahdanau.ini
 bin/neuralmonkey-train tests/bpe.ini

--- a/tests/vocab.ini
+++ b/tests/vocab.ini
@@ -1,7 +1,7 @@
 [main]
 name="translation"
 tf_manager=<tf_manager>
-output="tests/tmp-vocab-output"
+output="tests/tmp-vocab"
 overwrite_output_dir=True
 batch_size=16
 epochs=0
@@ -36,7 +36,9 @@ s_target="tests/data/val.tc.de"
 class=vocabulary.from_dataset
 datasets=[<train_data>]
 series_ids=["source"]
-max_size=25000
+max_size=60
+save_file="tests/tmp-vocab/encoder_vocab.pkl"
+overwrite=True
 
 [encoder]
 class=encoders.sentence_encoder.SentenceEncoder
@@ -53,7 +55,9 @@ vocabulary=<encoder_vocabulary>
 class=vocabulary.from_dataset
 datasets=[<train_data>]
 series_ids=["target"]
-max_size=25000
+max_size=70
+save_file="tests/tmp-vocab/decoder_vocab.pkl"
+overwrite=True
 
 [decoder]
 class=decoders.decoder.Decoder


### PR DESCRIPTION
This PR turns warnings into errors in tests.

Even if we decide not to use this, we should do something with the warning that it currently fails on. It's from `bpe.ini` and it says `The rnn_size argument is ignored in this type of projection.`. Apparently, it comes from the decoder. But there is no `rnn_size` for the decoder in the ini file. So it's not clear to me (as a user) what should I do to get rid of this warning.