### PR TITLE
CNN with layers from contrib

### DIFF
--- a/neuralmonkey/encoders/cnn_encoder.py
+++ b/neuralmonkey/encoders/cnn_encoder.py
@@ -14,9 +14,6 @@ from neuralmonkey.decoding_function import Attention
 from neuralmonkey.model.model_part import ModelPart, FeedDict
 
 
-# pylint: disable=too-many-instance-attributes, too-few-public-methods
-
-
 class CNNEncoder(ModelPart, Attentive):
     """An image encoder.
 
@@ -25,7 +22,6 @@ class CNNEncoder(ModelPart, Attentive):
     encode the image into a single vector.
 
     Attributes:
-
         input_op: Placeholder for the batch of input images
         padding_masks: Placeholder for matrices capturing telling where the
             image has been padded.
@@ -74,11 +70,7 @@ class CNNEncoder(ModelPart, Attentive):
         ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
         Attentive.__init__(self, attention_type)
 
-        self.convolutions = convolutions
         self.data_id = data_id
-        self.image_height = image_height
-        self.image_width = image_width
-        self.pixel_dim = pixel_dim
         self.dropout_keep_prob = dropout_keep_prob
 
         with tf.variable_scope(name):
@@ -132,7 +124,7 @@ class CNNEncoder(ModelPart, Attentive):
             # we average out by the image size -> shape is number
             # channels from the last convolution
             self.encoded = tf.reduce_mean(last_layer, [1, 2])
-            assert_shape(self.encoded, [None, self.convolutions[-1][1]])
+            assert_shape(self.encoded, [None, convolutions[-1][1]])
 
             self.__attention_tensor = tf.reshape(
                 last_layer, [-1, image_width,

--- a/tests/str.ini
+++ b/tests/str.ini
@@ -60,6 +60,7 @@ image_height=31
 image_width=310
 pixel_dim=1
 convolutions=[(3, 3, None), (3, 3, 2)]
+fully_connected=[4,2]
 
 [decoder_vocabulary]
 class=vocabulary.from_dataset

--- a/tests/str.ini
+++ b/tests/str.ini
@@ -59,7 +59,7 @@ data_id="images"
 image_height=31
 image_width=310
 pixel_dim=1
-convolutions=[(3, 3, None), (3, 3, None)]
+convolutions=[(3, 3, None), (3, 3, 2)]
 
 [decoder_vocabulary]
 class=vocabulary.from_dataset


### PR DESCRIPTION
This PR refactors `CNNEncoder`. I replaced our implementation of convolutions, maxpooling (which did not work) and batch normalization (which I did not trust) with layer function from the `contrib` module. `CNNEncoder` was added option to have fully connected layers on top of the convolution.

Because it uses `multilayer_projection`, it should merged only after #337.