### PR TITLE
Decoder should primarily use sequence data_id

### DIFF
--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -140,9 +140,9 @@ class Decoder(ModelPart):
             self.embedding_size = (
                 self.embeddings_source.embedding_matrix.get_shape()[1].value)
 
-            self.data_id = self.embeddings_source.data_id
-            log("Ignoring decoders data_id field and using the sequence"
-                "embedding data_id.")
+            if self.data_id != self.embeddings_source.data_id:
+                raise ValueError("Decoders data_id do not match sequence"
+                                 "embedding data_id.")
 
         if self.encoder_projection is None:
             if not self.encoders:

--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -140,6 +140,10 @@ class Decoder(ModelPart):
             self.embedding_size = (
                 self.embeddings_source.embedding_matrix.get_shape()[1].value)
 
+            self.data_id = self.embeddings_source.data_id
+            log("Ignoring decoders data_id field and using the sequence"
+                "embedding data_id.")
+
         if self.encoder_projection is None:
             if not self.encoders:
                 log("No encoder - language model only.")

--- a/tests/post-edit.ini
+++ b/tests/post-edit.ini
@@ -54,6 +54,14 @@ attention_type=decoding_function.Attention
 rnn_cell="LSTM"
 name="trans_encoder"
 
+[edits_embedded_input]
+class=model.sequence.EmbeddedSequence
+name="edits_decoder_input_sequence"
+data_id="edits"
+embedding_size=10
+max_length=5
+vocabulary=<target_vocabulary>
+
 [trans_embedded_input]
 class=model.sequence.EmbeddedSequence
 name="trans_encoder_input_sequence"
@@ -68,7 +76,7 @@ name="decoder"
 encoders=[<trans_encoder>, <src_encoder>]
 rnn_size=30
 max_output_len=5
-embeddings_source=<trans_embedded_input>
+embeddings_source=<edits_embedded_input>
 dropout_keep_prob=0.8
 use_attention=True
 data_id="edits"


### PR DESCRIPTION
This would avoid an error in configurations I did when I had different data_ids