### PR TITLE
Wrappers on model parts that prevent gradient propagation

### DIFF
--- a/neuralmonkey/model/gradient_blocking.py
+++ b/neuralmonkey/model/gradient_blocking.py
@@ -1,0 +1,67 @@
+"""Module that blocks gradient propagation to model parts."""
+import tensorflow as tf
+from typeguard import check_argument_types
+
+from neuralmonkey.model.stateful import (
+    Stateful, TemporalStateful, SpatialStateful,
+    TemporalStatefulWithOutput, SpatialStatefulWithOutput)
+
+
+# pylint: disable=too-few-public-methods
+class StatefulView(Stateful):
+
+    def __init__(self, blocked_object: Stateful) -> None:
+        check_argument_types()
+        self._output = tf.stop_gradient(blocked_object.output)
+
+    @property
+    def output(self) -> tf.Tensor:
+        return self._output
+# pylint: enable=too-few-public-methods
+
+
+class TemporalStatefulView(TemporalStateful):
+    def __init__(self, blocked_object: TemporalStateful) -> None:
+        check_argument_types()
+        self._blocked_object = blocked_object
+        self._states = tf.stop_gradient(blocked_object.temporal_states)
+
+    @property
+    def temporal_states(self) -> tf.Tensor:
+        return self._states
+
+    @property
+    def temporal_mask(self) -> tf.Tensor:
+        return self._blocked_object.temporal_mask
+
+
+class SpatialStatefulView(SpatialStateful):
+    def __init__(self, blocked_object: SpatialStateful) -> None:
+        check_argument_types()
+        self._blocked_object = blocked_object
+        self._states = tf.stop_gradient(blocked_object.spatial_states)
+
+    @property
+    def spatial_states(self) -> tf.Tensor:
+        return self._states
+
+    @property
+    def spatial_mask(self) -> tf.Tensor:
+        return self._blocked_object.spatial_mask
+
+
+# pylint: disable=abstract-method
+class TemporalStatefulWithOutputView(TemporalStatefulWithOutput,
+                                     TemporalStatefulView, StatefulView):
+    def __init__(self, blocked_object: TemporalStatefulWithOutput) -> None:
+        check_argument_types()
+        TemporalStatefulView.__init__(self, blocked_object)
+        StatefulView.__init__(self, blocked_object)
+
+
+class SpatialStatefulWithOutputView(SpatialStatefulWithOutput,
+                                    SpatialStatefulView, StatefulView):
+    def __init__(self, blocked_object: SpatialStatefulWithOutput) -> None:
+        check_argument_types()
+        SpatialStatefulView.__init__(self, blocked_object)
+        StatefulView.__init__(self, blocked_object)

--- a/tests/bpe.ini
+++ b/tests/bpe.ini
@@ -77,6 +77,10 @@ conv_features=10
 encoder_layers=2
 input_sequence=<encoder_input>
 
+[encoder_frozen]
+class=model.gradient_blocking.TemporalStatefulWithOutputView
+blocked_object=<encoder>
+
 [attention]
 class=attention.Attention
 state_size=8

--- a/tests/tests_run.sh
+++ b/tests/tests_run.sh
@@ -7,7 +7,8 @@ export PYTHONFAULTHANDLER=1
 
 bin/neuralmonkey-train tests/vocab.ini
 bin/neuralmonkey-train tests/bahdanau.ini
-bin/neuralmonkey-train tests/bpe.ini
+NEURALMONKEY_STRICT= bin/neuralmonkey-train tests/bpe.ini
+bin/neuralmonkey-train tests/bpe.ini -s 'decoder.encoders=[<encoder_frozen>]'
 #bin/neuralmonkey-train tests/alignment.ini
 bin/neuralmonkey-train tests/post-edit.ini
 bin/neuralmonkey-train tests/factored.ini

--- a/tests/tests_run.sh
+++ b/tests/tests_run.sh
@@ -8,7 +8,7 @@ export PYTHONFAULTHANDLER=1
 bin/neuralmonkey-train tests/vocab.ini
 bin/neuralmonkey-train tests/bahdanau.ini
 NEURALMONKEY_STRICT= bin/neuralmonkey-train tests/bpe.ini
-bin/neuralmonkey-train tests/bpe.ini -s 'decoder.encoders=[<encoder_frozen>]'
+bin/neuralmonkey-train tests/bpe.ini -s 'decoder.encoders=[<encoder_frozen>]' -s 'main.initial_variables=["tests/outputs/bpe/variables.data"]'
 #bin/neuralmonkey-train tests/alignment.ini
 bin/neuralmonkey-train tests/post-edit.ini
 bin/neuralmonkey-train tests/factored.ini


### PR DESCRIPTION
This PR introduces simple wrappers/views on various model part interfaces. It calls `tf.stop_gradient` on outputs of the model parts and provides the same interface as its parent.