### PR TITLE
Quick fix of factored encoder

### DIFF
--- a/neuralmonkey/encoders/factored_encoder.py
+++ b/neuralmonkey/encoders/factored_encoder.py
@@ -152,7 +152,8 @@ class FactoredEncoder(ModelPart, Attentive):
             # Create embeddings for this factor and embed the placeholders
             # NOTE the initialization
             embeddings = tf.get_variable(
-                "embeddings_{}".format(data_id), shape=[len(vocabulary), embedding_size],
+                "embeddings_{}".format(data_id), shape=[len(vocabulary),
+                                                        embedding_size],
                 initializer=tf.random_normal_initializer(stddev=0.01))
 
             embedded_inputs = [tf.nn.embedding_lookup(embeddings, i)

--- a/neuralmonkey/encoders/factored_encoder.py
+++ b/neuralmonkey/encoders/factored_encoder.py
@@ -9,8 +9,8 @@ from neuralmonkey.encoders.attentive import Attentive
 from neuralmonkey.logging import log
 from neuralmonkey.nn.bidirectional_rnn_layer import BidirectionalRNNLayer
 from neuralmonkey.nn.noisy_gru_cell import NoisyGRUCell
-from neuralmonkey.checking import assert_type
 from neuralmonkey.vocabulary import Vocabulary
+
 
 # tests: lint, mypy
 
@@ -28,8 +28,8 @@ class FactoredEncoder(ModelPart, Attentive):
                  data_ids: List[str],
                  embedding_sizes: List[int],
                  rnn_size: int,
-                 save_checkpoint: Optional[str]=None,
-                 load_checkpoint: Optional[str]=None,
+                 save_checkpoint: Optional[str] = None,
+                 load_checkpoint: Optional[str] = None,
                  **kwargs) -> None:
         """Construct a new instance of the factored encoder.
 
@@ -70,6 +70,7 @@ class FactoredEncoder(ModelPart, Attentive):
         with tf.variable_scope(self.name):
             self._create_encoder_graph()
             log("Encoder graph constructed.")
+
     # pylint: enable=too-many-arguments
 
     @property
@@ -110,8 +111,8 @@ class FactoredEncoder(ModelPart, Attentive):
         self.factor_inputs = {}
         factors = []
 
-        assert len(self.data_ids) == len(self.vocabularies) == \
-               len(self.embedding_sizes)
+        assert len(self.data_ids) == len(self.vocabularies) == len(
+            self.embedding_sizes)
 
         for data_id, vocabulary, embedding_size in zip(
                 self.data_ids, self.vocabularies, self.embedding_sizes):

--- a/neuralmonkey/encoders/factored_encoder.py
+++ b/neuralmonkey/encoders/factored_encoder.py
@@ -12,11 +12,7 @@ from neuralmonkey.nn.noisy_gru_cell import NoisyGRUCell
 from neuralmonkey.vocabulary import Vocabulary
 
 
-# tests: lint, mypy
-
 # pylint: disable=too-many-instance-attributes
-
-
 class FactoredEncoder(ModelPart, Attentive):
     """Generic encoder processing an arbitrary number of input sequences."""
 
@@ -28,8 +24,8 @@ class FactoredEncoder(ModelPart, Attentive):
                  data_ids: List[str],
                  embedding_sizes: List[int],
                  rnn_size: int,
-                 save_checkpoint: Optional[str] = None,
-                 load_checkpoint: Optional[str] = None,
+                 save_checkpoint: Optional[str]=None,
+                 load_checkpoint: Optional[str]=None,
                  **kwargs) -> None:
         """Construct a new instance of the factored encoder.
 
@@ -70,7 +66,6 @@ class FactoredEncoder(ModelPart, Attentive):
         with tf.variable_scope(self.name):
             self._create_encoder_graph()
             log("Encoder graph constructed.")
-
     # pylint: enable=too-many-arguments
 
     @property
@@ -179,15 +174,6 @@ class FactoredEncoder(ModelPart, Attentive):
         factors = {data_id: dataset.get_series(data_id)
                    for data_id in self.data_ids}
 
-        # this method should be responsible for checking if the factored
-        # sentences are of the same length
-
-        fd = {}
-        # we assume that all factors have equal word counts
-        # this is removed as res should only contain placeholders as keys
-        # res[self.sentence_lengths] = np.array(
-        #     [min(self.max_input_len, len(s)) +
-        #      2 for s in factors[self.data_ids[0]]])
         factor_vectors_and_weights = {
             data_id: vocabulary.sentences_to_tensor(factors[data_id],
                                                     self.max_input_len,
@@ -212,6 +198,7 @@ class FactoredEncoder(ModelPart, Attentive):
                     raise Exception("Sentence lengths are not the same for"
                                     "different factors.")
 
+        fd = {}
         for data_id in self.data_ids:
             inputs = self.factor_inputs[data_id]
             vectors, _ = factor_vectors_and_weights[data_id]

--- a/neuralmonkey/encoders/factored_encoder.py
+++ b/neuralmonkey/encoders/factored_encoder.py
@@ -58,8 +58,8 @@ class FactoredEncoder(ModelPart, Attentive):
             dropout_keep_prob: 1 - Dropout probability [1]
         """
         attention_type = kwargs.get("attention_type", None)
+        Attentive.__init__(self, attention_type)
         ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
-        Attentive.__init__(attention_type, **kwargs)
         for vocabulary in vocabularies:
             assert_type(self, 'vocabulary', vocabulary, Vocabulary)
 
@@ -128,7 +128,7 @@ class FactoredEncoder(ModelPart, Attentive):
 
         self.padding_weights = [
             tf.placeholder(tf.float32, shape=[None], name="input_{}".format(i))
-            for i in range(self.max_input_len + 2)]
+            for i in range(self.max_input_len + 1)]
 
         sentence_lengths = tf.to_int64(sum(self.padding_weights))
 
@@ -144,7 +144,7 @@ class FactoredEncoder(ModelPart, Attentive):
                 prefix = "{}_".format(data_id)
 
             names = ["{}input_{}".format(prefix, i)
-                     for i in range(self.max_input_len + 2)]
+                     for i in range(self.max_input_len + 1)]
 
             inputs = [tf.placeholder(tf.int32, shape=[None], name=n)
                       for n in names]
@@ -152,7 +152,7 @@ class FactoredEncoder(ModelPart, Attentive):
             # Create embeddings for this factor and embed the placeholders
             # NOTE the initialization
             embeddings = tf.get_variable(
-                "word_embeddings", shape=[len(vocabulary), embedding_size],
+                "embeddings_{}".format(data_id), shape=[len(vocabulary), embedding_size],
                 initializer=tf.random_normal_initializer(stddev=0.01))
 
             embedded_inputs = [tf.nn.embedding_lookup(embeddings, i)
@@ -163,7 +163,6 @@ class FactoredEncoder(ModelPart, Attentive):
                 for i in embedded_inputs]
 
             # Resulting shape is batch x embedding_size
-            assert_shape(dropped_embedded_inputs, [None, embedding_size])
             factors.append(dropped_embedded_inputs)
 
             # Add inputs and weights to self to be able to feed them
@@ -212,7 +211,9 @@ class FactoredEncoder(ModelPart, Attentive):
         factor_vectors_and_weights = {
             data_id: vocabulary.sentences_to_tensor(factors[data_id],
                                                     self.max_input_len,
-                                                    train_mode=train)
+                                                    train_mode=train,
+                                                    add_start_symbol=True,
+                                                    add_end_symbol=True)
             for data_id, vocabulary in zip(self.data_ids, self.vocabularies)}
 
         # check input lengths

--- a/neuralmonkey/encoders/factored_encoder.py
+++ b/neuralmonkey/encoders/factored_encoder.py
@@ -1,4 +1,5 @@
 from typing import List, Optional
+from typeguard import check_argument_types
 
 import tensorflow as tf
 
@@ -8,7 +9,6 @@ from neuralmonkey.encoders.attentive import Attentive
 from neuralmonkey.logging import log
 from neuralmonkey.nn.bidirectional_rnn_layer import BidirectionalRNNLayer
 from neuralmonkey.nn.noisy_gru_cell import NoisyGRUCell
-from neuralmonkey.nn.pervasive_dropout_wrapper import PervasiveDropoutWrapper
 from neuralmonkey.checking import assert_type
 from neuralmonkey.vocabulary import Vocabulary
 
@@ -18,7 +18,7 @@ from neuralmonkey.vocabulary import Vocabulary
 
 
 class FactoredEncoder(ModelPart, Attentive):
-    """Generic encoder processessig an arbitrary number of input sequences."""
+    """Generic encoder processing an arbitrary number of input sequences."""
 
     # pylint: disable=too-many-arguments
     def __init__(self,
@@ -35,33 +35,25 @@ class FactoredEncoder(ModelPart, Attentive):
 
         Args:
             max_input_len: Maximum input length (longer sequences are trimmed)
-
             vocabularies: List of vocabularies indexed
             data_ids: List of data series IDs
             embedding_sizes: List of embedding sizes for each data series
-
+            name: The name for this encoder. [sentence_encoder]
             rnn_size: The size of the hidden state
 
         Keyword arguments:
             use_noisy_activations: Boolean flag whether to use noisy activation
                                    functions in RNN cells.
                                    (see neuralmonkey.nn.noisy_gru_cell) [False]
-
-            use_pervasive_dropout: Boolean flag whether to use pervasive
-                                   dropout
-                                   (see arxiv.org/abs/1606.02891) [False]
-
             attention_type: The attention to use. [None]
             attention_fertility: Fertility for CoverageAttention (if used). [3]
-
-            name: The name for this encoder. [sentence_encoder]
             dropout_keep_prob: 1 - Dropout probability [1]
         """
         attention_type = kwargs.get("attention_type", None)
         Attentive.__init__(self, attention_type)
         ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
-        for vocabulary in vocabularies:
-            assert_type(self, 'vocabulary', vocabulary, Vocabulary)
+
+        assert check_argument_types()
 
         self.vocabularies = vocabularies
         self.data_ids = data_ids
@@ -73,14 +65,10 @@ class FactoredEncoder(ModelPart, Attentive):
         self.dropout_keep_prob = kwargs.get("dropout_keep_prob", 1)
 
         self.use_noisy_activations = kwargs.get("use_noisy_activations", False)
-        self.use_pervasive_dropout = kwargs.get("use_pervasive_dropout", False)
 
         log("Building encoder graph, name: '{}'.".format(self.name))
         with tf.variable_scope(self.name):
             self._create_encoder_graph()
-
-            # Attention mechanism
-
             log("Encoder graph constructed.")
     # pylint: enable=too-many-arguments
 
@@ -99,19 +87,6 @@ class FactoredEncoder(ModelPart, Attentive):
             cell = NoisyGRUCell(self.rnn_size, self.is_training)
         else:
             cell = tf.nn.rnn_cell.GRUCell(self.rnn_size)
-
-        if self.use_pervasive_dropout:
-            # pylint: disable=no-member, undefined-variable
-            # TODO fix this
-            shape = tf.concat(0, [tf.shape(self.inputs[0]), [rnn_size]])
-            # TODO shape needs recomputing
-
-            dropout_mask = tf.floor(tf.random_uniform(shape, 0.0, 1.0)
-                                    + self.dropout_placeholder)
-
-            scale = tf.inv(self.dropout_placeholder)
-            cell = PervasiveDropoutWrapper(cell, dropout_mask, scale)
-
         return cell
 
     def _get_birnn_cells(self):
@@ -135,9 +110,12 @@ class FactoredEncoder(ModelPart, Attentive):
         self.factor_inputs = {}
         factors = []
 
+        assert len(self.data_ids) == len(self.vocabularies) == \
+               len(self.embedding_sizes)
+
         for data_id, vocabulary, embedding_size in zip(
                 self.data_ids, self.vocabularies, self.embedding_sizes):
-            # Create data placehoders. The tensors' length is max_input_len+2
+            # Create data placeholders. The tensors' length is max_input_len+1
             # because we add explicit start and end symbols.
             prefix = ""
             if len(self.data_ids) > 1:
@@ -204,7 +182,7 @@ class FactoredEncoder(ModelPart, Attentive):
         # sentences are of the same length
 
         fd = {}
-        # we asume that all factors have equal word counts
+        # we assume that all factors have equal word counts
         # this is removed as res should only contain placeholders as keys
         # res[self.sentence_lengths] = np.array(
         #     [min(self.max_input_len, len(s)) +
@@ -230,7 +208,7 @@ class FactoredEncoder(ModelPart, Attentive):
                 lengths_this = [sum(p) for p in padding_weights]
 
                 if lengths_this != lengths:
-                    raise Exception("Sentence lenghts are not the same for"
+                    raise Exception("Sentence lengths are not the same for"
                                     "different factors.")
 
         for data_id in self.data_ids:

--- a/tests/factored.ini
+++ b/tests/factored.ini
@@ -1,21 +1,25 @@
 ; This is a test configuration file for MT task with factored input.
 
 [main]
-name="translation"
+name="translation with factored input"
+tf_manager=<tf_manager>
 output="tests/tmp-test-output"
 overwrite_output_dir=True
-batch_size=7
+batch_size=16
 epochs=2
-encoders=[<encoder>]
-decoder=<decoder>
 train_dataset=<train_data>
 val_dataset=<val_data>
 trainer=<trainer>
-runner=<runner>
+runners=[<runner>]
 postprocess=None
-evaluation=[<bleu>]
-logging_period=5
-validation_period=20
+evaluation=[("target", <bleu>)]
+logging_period=10
+validation_period=10
+
+[tf_manager]
+class=tf_manager.TensorFlowManager
+num_threads=4
+num_sessions=1
 
 [bleu]
 class=evaluators.bleu.BLEUEvaluator
@@ -59,6 +63,7 @@ overwrite=True
 
 [encoder]
 class=encoders.factored_encoder.FactoredEncoder
+name="factored_encoder"
 rnn_size=256
 max_input_len=20
 embedding_sizes=[200, 100]
@@ -69,20 +74,24 @@ vocabularies=[<surface_source_vocabulary>, <tag_vocabulary>]
 
 [decoder]
 class=decoders.decoder.Decoder
+name="decoder"
 encoders=[<encoder>]
 rnn_size=256
 embedding_size=256
 use_attention=True
 dropout_keep_prob=0.5
 data_id="target"
+max_output_len=20
 vocabulary=<surface_target_vocabulary>
 
 [trainer]
 class=trainers.cross_entropy_trainer.CrossEntropyTrainer
-decoder=<decoder>
-l2_regularization=1.0e-8
+decoders=[<decoder>]
+l2_weight=1.0e-8
+clip_norm=1.0
 
 [runner]
 class=runners.runner.GreedyRunner
 decoder=<decoder>
-batch_size=16
+output_series="target"
+

--- a/tests/tests_run.sh
+++ b/tests/tests_run.sh
@@ -9,6 +9,7 @@ bin/neuralmonkey-train tests/bahdanau.ini
 bin/neuralmonkey-train tests/bpe.ini
 bin/neuralmonkey-train tests/alignment.ini
 bin/neuralmonkey-train tests/post-edit.ini
+bin/neuralmonkey-train tests/factored.ini
 
 bin/neuralmonkey-train tests/small.ini
 bin/neuralmonkey-run tests/small.ini tests/test_data.ini


### PR DESCRIPTION
Didn't refactor, but made current version of factored encoder work, this involved:
- correcting attention initialization
- renaming embeddings 
- adding start and end symbols and changing the loops over the inputs accordingly (not sure whether this should be the default setting though)
- removing pervasive dropout (code didn't work, there was a TODO in the code)

The config factored.ini is updated and included into test_runs.sh.