### PR TITLE
Enable referencing attributes in config

### DIFF
--- a/neuralmonkey/config/builder.py
+++ b/neuralmonkey/config/builder.py
@@ -6,6 +6,7 @@ specified by the experiment configuration.
 
 import collections
 import importlib
+from argparse import Namespace
 from inspect import signature, isclass, isfunction
 from typing import Any, Dict, Set
 
@@ -203,6 +204,7 @@ def build_config(config_dicts: Dict[str, Any],
     existing_objects = collections.OrderedDict()  # type: Dict[str, Any]
 
     main_config = config_dicts["main"]
+    existing_objects["main"] = Namespace(**main_config)
 
     configuration = collections.OrderedDict()  # type: Dict[str, Any]
     # TODO ensure tf_manager goes last in a better way

--- a/neuralmonkey/config/builder.py
+++ b/neuralmonkey/config/builder.py
@@ -64,16 +64,16 @@ class ClassSymbol(object):
 class ObjectRef(object):
     """Represents a named object or its attribute in configuration."""
 
-    def __init__(self, expression: str):
-        self.name, *self.attr_chain = expression.split('.')
-        self.obj_ = None
+    def __init__(self, expression: str) -> None:
+        self.name, *self.attr_chain = expression.split(".")
+        self._obj = None
 
     def bind(self, value: Any):
-        self.obj_ = value
+        self._obj = value
 
     @property
     def target(self) -> Any:
-        value = self.obj_
+        value = self._obj
         for attr in self.attr_chain:
             value = getattr(value, attr)
         return value

--- a/neuralmonkey/config/parsing.py
+++ b/neuralmonkey/config/parsing.py
@@ -8,18 +8,19 @@ import time
 from typing import Any, Dict, Callable, Iterable, IO, List, Tuple, Optional
 # pylint: enable=unused-import
 
-from neuralmonkey.config.builder import ClassSymbol
+from neuralmonkey.config.builder import ClassSymbol, ObjectRef
 from neuralmonkey.config.exceptions import IniError
 from neuralmonkey.logging import log
 
 LINE_NUM = re.compile(r"^(.*) ([0-9]+)$")
 
-OBJECT_REF = re.compile(r"^<([a-zA-Z][a-zA-Z0-9_]*)>$")
 INTEGER = re.compile(r"^[0-9]+$")
 FLOAT = re.compile(r"^[0-9]*\.[0-9]*(e[+-]?[0-9]+)?$")
 LIST = re.compile(r"\[([^]]*)\]")
 TUPLE = re.compile(r"\(([^]]+)\)")
 STRING = re.compile(r'^"(.*)"$')
+OBJECT_REF = re.compile(
+    r"^<([a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)*)>$")
 CLASS_NAME = re.compile(
     r"^_*[a-zA-Z][a-zA-Z0-9_]*(\._*[a-zA-Z][a-zA-Z0-9_]*)+$")
 
@@ -39,7 +40,7 @@ def _keyval_parser_dict() -> Dict[Any, Callable]:
         FLOAT: float,
         STRING: lambda x: STRING.match(x).group(1),
         CLASS_NAME: _parse_class_name,
-        OBJECT_REF: lambda x: "object:" + OBJECT_REF.match(x).group(1),
+        OBJECT_REF: lambda x: ObjectRef(OBJECT_REF.match(x).group(1)),
         LIST: _parse_list,
         TUPLE: _parse_tuple
     }


### PR DESCRIPTION
This adds attribute referencing as described in #576. (closes #576)

I'm also replacing the `"object:"` prefix with the `ObjectRef` class, which takes care of resolving the attribute references.