### PR TITLE
Dynamic encoder length

### DIFF
--- a/neuralmonkey/decoding_function.py
+++ b/neuralmonkey/decoding_function.py
@@ -35,14 +35,11 @@ class Attention(object):
         self.input_weights = input_weights
 
         with tf.variable_scope(scope):
-            self.attn_length = attention_states.get_shape()[1].value
             self.attn_size = attention_states.get_shape()[2].value
 
             # To calculate W1 * h_t we use a 1-by-1 convolution, need to
             # reshape before.
-            self.att_states_reshaped = tf.reshape(
-                self.attention_states,
-                [-1, self.attn_length, 1, self.attn_size])
+            self.att_states_reshaped = tf.expand_dims(self.attention_states, 2)
 
             # Size of query vectors for attention.
             self.attention_vec_size = self.attn_size
@@ -94,7 +91,7 @@ class Attention(object):
             self.attentions_in_time.append(a)
 
             # Now calculate the attention-weighted vector d.
-            d = tf.reduce_sum(tf.reshape(a, [-1, self.attn_length, 1, 1])
+            d = tf.reduce_sum(tf.expand_dims(tf.expand_dims(a, -1), -1)
                               * self.att_states_reshaped, [1, 2])
 
             return tf.reshape(d, [-1, self.attn_size])
@@ -132,8 +129,8 @@ class CoverageAttention(Attention):
 
         logits = tf.reduce_sum(
             self.v * tf.tanh(
-                self.hidden_features + y + self.coverage_weights * tf.reshape(
-                    coverage, [-1, self.attn_length, 1, 1])),
+                self.hidden_features + y + self.coverage_weights *
+                tf.expand_dims(tf.expand_dims(coverage, -1), -1)),
             [2, 3])
 
         return logits

--- a/neuralmonkey/encoders/sentence_encoder.py
+++ b/neuralmonkey/encoders/sentence_encoder.py
@@ -30,9 +30,9 @@ class SentenceEncoder(ModelPart, Attentive):
                  name: str,
                  vocabulary: Vocabulary,
                  data_id: str,
-                 max_input_len: int,
                  embedding_size: int,
                  rnn_size: int,
+                 max_input_len: Optional[int]=None,
                  dropout_keep_prob: float=1.0,
                  attention_type: Optional[Callable]=None,
                  attention_fertility: int=3,
@@ -78,8 +78,8 @@ class SentenceEncoder(ModelPart, Attentive):
         self.use_noisy_activations = use_noisy_activations
         self.parent_encoder = parent_encoder
 
-        if max_input_len <= 0:
-            raise ValueError("Input length must be non-negative.")
+        if max_input_len is not None and max_input_len <= 0:
+            raise ValueError("Input length must be positive.")
 
         log("Initializing sentence encoder, name: '{}'"
             .format(self.name))
@@ -209,7 +209,8 @@ class SentenceEncoder(ModelPart, Attentive):
         sentences = dataset.get_series(self.data_id)
 
         vectors, paddings = self.vocabulary.sentences_to_tensor(
-            list(sentences), self.max_input_len, train_mode=train)
+            list(sentences), self.max_input_len, pad_to_max_len=False,
+            train_mode=train)
 
         # as sentences_to_tensor returns lists of shape (time, batch),
         # we need to transpose

--- a/neuralmonkey/encoders/sentence_encoder.py
+++ b/neuralmonkey/encoders/sentence_encoder.py
@@ -123,11 +123,11 @@ class SentenceEncoder(ModelPart, Attentive):
                                          name="mode_placeholder")
 
         self.inputs = tf.placeholder(tf.int32,
-                                     shape=[None, self.max_input_len],
+                                     shape=[None, None],
                                      name="encoder_input")
 
         self._input_mask = tf.placeholder(
-            tf.float32, shape=[None, self.max_input_len],
+            tf.float32, shape=[None, None],
             name="encoder_padding")
 
         self.sentence_lengths = tf.to_int32(


### PR DESCRIPTION
- Make `SentenceEncoder` and `Attention` work with variable length input.
- Enable `Vocabulary.sentences_to_tensor` to produce tensors of variable length. (This is achieved by either omitting `max_len` or by saying `pad_to_max_len=False`.)

The result:
- `SentenceEncoder` infers the input length at run time. `max_input_len` can still be (optionally) specified – the sentences are then truncated if they are longer, but there is no excessive padding.
- Other encoders and decoders are unaffected: they still require `max_*put_len` and work with tensors of fixed dimensions.

This should make the encoder more efficient in some cases, but should preserve the current functionality without the need to change the config files.