### PR TITLE
Specifying variables in trainer

### DIFF
--- a/neuralmonkey/learning_utils.py
+++ b/neuralmonkey/learning_utils.py
@@ -651,7 +651,7 @@ def _skip_lines(start_offset: int,
         log("Skipped {} instances".format(skipped_instances))
 
 
-def _log_model_variables(var_list: Optional[List[tf.Variable]] = None) -> None:
+def _log_model_variables(var_list: List[tf.Variable] = None) -> None:
     trainable_vars = tf.trainable_variables()
     if not var_list:
         var_list = trainable_vars

--- a/neuralmonkey/trainers/cross_entropy_trainer.py
+++ b/neuralmonkey/trainers/cross_entropy_trainer.py
@@ -16,7 +16,7 @@ def xent_objective(decoder, weight=None) -> Objective:
         weight=weight,
     )
 
-# pylint: disable=too-few-public-methods
+# pylint: disable=too-few-public-methods,too-many-arguments
 
 
 class CrossEntropyTrainer(GenericTrainer):
@@ -24,7 +24,9 @@ class CrossEntropyTrainer(GenericTrainer):
     def __init__(self, decoders: List[Any],
                  decoder_weights: Optional[List[ObjectiveWeight]] = None,
                  l1_weight=0., l2_weight=0.,
-                 clip_norm=False, optimizer=None, global_step=None) -> None:
+                 clip_norm=False, optimizer=None, global_step=None,
+                 var_scopes: Optional[List[str]] = None,
+                 var_collection: Optional[str] = None) -> None:
         check_argument_types()
 
         if decoder_weights is None:
@@ -39,4 +41,5 @@ class CrossEntropyTrainer(GenericTrainer):
                       for dec, w in zip(decoders, decoder_weights)]
         super(CrossEntropyTrainer, self).__init__(
             objectives, l1_weight, l2_weight, clip_norm=clip_norm,
-            optimizer=optimizer, global_step=global_step)
+            optimizer=optimizer, global_step=global_step,
+            var_scopes=var_scopes, var_collection=var_collection)

--- a/neuralmonkey/trainers/cross_entropy_trainer.py
+++ b/neuralmonkey/trainers/cross_entropy_trainer.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, List
 
 from typeguard import check_argument_types
 
@@ -22,11 +22,11 @@ def xent_objective(decoder, weight=None) -> Objective:
 class CrossEntropyTrainer(GenericTrainer):
 
     def __init__(self, decoders: List[Any],
-                 decoder_weights: Optional[List[ObjectiveWeight]] = None,
+                 decoder_weights: List[ObjectiveWeight] = None,
                  l1_weight=0., l2_weight=0.,
                  clip_norm=False, optimizer=None, global_step=None,
-                 var_scopes: Optional[List[str]] = None,
-                 var_collection: Optional[str] = None) -> None:
+                 var_scopes: List[str] = None,
+                 var_collection: str = None) -> None:
         check_argument_types()
 
         if decoder_weights is None:

--- a/neuralmonkey/trainers/generic_trainer.py
+++ b/neuralmonkey/trainers/generic_trainer.py
@@ -26,16 +26,17 @@ class GenericTrainer(object):
 
     def __init__(self, objectives: List[Objective],
                  l1_weight: float = 0.0, l2_weight: float = 0.0,
-                 clip_norm: Optional[float] = None, optimizer=None,
-                 global_step=None, var_scopes: Optional[List[str]] = None,
-                 var_collection: Optional[str] = None) -> None:
+                 clip_norm: float = None, optimizer=None,
+                 global_step=None, var_scopes: List[str] = None,
+                 var_collection: str = None) -> None:
 
-        if not var_collection:
+        if var_collection is None:
             var_collection = tf.GraphKeys.TRAINABLE_VARIABLES
-        if not var_scopes:
+        if var_scopes is None:
             var_scopes = [None]
         var_lists = [tf.get_collection(var_collection, scope)
                      for scope in var_scopes]
+        # Flatten the list of lists
         self.var_list = [var for var_list in var_lists for var in var_list]
 
         with tf.name_scope("trainer"):


### PR DESCRIPTION
This adds two options to the trainer to control which variables should be trained: `var_collection` (e.g. `"trainable_variables"`) and `var_scopes` (a list of variable scope names).