### PR TITLE
doc: rename sentence_encoder to recurrent

### DIFF
--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -20,7 +20,7 @@ network during training. This prevents units from co-adapting too much. But duri
 If you want to enable dropout on an encoder or on the decoder, you can simply add dropout_keep_prob to the particular section::
   
   [encoder]
-  class=encoders.sentence_encoder.SentenceEncoder
+  class=encoders.recurrent.SentenceEncoder
   dropout_keep_prob=0.8
   ...
 
@@ -39,7 +39,7 @@ Detailed information in https://arxiv.org/abs/1512.05287
 If you want allow dropout on the recurrent layer of your encoder, you can add use_pervasive_dropout parameter into it and then the dropout probability will be used::
 
   [encoder]
-  class=encoders.sentence_encoder.SentenceEncoder
+  class=encoders.recurrent.SentenceEncoder
   dropout_keep_prob=0.8
   use_pervasive_dropout=True
   ...

--- a/docs/source/machine_translation.rst
+++ b/docs/source/machine_translation.rst
@@ -185,7 +185,7 @@ The encoder and decored are similar to those from
 .. code-block:: ini
 
   [encoder]
-  class=encoders.sentence_encoder.SentenceEncoder
+  class=encoders.recurrent.SentenceEncoder
   name="sentence_encoder"
   rnn_size=300
   max_input_len=50

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -307,7 +307,7 @@ the source sentences:
 .. code-block:: ini
 
   [src_encoder]
-  class=encoders.sentence_encoder.SentenceEncoder
+  class=encoders.recurrent.SentenceEncoder
   rnn_size=300
   max_input_len=50
   embedding_size=300
@@ -333,7 +333,7 @@ The configuration of the second encoder follows:
 .. code-block:: ini
 
   [trans_encoder]
-  class=encoders.sentence_encoder.SentenceEncoder
+  class=encoders.recurrent.SentenceEncoder
   rnn_size=300
   max_input_len=50
   embedding_size=300

--- a/examples/_old/multiobjective.ini
+++ b/examples/_old/multiobjective.ini
@@ -60,7 +60,7 @@ series_ids=[tags]
 max_size=50
 
 [encoder]
-class=encoders.sentence_encoder.SentenceEncoder
+class=encoders.recurrent.SentenceEncoder
 rnn_size=300
 max_input_len=50
 embedding_size=300

--- a/examples/tagging.ini
+++ b/examples/tagging.ini
@@ -52,7 +52,7 @@ max_size=50
 
 
 [encoder]
-class=encoders.sentence_encoder.SentenceEncoder
+class=encoders.recurrent.SentenceEncoder
 name="sentence_encoder"
 rnn_size=100
 max_input_len=50

--- a/examples/translation.ini
+++ b/examples/translation.ini
@@ -88,7 +88,7 @@ path="examples/data/translation/bpe_merges"
 
 ; This section defines the sentence encoder object.
 [encoder]
-class=encoders.sentence_encoder.SentenceEncoder
+class=encoders.recurrent.SentenceEncoder
 name="sentence_encoder"
 rnn_size=300
 max_input_len=50


### PR DESCRIPTION
sentence_encoder is apparently renamed to recurrent and all configs in tutorials are broken. Fix this.