### PR TITLE
Support config changes on command line

### DIFF
--- a/neuralmonkey/config/parsing.py
+++ b/neuralmonkey/config/parsing.py
@@ -145,6 +145,7 @@ def _parse_ini(config_file: Iterable[str], filename: str="") -> Dict[str, Any]:
 
     return new_config
 
+
 def _apply_change(config_dict: Dict[str, Any], setting: str) -> None:
     if '=' not in setting:
         raise Exception('Invalid setting "{}"'.format(setting))
@@ -161,6 +162,7 @@ def _apply_change(config_dict: Dict[str, Any], setting: str) -> None:
         config_dict[section] = OrderedDict()
 
     config_dict[section][option] = -1, value  # no line number
+
 
 def parse_file(config_file: Iterable[str],
                changes: Optional[Iterable[str]]=None) -> Tuple[Dict[str, Any],
@@ -200,6 +202,7 @@ def parse_file(config_file: Iterable[str],
         for name, section in config.items()])
 
     return raw_config, parsed_dicts
+
 
 def write_file(config_dict: Dict[str, Any], config_file: IO[str]) -> None:
     config = configparser.ConfigParser()

--- a/neuralmonkey/config/parsing.py
+++ b/neuralmonkey/config/parsing.py
@@ -5,11 +5,12 @@ import configparser
 import re
 import time
 # pylint: disable=unused-import
-from typing import Any, Dict, Callable, Iterable, List, Tuple, Optional
+from typing import Any, Dict, Callable, Iterable, IO, List, Tuple, Optional
 # pylint: enable=unused-import
 
 from neuralmonkey.config.builder import ClassSymbol
 from neuralmonkey.config.exceptions import IniError
+from neuralmonkey.logging import log
 
 LINE_NUM = re.compile(r"^(.*) ([0-9]+)$")
 
@@ -144,14 +145,36 @@ def _parse_ini(config_file: Iterable[str], filename: str="") -> Dict[str, Any]:
 
     return new_config
 
+def _apply_change(config_dict: Dict[str, Any], setting: str) -> None:
+    if '=' not in setting:
+        raise Exception('Invalid setting "{}"'.format(setting))
+    key, value = (s.strip() for s in setting.split('=', maxsplit=1))
 
-def parse_file(config_file: Iterable[str]) -> Dict[str, Any]:
+    if '.' in key:
+        section, option = key.split('.', maxsplit=1)
+    else:
+        section = 'main'
+        option = key
+
+    if section not in config_dict:
+        log("Creating new section '{}'".format(section))
+        config_dict[section] = OrderedDict()
+
+    config_dict[section][option] = -1, value  # no line number
+
+def parse_file(config_file: Iterable[str],
+               changes: Optional[Iterable[str]]=None) -> Tuple[Dict[str, Any],
+                                                               Dict[str, Any]]:
     """ Parses an INI file and creates all values """
 
     parsed_dicts = OrderedDict()  # type: Dict[str, Any]
     time_stamp = time.strftime("%Y-%m-%d-%H-%M-%S")
 
     config = _parse_ini(config_file)
+
+    if changes is not None:
+        for change in changes:
+            _apply_change(config, change)
 
     for section in config:
         parsed_dicts[section] = OrderedDict()
@@ -171,4 +194,14 @@ def parse_file(config_file: Iterable[str]) -> Dict[str, Any]:
 
             parsed_dicts[section][key] = value
 
-    return parsed_dicts
+    # also return the unparsed config dict; need to remove line numbers
+    raw_config = OrderedDict([
+        (name, OrderedDict([(key, val) for key, (_, val) in section.items()]))
+        for name, section in config.items()])
+
+    return raw_config, parsed_dicts
+
+def write_file(config_dict: Dict[str, Any], config_file: IO[str]) -> None:
+    config = configparser.ConfigParser()
+    config.read_dict(config_dict)
+    config.write(config_file, space_around_delimiters=False)

--- a/neuralmonkey/train.py
+++ b/neuralmonkey/train.py
@@ -6,6 +6,7 @@ import argparse
 import sys
 import random
 import os
+import shlex
 from shutil import copyfile
 import numpy as np
 import tensorflow as tf
@@ -132,7 +133,7 @@ def main() -> None:
             cfg.args.output, cont_index)
 
     with open(args_file, 'w') as file:
-        print('\n'.join(sys.argv), file=file)
+        print(' '.join(shlex.quote(a) for a in sys.argv), file=file)
 
     cfg.save_file(ini_file)
     copyfile(args.config, orig_ini_file)

--- a/neuralmonkey/train.py
+++ b/neuralmonkey/train.py
@@ -2,6 +2,7 @@
 This is a training script for sequence to sequence learning.
 """
 
+import argparse
 import sys
 import random
 import os
@@ -51,14 +52,19 @@ def create_config() -> Configuration:
 
 # pylint: disable=too-many-statements
 def main() -> None:
-    if len(sys.argv) != 2:
-        print("Usage: train.py <ini_file>")
-        exit(1)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('config', metavar='INI-FILE',
+                        help='the configuration file for the experiment')
+    parser.add_argument('-s', '--set', type=str, metavar='SETTING',
+                        action='append', dest='config_changes',
+                        help='override an option in the configuration; the '
+                        'syntax is [section.]option=value')
+    args = parser.parse_args()
 
     # define valid parameters and defaults
     cfg = create_config()
     # load the params from the config file, getting also the simple arguments
-    cfg.load_file(sys.argv[1])
+    cfg.load_file(args.config, changes=args.config_changes)
     # various things like randseed or summarywriter should be set up here
     # so that graph building can be recorded
     # build all the objects specified in the config
@@ -92,8 +98,10 @@ def main() -> None:
                 .format(cfg.args.output, exc), color='red')
             exit(1)
 
+    args_file = "{}/args".format(cfg.args.output)
     log_file = "{}/experiment.log".format(cfg.args.output)
     ini_file = "{}/experiment.ini".format(cfg.args.output)
+    orig_ini_file = "{}/original.ini".format(cfg.args.output)
     git_commit_file = "{}/git_commit".format(cfg.args.output)
     git_diff_file = "{}/git_diff".format(cfg.args.output)
     variables_file_prefix = "{}/variables.data".format(cfg.args.output)
@@ -108,9 +116,13 @@ def main() -> None:
            or os.path.exists("{}.0".format(variables_file_prefix))):
         cont_index += 1
 
+        args_file = "{}/args.cont-{}".format(
+            cfg.args.output, cont_index)
         log_file = "{}/experiment.log.cont-{}".format(
             cfg.args.output, cont_index)
         ini_file = "{}/experiment.ini.cont-{}".format(
+            cfg.args.output, cont_index)
+        orig_ini_file = "{}/original.ini.cont-{}".format(
             cfg.args.output, cont_index)
         git_commit_file = "{}/git_commit.cont-{}".format(
             cfg.args.output, cont_index)
@@ -119,7 +131,12 @@ def main() -> None:
         variables_file_prefix = "{}/variables.data.cont-{}".format(
             cfg.args.output, cont_index)
 
-    copyfile(sys.argv[1], ini_file)
+    with open(args_file, 'w') as file:
+        print('\n'.join(sys.argv), file=file)
+
+    cfg.save_file(ini_file)
+    copyfile(args.config, orig_ini_file)
+
     Logging.set_log_file(log_file)
 
     # this points inside the neuralmonkey/ dir inside the repo, but


### PR DESCRIPTION
- Use `argparse` for argument parsing in `train.py`
- Add the `-s` option for modifying configuration
- Keep the loaded (but not fully parsed) configuration and write it to `experiment.ini`; store a copy of the original file as `original.ini`

Resolves #285.