### PR TITLE
Create vocabulary excluding infrequent words

### DIFF
--- a/neuralmonkey/tests/test_vocabulary.py
+++ b/neuralmonkey/tests/test_vocabulary.py
@@ -50,8 +50,8 @@ class TestVocabulary(unittest.TestCase):
 
         vocabulary = Vocabulary()
 
-        for s in TOKENIZED_CORPUS:
-            vocabulary.add_tokenized_text(s)
+        for sentence in TOKENIZED_CORPUS:
+            vocabulary.add_tokenized_text(sentence)
 
         vocabulary.truncate_by_min_freq(2)
 

--- a/neuralmonkey/tests/test_vocabulary.py
+++ b/neuralmonkey/tests/test_vocabulary.py
@@ -21,6 +21,7 @@ for s in TOKENIZED_CORPUS:
 
 
 class TestVocabulary(unittest.TestCase):
+
     def test_all_words_in(self):
         for sentence in TOKENIZED_CORPUS:
             for word in sentence:
@@ -44,6 +45,18 @@ class TestVocabulary(unittest.TestCase):
         for orig_sentence, reconstructed_sentence in \
                 zip(TOKENIZED_CORPUS, senteces_again):
             self.assertSequenceEqual(orig_sentence, reconstructed_sentence)
+
+    def test_min_freq(self):
+
+        v = Vocabulary()
+
+        for s in TOKENIZED_CORPUS:
+            v.add_tokenized_text(s)
+
+        v.truncate_by_min_freq(min_freq=2)
+
+        self.assertTrue("walrus" in v)
+        self.assertFalse("colorless" in v)
 
 
 if __name__ == "__main__":

--- a/neuralmonkey/tests/test_vocabulary.py
+++ b/neuralmonkey/tests/test_vocabulary.py
@@ -48,15 +48,15 @@ class TestVocabulary(unittest.TestCase):
 
     def test_min_freq(self):
 
-        v = Vocabulary()
+        vocabulary = Vocabulary()
 
         for s in TOKENIZED_CORPUS:
-            v.add_tokenized_text(s)
+            vocabulary.add_tokenized_text(s)
 
-        v.truncate_by_min_freq(min_freq=2)
+        vocabulary.truncate_by_min_freq(2)
 
-        self.assertTrue("walrus" in v)
-        self.assertFalse("colorless" in v)
+        self.assertTrue("walrus" in vocabulary)
+        self.assertFalse("colorless" in vocabulary)
 
 
 if __name__ == "__main__":

--- a/neuralmonkey/vocabulary.py
+++ b/neuralmonkey/vocabulary.py
@@ -94,6 +94,7 @@ def from_wordlist(path: str, encoding: str="utf-8") -> 'Vocabulary':
 # helper function, this number of parameters is needed
 def from_dataset(datasets: List[Dataset], series_ids: List[str], max_size: int,
                  save_file: str=None, overwrite: bool=False,
+                 min_freq: Optional[int]=1,
                  unk_sample_prob: float=0.5) -> 'Vocabulary':
     """Loads vocabulary from a dataset with an option to save it.
 
@@ -105,6 +106,7 @@ def from_dataset(datasets: List[Dataset], series_ids: List[str], max_size: int,
         save_file: A file to save the vocabulary to. If None (default),
                    the vocabulary will not be saved.
         overwrite: Overwrite existing file.
+        min_freq: Do not include words with frequency smaller than this.
         unk_sample_prob: The probability with which to sample unks out of
                          words with frequency 1. Defaults to 0.5.
 
@@ -127,6 +129,9 @@ def from_dataset(datasets: List[Dataset], series_ids: List[str], max_size: int,
                     [token for sent in series for token in sent])
 
     vocabulary.truncate(max_size)
+
+    if min_freq > 1:
+        vocabulary.truncate_by_min_freq(min_freq)
 
     log("Vocabulary for series {} initialized, containing {} words"
         .format(series_ids, len(vocabulary)))

--- a/neuralmonkey/vocabulary.py
+++ b/neuralmonkey/vocabulary.py
@@ -126,7 +126,7 @@ def from_dataset(datasets: List[Dataset], series_ids: List[str], max_size: int,
                 vocabulary.add_tokenized_text(
                     [token for sent in series for token in sent])
 
-    vocabulary.trunkate(max_size)
+    vocabulary.truncate(max_size)
 
     log("Vocabulary for series {} initialized, containing {} words"
         .format(series_ids, len(vocabulary)))
@@ -323,7 +323,7 @@ class Vocabulary(collections.Sized):
 
         return idx
 
-    def trunkate(self, size: int) -> None:
+    def truncate(self, size: int) -> None:
         """Truncate the vocabulary to the requested size by discarding
         infrequent tokens.
 

--- a/neuralmonkey/vocabulary.py
+++ b/neuralmonkey/vocabulary.py
@@ -359,24 +359,19 @@ class Vocabulary(collections.Sized):
             self.word_to_index[word] = index
 
     def truncate_by_min_freq(self, min_freq: int) -> None:
-        """Truncate the vocabulary by only keeping tokens with given minimum
-        frequency.
+        """Truncate the vocabulary only keeping tokens with a minimum frequency.
 
         Arguments:
             min_freq: The minimum frequency of included words.
         """
-        if min_freq == 1:
-            return
-
-        # count how many words there are with frequency < min_freq
-        infreq_word_count = sum([1 for w in self.word_count.keys()
-                                 if self.word_count[w] < min_freq])
-
-        log("Removing {} infrequent (<{}) words from vocabulary".format(
-            infreq_word_count, min_freq))
-
-        new_size = len(self)-infreq_word_count
-        self.truncate(new_size)
+        if min_freq > 1:
+            # count how many words there are with frequency < min_freq
+            infreq_word_count = sum([1 for w in self.word_count.keys()
+                                     if self.word_count[w] < min_freq])
+            log("Removing {} infrequent (<{}) words from vocabulary".format(
+                infreq_word_count, min_freq))
+            new_size = len(self)-infreq_word_count
+            self.truncate(new_size)
 
     def sentences_to_tensor(
             self,

--- a/neuralmonkey/vocabulary.py
+++ b/neuralmonkey/vocabulary.py
@@ -94,7 +94,7 @@ def from_wordlist(path: str, encoding: str="utf-8") -> 'Vocabulary':
 # helper function, this number of parameters is needed
 def from_dataset(datasets: List[Dataset], series_ids: List[str], max_size: int,
                  save_file: str=None, overwrite: bool=False,
-                 min_freq: Optional[int]=1,
+                 min_freq: Optional[int]=None,
                  unk_sample_prob: float=0.5) -> 'Vocabulary':
     """Loads vocabulary from a dataset with an option to save it.
 
@@ -130,8 +130,9 @@ def from_dataset(datasets: List[Dataset], series_ids: List[str], max_size: int,
 
     vocabulary.truncate(max_size)
 
-    if min_freq > 1:
-        vocabulary.truncate_by_min_freq(min_freq)
+    if min_freq is not None:
+        if min_freq > 1:
+            vocabulary.truncate_by_min_freq(min_freq)
 
     log("Vocabulary for series {} initialized, containing {} words"
         .format(series_ids, len(vocabulary)))
@@ -370,8 +371,10 @@ class Vocabulary(collections.Sized):
         # count how many words there are with frequency < min_freq
         infreq_word_count = sum([1 for w in self.word_count.keys()
                                  if self.word_count[w] < min_freq])
+
         log("Removing {} infrequent (<{}) words from vocabulary".format(
             infreq_word_count, min_freq))
+
         new_size = len(self)-infreq_word_count
         self.truncate(new_size)
 

--- a/neuralmonkey/vocabulary.py
+++ b/neuralmonkey/vocabulary.py
@@ -352,6 +352,24 @@ class Vocabulary(collections.Sized):
         for index, word in enumerate(self.index_to_word):
             self.word_to_index[word] = index
 
+    def truncate_by_min_freq(self, min_freq: int) -> None:
+        """Truncate the vocabulary by only keeping tokens with given minimum
+        frequency.
+
+        Arguments:
+            min_freq: The minimum frequency of included words.
+        """
+        if min_freq == 1:
+            return
+
+        # count how many words there are with frequency < min_freq
+        infreq_word_count = sum([1 for w in self.word_count.keys()
+                                 if self.word_count[w] < min_freq])
+        log("Removing {} infrequent (<{}) words from vocabulary".format(
+            infreq_word_count, min_freq))
+        new_size = len(self)-infreq_word_count
+        self.truncate(new_size)
+
     def sentences_to_tensor(
             self,
             sentences: List[List[str]],

--- a/neuralmonkey/vocabulary.py
+++ b/neuralmonkey/vocabulary.py
@@ -359,7 +359,7 @@ class Vocabulary(collections.Sized):
             self.word_to_index[word] = index
 
     def truncate_by_min_freq(self, min_freq: int) -> None:
-        """Truncate the vocabulary only keeping tokens with a minimum frequency.
+        """Truncate the vocabulary only keeping words with a minimum frequency.
 
         Arguments:
             min_freq: The minimum frequency of included words.


### PR DESCRIPTION
These changes add a `min_freq` option to `from_dataset` to allow filtering out infrequent words, as an alternative (and arguably more common) strategy to UNK-sampling.