### PR TITLE
Keep using pylint 1.6.5

### DIFF
--- a/tests/lint_requirements.txt
+++ b/tests/lint_requirements.txt
@@ -1,1 +1,1 @@
-pylint
+pylint==1.6.5


### PR DESCRIPTION
Pylint version 1.7.0 has been released. It treats strangely the keyword arguments (it requires to have spaces around `=`) which I believe violates PEP8. The new pylint is capable of catching more suspicious things, so I would switch to it eventually, but I would wait how the development with keyword arguments will be.