### PR TITLE
Helper for list of beam search runners

### DIFF
--- a/neuralmonkey/decoders/beam_search_decoder.py
+++ b/neuralmonkey/decoders/beam_search_decoder.py
@@ -112,7 +112,7 @@ class BeamSearchDecoder(ModelPart):
 
         finished_row = tf.one_hot(
             PAD_TOKEN_INDEX,
-            len(self._parent_decoder.vocabulary),
+            len(self.parent_decoder.vocabulary),
             dtype=tf.float32,
             on_value=0.,
             off_value=tf.float32.min)

--- a/neuralmonkey/runners/base_runner.py
+++ b/neuralmonkey/runners/base_runner.py
@@ -30,6 +30,9 @@ def collect_encoders(coder):
                                     for enc in coder.encoders))
     if hasattr(coder, "encoder"):
         return set([coder]).union(collect_encoders(coder.encoder))
+    if hasattr(coder, "parent_decoder"):
+        return set([coder]).union(collect_encoders(coder.parent_decoder))
+    # TODO replace by .get_predecesor method of ModelPart
 
     return set([coder])
 

--- a/neuralmonkey/runners/beamsearch_runner.py
+++ b/neuralmonkey/runners/beamsearch_runner.py
@@ -104,12 +104,34 @@ class BeamSearchRunner(BaseRunner):
 
 def beam_search_runner_range(output_series: str,
                              decoder: BeamSearchDecoder,
-                             max_rank: int = 1,
+                             max_rank: int = 10,
                              postprocess: Callable[
                                  [List[str]], List[str]]=None
                             ) -> List[BeamSearchRunner]:
-    """List of runners for different the range of ranks."""
+    """List of runners for different the range of ranks from 1 to max_rank.
+
+    This means there is max_rank output series where the n-th series contains
+    the n-th best hypothesis from the beam search.
+
+    Args:
+        output_series: Prefix of output series.
+        decoder: Beam search decoder shared by all runners.
+        max_rank: Maximum rank of the hypotheses.
+        postprocess: Series-level postprocess applied on output.
+
+    Returns:
+        List of beam search runners getting hypotheses with rank from 1 to
+        max_rank.
+    """
+
     assert check_argument_types()
+
+    if max_rank > decoder.beam_size:
+        raise ValueError(
+            ("The maximum rank ({}) cannot be "
+             "bigger than beam size {}.").format(
+                 max_rank, decoder.beam_size))
+
     return [BeamSearchRunner("{}.rank{:03d}".format(output_series, r),
                              decoder, r, postprocess)
             for r in range(1, max_rank + 1)]

--- a/neuralmonkey/runners/beamsearch_runner.py
+++ b/neuralmonkey/runners/beamsearch_runner.py
@@ -108,7 +108,7 @@ def beam_search_runner_range(output_series: str,
                              postprocess: Callable[
                                  [List[str]], List[str]]=None
                             ) -> List[BeamSearchRunner]:
-    """List of runners for different the range of ranks from 1 to max_rank.
+    """A list of beam search runners for a range of ranks from 1 to max_rank.
 
     This means there is max_rank output series where the n-th series contains
     the n-th best hypothesis from the beam search.

--- a/neuralmonkey/runners/beamsearch_runner.py
+++ b/neuralmonkey/runners/beamsearch_runner.py
@@ -100,3 +100,16 @@ class BeamSearchRunner(BaseRunner):
     @property
     def decoder_data_id(self) -> Optional[str]:
         return None
+
+
+def beam_search_runner_range(output_series: str,
+                             decoder: BeamSearchDecoder,
+                             max_rank: int = 1,
+                             postprocess: Callable[
+                                 [List[str]], List[str]]=None
+                            ) -> List[BeamSearchRunner]:
+    """List of runners for different the range of ranks."""
+    assert check_argument_types()
+    return [BeamSearchRunner("{}.rank{:03d}".format(output_series, r),
+                             decoder, r, postprocess)
+            for r in range(1, max_rank + 1)]

--- a/tests/beamsearch.ini
+++ b/tests/beamsearch.ini
@@ -10,9 +10,9 @@ epochs=2
 train_dataset=<train_data>
 val_dataset=<val_data>
 trainer=<trainer>
-runners=[<runner>,<bs_runner>]
+runners=<bs_runners>
 postprocess=None
-evaluation=[("target_greedy", "target", <bleu>), ("target_beam", "target", <bleu>)]
+evaluation=[("target_beam.rank001", "target", <bleu>)]
 logging_period=20
 validation_period=60
 runners_batch_size=1
@@ -92,12 +92,8 @@ decoders=[<decoder>]
 l2_weight=1.0e-8
 clip_norm=1.0
 
-[runner]
-class=runners.runner.GreedyRunner
-decoder=<decoder>
-output_series="target_greedy"
-
-[bs_runner]
-class=runners.beamsearch_runner.BeamSearchRunner
+[bs_runners]
+class=runners.beamsearch_runner.beam_search_runner_range
 output_series="target_beam"
 decoder=<bs_decoder>
+max_rank=2


### PR DESCRIPTION
This PR introduces a helper function that returns a list of beam search runners of the same beam search decoder. In this way we can get an _n_-best list from the beam search.