### PR TITLE
Introducing pydocstyle tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   matrix:
     - TEST_SUITE=lint
     - TEST_SUITE=pycodestyle
+    - TEST_SUITE=pydocstyle
     - TEST_SUITE=unit-tests
     - TEST_SUITE=tests
     - TEST_SUITE=mypy

--- a/tests/pydocstyle_run.sh
+++ b/tests/pydocstyle_run.sh
@@ -9,6 +9,6 @@ IGNORED="D202,D203,D213,D406,D407,D408,D409,D413"
 # These are currently turned off on master branch
 # because of the missing docstrings. However, they should
 # be switched on in the future.
-IGNORED="D100,D101,D102,D103,D104,$IGNORED"
+IGNORED="D100,D101,D102,D103,D104,D107,$IGNORED"
 
 pydocstyle --ignore=$IGNORED neuralmonkey


### PR DESCRIPTION
The docstring style is unified to comply with current pydocstyle setting (see tests/pydocstyle_run.sh for list of ignored messages).

Due to the missing docstrings (~400 pydocstyle error messages), the pydocstyle messages related to missing documentation will be ignored for the time being. However, after everything is properly documented, they should be switched on again.