### PR TITLE
Improved scopes for model parts

### DIFF
--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -127,7 +127,7 @@ class Decoder(ModelPart):
             log("No output projection specified - using simple concatenation")
             self.output_projection = no_deep_output
 
-        with tf.variable_scope(name):
+        with self.use_scope():
             self._create_input_placeholders()
             self._create_training_placeholders()
             self._create_initial_state()

--- a/neuralmonkey/decoders/sequence_classifier.py
+++ b/neuralmonkey/decoders/sequence_classifier.py
@@ -53,7 +53,7 @@ class SequenceClassifier(ModelPart):
         self.dropout_keep_prob = dropout_keep_prob
         self.max_output_len = 1
 
-        with tf.variable_scope(name):
+        with self.use_scope():
             self.learning_step = tf.get_variable(
                 "learning_step", [], trainable=False,
                 initializer=tf.constant_initializer(0))

--- a/neuralmonkey/decorators.py
+++ b/neuralmonkey/decorators.py
@@ -1,12 +1,19 @@
 from functools import wraps
 
+from neuralmonkey.model.model_part import ModelPart
+
 
 def tensor(func):
     @wraps(func)
     def decorate(self, *args, **kwargs):
         attribute_name = "_{}_cached_placeholder".format(func.__name__)
         if not hasattr(self, attribute_name):
-            value = func(self, *args, **kwargs)
+            if isinstance(self, ModelPart):
+                # jump out of the caller's scope and into the ModelPart's scope
+                with self.use_scope():
+                    value = func(self, *args, **kwargs)
+            else:
+                value = func(self, *args, **kwargs)
             setattr(self, attribute_name, value)
         return getattr(self, attribute_name)
 

--- a/neuralmonkey/encoders/cnn_encoder.py
+++ b/neuralmonkey/encoders/cnn_encoder.py
@@ -76,7 +76,7 @@ class CNNEncoder(ModelPart, Attentive):
         self.data_id = data_id
         self.dropout_keep_prob = dropout_keep_prob
 
-        with tf.variable_scope(name):
+        with self.use_scope():
             self.dropout_placeholder = tf.placeholder(
                 tf.float32, name="dropout")
             self.train_mode = tf.placeholder(tf.bool, shape=[],

--- a/neuralmonkey/encoders/factored_encoder.py
+++ b/neuralmonkey/encoders/factored_encoder.py
@@ -56,7 +56,7 @@ class FactoredEncoder(ModelPart, Attentive):
         self.dropout_keep_prob = dropout_keep_prob
 
         log("Building encoder graph, name: '{}'.".format(self.name))
-        with tf.variable_scope(self.name):
+        with self.use_scope():
             self._create_encoder_graph()
             log("Encoder graph constructed.")
     # pylint: enable=too-many-arguments

--- a/neuralmonkey/encoders/numpy_encoder.py
+++ b/neuralmonkey/encoders/numpy_encoder.py
@@ -32,7 +32,7 @@ class VectorEncoder(ModelPart):
             tf.float32, shape=[None, dimension])
         self.data_id = data_id
 
-        with tf.variable_scope(self.name):
+        with self.use_scope():
             if output_shape and dimension != output_shape:
                 project_w = tf.get_variable(
                     shape=[dimension, output_shape],
@@ -71,7 +71,7 @@ class PostCNNImageEncoder(ModelPart, Attentive):
 
         self.data_id = data_id
 
-        with tf.variable_scope(self.name):
+        with self.use_scope():
             features_shape = [None] + input_shape  # type: ignore
             self.image_features = tf.placeholder(tf.float32,
                                                  shape=features_shape,

--- a/neuralmonkey/encoders/raw_rnn_encoder.py
+++ b/neuralmonkey/encoders/raw_rnn_encoder.py
@@ -62,7 +62,7 @@ class RawRNNEncoder(ModelPart, Attentive):
         log("Initializing RNN encoder, name: '{}'"
             .format(self.name))
 
-        with tf.variable_scope(self.name):
+        with self.use_scope():
             self._create_input_placeholders()
 
             self._input_mask = tf.sequence_mask(self._input_lengths,

--- a/neuralmonkey/encoders/sentence_encoder.py
+++ b/neuralmonkey/encoders/sentence_encoder.py
@@ -84,7 +84,7 @@ class SentenceEncoder(ModelPart, Attentive):
         log("Initializing sentence encoder, name: '{}'"
             .format(self.name))
 
-        with tf.variable_scope(self.name):
+        with self.use_scope():
             self._create_input_placeholders()
             with tf.variable_scope('input_projection'):
                 self._create_embedding_matrix()

--- a/neuralmonkey/encoders/sequence_cnn_encoder.py
+++ b/neuralmonkey/encoders/sequence_cnn_encoder.py
@@ -48,7 +48,7 @@ class SequenceCNNEncoder(ModelPart):
         self.data_id = data_id
         self.max_input_len = max_input_len
 
-        with tf.variable_scope(self.name):
+        with self.use_scope():
             self.train_mode = tf.placeholder(tf.bool, shape=[],
                                              name="mode_placeholder")
 


### PR DESCRIPTION
- Each model part's `VariableScope` is stored in `self._variable_scope` and invoked using `self.use_scope()`.
- The above is used to make sure that `@tensor` properties use the right scope.