### PR TITLE
Remove kwargs argument from constructors of all configurable units

### DIFF
--- a/neuralmonkey/encoders/sentence_encoder.py
+++ b/neuralmonkey/encoders/sentence_encoder.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, Tuple
+from typing import Optional, Tuple, Any
 
 import tensorflow as tf
 from typeguard import check_argument_types
@@ -34,7 +34,7 @@ class SentenceEncoder(ModelPart, Attentive):
                  rnn_size: int,
                  max_input_len: Optional[int]=None,
                  dropout_keep_prob: float=1.0,
-                 attention_type: Optional[Callable]=None,
+                 attention_type: Optional[Any]=None,
                  attention_fertility: int=3,
                  use_noisy_activations: bool=False,
                  parent_encoder: Optional["SentenceEncoder"]=None,

--- a/neuralmonkey/processors/bpe.py
+++ b/neuralmonkey/processors/bpe.py
@@ -15,15 +15,8 @@ class BPEPreprocessor(object):
     Code: https://github.com/rsennrich/subword-nmt
     """
 
-    def __init__(self, **kwargs):
-
-        if "merge_file" not in kwargs:
-            raise Exception("No merge file for BPE preprocessor")
-
+    def __init__(self, merge_file: str, separator: str="@@") -> None:
         log("Initializing BPE preprocessor")
-
-        separator = kwargs.get("separator", "@@")
-        merge_file = kwargs["merge_file"]
 
         with codecs.open(merge_file, "r", "utf-8") as f_data:
             self.bpe = BPE(f_data, separator)
@@ -50,10 +43,8 @@ class BPEPreprocessor(object):
 
 class BPEPostprocessor(object):
 
-    def __init__(self, **kwargs):
-        self.separator = kwargs.get("separator", "@@")
-
-        esc = re.escape(self.separator)
+    def __init__(self, separator: str="@@") -> None:
+        esc = re.escape(separator)
         self.pattern = re.compile(esc + r" ")
 
     def __call__(self, decoded_sentences: List[List[str]]) -> List[List[str]]:

--- a/neuralmonkey/processors/bpe.py
+++ b/neuralmonkey/processors/bpe.py
@@ -1,4 +1,3 @@
-import codecs
 import re
 from typing import List
 
@@ -18,7 +17,7 @@ class BPEPreprocessor(object):
     def __init__(self, merge_file: str, separator: str="@@") -> None:
         log("Initializing BPE preprocessor")
 
-        with codecs.open(merge_file, "r", "utf-8") as f_data:
+        with open(merge_file, "r") as f_data:
             self.bpe = BPE(f_data, separator)
 
     def __call__(self, sentence: List[str]) -> List[str]:


### PR DESCRIPTION
Closes #95

The only place where there is the kwargs argument used directly from the
configuration is the dataset.