### PR TITLE
Support for running the inference on SGE cluster

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,5 +28,6 @@ Getting Started
    visualization
    features
    tf_manager
+   running
    benchmark
    internal_dev

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -1,0 +1,61 @@
+.. _running:
+
+=======================================
+Use SGE cluster array job for inference
+=======================================
+
+To speed up the inference, the ``neuralmonkey-run`` binary provides the
+``--grid`` option, which can be used when running the program as a SGE array
+job.
+
+The ``run`` script make use of the ``SGE_TASK_ID`` and ``SGE_TASK_STEPSIZE``
+environment variables that are set in each computing node of the array job.
+If the ``--grid`` option is supplied and these variables are present, it runs
+the inference only on a subset of the dataset, specified by the variables.
+
+Consider this example ``test_data.ini``::
+
+  [main]
+  test_datasets=[<dataset>]
+  variables=["path/to/variables.data"]
+
+  [dataset]
+  class=dataset.load_dataset_from_files
+  s_source="data/source.en"
+  s_target_out="out/target.de"
+
+If we want to run a model configured in ``model.ini`` on this dataset, we can
+do::
+
+  neuralmonkey-run model.ini test_data.ini
+
+And the program executes the model on the dataset loaded from
+``data/source.en`` and stores the results in ``out/target.de``.
+
+If the source file is large or if you use a slow inference method (such as beam
+search), you may want to split the source file into smaller parts and execute
+the model on all of them in parallel. If you have access to a SGE cluster, you
+don't have to do it manually - just create an array job and supply the
+``--grid`` option to the program. Now, suppose that the source file contains
+100,000 sentences and you want to split it to 100 parts and run it on
+cluster. To accomplish this, just run::
+
+  qsub <qsub_options> -t 1-100000:1000 -b y \
+  "neuralmonkey-run --grid model.ini test_data.ini"
+
+This will submit 100 jobs to your cluster. Each job will use its
+``SGE_TASK_ID`` and ``SGE_TASK_STEPSIZE`` parameters to determine its part of
+the data to process. It then runs the inference only on the subset of the
+dataset and stores the result in a suffixed file.
+
+For example, if the ``SGE_TASK_ID`` is 3, the ``SGE_TASK_STEPSIZE`` is 100, and
+the ``--grid`` option is specified, the inference will be run on lines 201 to
+300 of the file ``data/source.en`` and the output will be written to
+``out/target.de.0000000200``.
+
+After all the jobs are finished, you just need to manually run::
+
+  cat out/target.de.* > out/target.de
+
+and delete the intermediate files. (Careful when your file has more than 10^10
+lines - you need to concatenate the intermediate files in the right order!)

--- a/neuralmonkey/dataset.py
+++ b/neuralmonkey/dataset.py
@@ -163,7 +163,7 @@ class Dataset(collections.Sized):
                           for k, v in self.series_outputs.items()}
 
         # new series
-        subset_series = {k: v[start:start+length]
+        subset_series = {k: v[start:start + length]
                          for k, v in self._series.items()}
 
         return Dataset(subset_name, subset_series, subset_outputs)

--- a/neuralmonkey/run.py
+++ b/neuralmonkey/run.py
@@ -119,12 +119,11 @@ def main() -> None:
                 raise EnvironmentError(
                     "Some SGE environment variables are missing")
 
-            start = int(os.environ["SGE_TASK_FIRST"]) - 1
             length = int(os.environ["SGE_TASK_STEPSIZE"])
-            task_id = int(os.environ["SGE_TASK_ID"])
+            start = int(os.environ["SGE_TASK_ID"]) - 1
 
             log("Running grid task {} starting at {} with step {}"
-                .format(task_id, start, length))
+                .format(start // length, start, length))
 
             dataset = dataset.subset(start, length)
 

--- a/neuralmonkey/run.py
+++ b/neuralmonkey/run.py
@@ -1,5 +1,5 @@
-import sys
 import os
+import argparse
 
 from neuralmonkey.logging import log, log_print
 from neuralmonkey.config.configuration import Configuration
@@ -81,28 +81,53 @@ def initialize_for_running(output_dir, tf_manager, variable_files) -> None:
 
 def main() -> None:
     # pylint: disable=no-member,broad-except
-    if len(sys.argv) != 3:
-        print("Usage: run.py <run_ini_file> <test_datasets>")
-        exit(1)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("config", metavar="INI-FILE",
+                        help="the configuration file of the experiment")
+    parser.add_argument('datasets', metavar='INI-TEST-DATASETS',
+                        help="the configuration of the test datasets")
+    parser.add_argument("-g", "--grid", dest="grid", action="store_true",
+                        help="look at the SGE variables for slicing the data")
+    args = parser.parse_args()
 
     test_datasets = Configuration()
     test_datasets.add_argument('test_datasets')
     test_datasets.add_argument('variables')
 
-    CONFIG.load_file(sys.argv[1])
+    CONFIG.load_file(args.config)
     CONFIG.build_model()
-    test_datasets.load_file(sys.argv[2])
+    test_datasets.load_file(args.datasets)
     test_datasets.build_model()
-    datesets_model = test_datasets.model
+    datasets_model = test_datasets.model
     initialize_for_running(CONFIG.model.output, CONFIG.model.tf_manager,
-                           datesets_model.variables)
+                           datasets_model.variables)
 
     print("")
 
     evaluators = [(e[0], e[0], e[1]) if len(e) == 2 else e
                   for e in CONFIG.model.evaluation]
 
-    for dataset in datesets_model.test_datasets:
+    if args.grid and len(datasets_model.test_datasets) > 1:
+        raise ValueError("Only one test dataset supported when using --grid")
+
+    for dataset in datasets_model.test_datasets:
+        if args.grid:
+            if ("SGE_TASK_FIRST" not in os.environ
+                    or "SGE_TASK_LAST" not in os.environ
+                    or "SGE_TASK_STEPSIZE" not in os.environ
+                    or "SGE_TASK_ID" not in os.environ):
+                raise EnvironmentError(
+                    "Some SGE environment variables are missing")
+
+            start = int(os.environ["SGE_TASK_FIRST"]) - 1
+            length = int(os.environ["SGE_TASK_STEPSIZE"])
+            task_id = int(os.environ["SGE_TASK_ID"])
+
+            log("Running grid task {} starting at {} with step {}"
+                .format(task_id, start, length))
+
+            dataset = dataset.subset(start, length)
+
         execution_results, output_data = run_on_dataset(
             CONFIG.model.tf_manager, CONFIG.model.runners,
             dataset, CONFIG.model.postprocess, write_out=True,


### PR DESCRIPTION
Added `--grid` option to `neuralmonkey-run` script. When run as a part of a SGE array job (with `SGE_TASK_ID` and `SGE_TASK_STEPSIZE` environment variables set), it runs the inference on a corresponding subset of the dataset.

quirks:
* only works with a single test dataset
* all the SGE array job variables must be present in the environment
* suffixes the output file with a ten-digit number marking the starting input line. (Maybe it would be nicer to  rewrite this to the task ID padded to the number of digits of `$SGE_TASK_LAST`)
* concatenation of the intermediate files has to be done manually since the program is not run anywhere but the nodes

Useful for beam search or large datasets.

Future work: support multiple grid environments (e.g. PBS)