### PR TITLE
Make RepresentationRunner produce np.ndarray instead of list

### DIFF
--- a/neuralmonkey/runners/representation_runner.py
+++ b/neuralmonkey/runners/representation_runner.py
@@ -32,7 +32,7 @@ class RepresentationExecutable(Executable):
         vectors = results[self._used_session]["encoded"]
 
         self.result = ExecutionResult(
-            outputs=vectors.tolist(),
+            outputs=vectors,
             losses=[],
             scalar_summaries=None,
             histogram_summaries=None,

--- a/tests/bahdanau.ini
+++ b/tests/bahdanau.ini
@@ -49,6 +49,7 @@ s_target="tests/data/val.tc.de"
 ; access the data series via the string identifiers defined here.
 class=dataset.load_dataset_from_files
 s_source="tests/data/val.tc.en"
+s_encoded_out="tests/outputs/bahdanau/encoded"
 
 
 [encoder_vocabulary]


### PR DESCRIPTION
Without this change, the following error is raised when trying to save the runner's output series to a file:
```
Traceback (most recent call last):
  File "bin/neuralmonkey-train", line 6, in <module>
    main()
  File "/a/merkur3/cifka/build/neuralmonkey/bin/neuralmonkey/train.py", line 226, in main
    initial_variables=cfg.model.initial_variables)
  File "/a/merkur3/cifka/build/neuralmonkey/bin/neuralmonkey/learning_utils.py", line 294, in training_loop
    write_out=True, batch_size=runners_batch_size)
  File "/a/merkur3/cifka/build/neuralmonkey/bin/neuralmonkey/learning_utils.py", line 424, in run_on_dataset
    [" ".join(sent) + "\n" for sent in data])
  File "/a/merkur3/cifka/build/neuralmonkey/bin/neuralmonkey/learning_utils.py", line 424, in <listcomp>
    [" ".join(sent) + "\n" for sent in data])
TypeError: sequence item 0: expected str instance, float found
```
I added a line to `tests/bahdanau.ini` to test that this now works.