### PR TITLE
Remove asserts from type checking

### DIFF
--- a/neuralmonkey/dataset.py
+++ b/neuralmonkey/dataset.py
@@ -348,8 +348,7 @@ def load_dataset_from_files(
     Raises:
         Exception when no input files are provided.
     """
-
-    assert check_argument_types()
+    check_argument_types()
 
     series_paths_and_readers = _get_series_paths_and_readers(kwargs)
     series_outputs = _get_series_outputs(kwargs)

--- a/neuralmonkey/decoders/beam_search_decoder.py
+++ b/neuralmonkey/decoders/beam_search_decoder.py
@@ -42,7 +42,7 @@ class BeamSearchDecoder(ModelPart):
                  save_checkpoint: str = None,
                  load_checkpoint: str = None) -> None:
         ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
-        assert check_argument_types()
+        check_argument_types()
 
         self.parent_decoder = parent_decoder
         self._beam_size = beam_size

--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -77,9 +77,9 @@ class Decoder(ModelPart):
                 step should be combined with the input in the next step.
         """
         ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
-        log("Initializing decoder, name: '{}'".format(name))
+        check_argument_types()
 
-        assert check_argument_types()
+        log("Initializing decoder, name: '{}'".format(name))
 
         self.encoders = encoders
         self.vocabulary = vocabulary

--- a/neuralmonkey/encoders/factored_encoder.py
+++ b/neuralmonkey/encoders/factored_encoder.py
@@ -44,8 +44,7 @@ class FactoredEncoder(ModelPart, Attentive):
         """
         Attentive.__init__(self, attention_type)
         ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
-
-        assert check_argument_types()
+        check_argument_types()
 
         self.vocabularies = vocabularies
         self.data_ids = data_ids

--- a/neuralmonkey/encoders/numpy_encoder.py
+++ b/neuralmonkey/encoders/numpy_encoder.py
@@ -21,7 +21,7 @@ class VectorEncoder(ModelPart):
                  save_checkpoint: str = None,
                  load_checkpoint: str = None) -> None:
         ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
-        assert check_argument_types()
+        check_argument_types()
 
         if dimension <= 0:
             raise ValueError("Input vector dimension must be postive.")
@@ -63,7 +63,7 @@ class PostCNNImageEncoder(ModelPart, Attentive):
                  load_checkpoint: Optional[str] = None) -> None:
         ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
         Attentive.__init__(self, attention_type)
-        assert check_argument_types()
+        check_argument_types()
 
         assert len(input_shape) == 3
         if output_shape <= 0:

--- a/neuralmonkey/encoders/raw_rnn_encoder.py
+++ b/neuralmonkey/encoders/raw_rnn_encoder.py
@@ -74,8 +74,7 @@ class RawRNNEncoder(ModelPart, Attentive):
         """
         ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
         Attentive.__init__(self, attention_type)
-
-        assert check_argument_types()
+        check_argument_types()
 
         self.data_id = data_id
 

--- a/neuralmonkey/encoders/sentence_cnn_encoder.py
+++ b/neuralmonkey/encoders/sentence_cnn_encoder.py
@@ -74,8 +74,7 @@ class SentenceCNNEncoder(ModelPart, Attentive):
         ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
         Attentive.__init__(
             self, attention_type, attention_fertility=attention_fertility)
-
-        assert check_argument_types()
+        check_argument_types()
 
         self.vocabulary = vocabulary
         self.data_id = data_id

--- a/neuralmonkey/encoders/sentence_encoder.py
+++ b/neuralmonkey/encoders/sentence_encoder.py
@@ -66,8 +66,7 @@ class SentenceEncoder(ModelPart, Attentive):
         ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
         Attentive.__init__(
             self, attention_type, attention_fertility=attention_fertility)
-
-        assert check_argument_types()
+        check_argument_types()
 
         self.vocabulary = vocabulary
         self.data_id = data_id

--- a/neuralmonkey/encoders/sequence_cnn_encoder.py
+++ b/neuralmonkey/encoders/sequence_cnn_encoder.py
@@ -41,8 +41,7 @@ class SequenceCNNEncoder(ModelPart):
                 (default 1.0)
         """
         ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
-
-        assert check_argument_types()
+        check_argument_types()
 
         self.vocabulary = vocabulary
         self.data_id = data_id

--- a/neuralmonkey/learning_utils.py
+++ b/neuralmonkey/learning_utils.py
@@ -86,8 +86,7 @@ def training_loop(tf_manager: TensorFlowManager,
         postprocess: A function which takes the dataset with its output series
             and generates additional series from them.
     """
-
-    assert check_argument_types()
+    check_argument_types()
 
     if isinstance(val_dataset, Dataset):
         val_datasets = [val_dataset]

--- a/neuralmonkey/runners/beamsearch_runner.py
+++ b/neuralmonkey/runners/beamsearch_runner.py
@@ -76,7 +76,7 @@ class BeamSearchRunner(BaseRunner):
                  rank: int = 1,
                  postprocess: Callable[[List[str]], List[str]] = None) -> None:
         super(BeamSearchRunner, self).__init__(output_series, decoder)
-        assert check_argument_types()
+        check_argument_types()
 
         if rank < 1 or rank > decoder.beam_size:
             raise ValueError(
@@ -123,8 +123,7 @@ def beam_search_runner_range(output_series: str,
         List of beam search runners getting hypotheses with rank from 1 to
         max_rank.
     """
-
-    assert check_argument_types()
+    check_argument_types()
 
     if max_rank is None:
         max_rank = decoder.beam_size

--- a/neuralmonkey/runners/logits_runner.py
+++ b/neuralmonkey/runners/logits_runner.py
@@ -102,7 +102,7 @@ class LogitsRunner(BaseRunner):
                 vocabulary whose logit or probability should be on output.
         """
         super(LogitsRunner, self).__init__(output_series, decoder)
-        assert check_argument_types()
+        check_argument_types()
 
         if pick_index is not None and pick_value is not None:
             raise ValueError("Either a pick index or a vocabulary value can "

--- a/neuralmonkey/tf_manager.py
+++ b/neuralmonkey/tf_manager.py
@@ -62,7 +62,7 @@ class TensorFlowManager(object):
             report_gpu_memory_consumption: Report overall GPU memory at every
                 logging
         """
-        assert check_argument_types()
+        check_argument_types()
 
         session_cfg = tf.ConfigProto()
         session_cfg.inter_op_parallelism_threads = num_threads

--- a/neuralmonkey/trainers/cross_entropy_trainer.py
+++ b/neuralmonkey/trainers/cross_entropy_trainer.py
@@ -25,8 +25,7 @@ class CrossEntropyTrainer(GenericTrainer):
                  decoder_weights: Optional[List[ObjectiveWeight]] = None,
                  l1_weight=0., l2_weight=0.,
                  clip_norm=False, optimizer=None, global_step=None) -> None:
-
-        assert check_argument_types()
+        check_argument_types()
 
         if decoder_weights is None:
             decoder_weights = [None for _ in decoders]

--- a/neuralmonkey/trainers/self_critical_objective.py
+++ b/neuralmonkey/trainers/self_critical_objective.py
@@ -66,8 +66,7 @@ def self_critical_objective(decoder: Decoder,
     Returns:
         Objective object to be used in generic trainer.
     """
-
-    assert check_argument_types()
+    check_argument_types()
 
     # logits, shape (time, batch, vocab)
     train_logits = tf.stack(decoder.train_logits)

--- a/neuralmonkey/vocabulary.py
+++ b/neuralmonkey/vocabulary.py
@@ -113,8 +113,7 @@ def from_dataset(datasets: List[Dataset], series_ids: List[str], max_size: int,
     Returns:
         The new Vocabulary instance.
     """
-
-    assert check_argument_types()
+    check_argument_types()
 
     vocabulary = Vocabulary(unk_sample_prob=unk_sample_prob)
 


### PR DESCRIPTION
All lines `assert check_argument_types()` were changed to just `check_argument_types()`..

Je to proto, že ten assert se vůbec nepoužije, protože check_argument_types vyhodí výjimku, pokud je to blbě. Jedinej důvod k použití `assert`  v tomhle případě je, že když se zapne optimizace (čili pro produkci), tak se to vypne. A to právě nechceme.