### PR TITLE
Variable substitution in config files

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -55,6 +55,34 @@ On top of that, there are two compound types syntax from Python:
    ``("target", <ter>)``)
 
 
+Variables
+---------
+
+The configuration file can contain a ``[vars]`` section, defining
+variables which can be used in the rest of the config file. Their values
+can have any of the types listed above. To reference a variable, use its
+name preceded by a dollar sign (e.g. ``$variable``). Variable values can
+also be included inside strings using the :py:func:`str.format` notation.
+For example:
+
+.. code-block:: ini
+
+  [vars]
+  parent_dir="experiments"
+  drop_keep_p=0.5
+  output_dir="{parent_dir}/test_drop{drop_keep_p:.2f}"
+  prefix="my"
+ 
+  [main]
+  output=$output_dir
+ 
+  ...
+  
+  [encoder]
+  name="{prefix}_encoder"
+  dropout_keep_prob=$drop_keep_p
+  ...
+
 Interpretation
 --------------
 
@@ -73,8 +101,8 @@ you write ``<session_manager>`` in a right-hand side and a section
 a Python object based on the key-value pairs in the section
 ``[session_manager]``.)
 
-Every section except the ``[main]`` section needs to contain the key
-``class`` with
+Every section except the ``[main]`` and ``[vars]`` sections needs
+to contain the key ``class`` with
 a value of Python name which is a callable (e.g., a class constructor or a
 function). The other keys are used as named arguments of the callable.
 
@@ -86,6 +114,8 @@ can be configured in Neural Monkey with respect to TensorFlow.  The
 configuration of the TensorFlow manager is specified within the INI file in
 section with class :py:class:`neuralmonkey.tf_manager.TensorFlowManager`::
 
+.. code-block:: ini
+
   [session_manager]
   class=tf_manager.TensorFlowManager
   ...
@@ -93,10 +123,11 @@ section with class :py:class:`neuralmonkey.tf_manager.TensorFlowManager`::
 The ``session_manager`` configuration object is then referenced from the main
 section of the configuration::
 
+.. code-block:: ini
+
   [main]
   tf_manager=<session_manager>
   ...
-
 
 
 Training on GPU
@@ -115,9 +146,13 @@ needed. This can create problems with memory
 fragmentation. If you know that you can allocate the whole memory at once
 add the following parameter the ``session_manager`` section::
 
+.. code-block:: ini
+
   gpu_allow_growth=False
 
 You can also restrict TensorFlow to use only a fixed proportion of GPU memory::
+
+.. code-block:: ini
 
   per_process_gpu_memory_fraction=0.65
 
@@ -126,6 +161,8 @@ This parameter tells TensorFlow to use only 65% of GPU memory.
 With the default ``gpu_allow_growth=True``, it makes sense to monitor memory
 consumption. Neural Monkey can include a short summary total GPU memory used
 in the periodic log line. Just set::
+
+.. code-block:: ini
 
   report_gpu_memory_consumption=True
 
@@ -142,6 +179,8 @@ Training on CPUs
 TensorFlow Manager settings also affect training on CPUs.
 
 The line::
+
+.. code-block:: ini
 
   num_threads=4
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -112,7 +112,7 @@ Session Manager
 This and following sections describes TensorFlow Manager from the users' perspective: what
 can be configured in Neural Monkey with respect to TensorFlow.  The
 configuration of the TensorFlow manager is specified within the INI file in
-section with class :py:class:`neuralmonkey.tf_manager.TensorFlowManager`::
+section with class :py:class:`neuralmonkey.tf_manager.TensorFlowManager`:
 
 .. code-block:: ini
 
@@ -121,7 +121,7 @@ section with class :py:class:`neuralmonkey.tf_manager.TensorFlowManager`::
   ...
 
 The ``session_manager`` configuration object is then referenced from the main
-section of the configuration::
+section of the configuration:
 
 .. code-block:: ini
 
@@ -144,13 +144,13 @@ Neural Monkey.
 By default, Neural Monkey prefers to allocate GPU memory stepwise only as
 needed. This can create problems with memory
 fragmentation. If you know that you can allocate the whole memory at once
-add the following parameter the ``session_manager`` section::
+add the following parameter the ``session_manager`` section:
 
 .. code-block:: ini
 
   gpu_allow_growth=False
 
-You can also restrict TensorFlow to use only a fixed proportion of GPU memory::
+You can also restrict TensorFlow to use only a fixed proportion of GPU memory:
 
 .. code-block:: ini
 
@@ -160,7 +160,7 @@ This parameter tells TensorFlow to use only 65% of GPU memory.
 
 With the default ``gpu_allow_growth=True``, it makes sense to monitor memory
 consumption. Neural Monkey can include a short summary total GPU memory used
-in the periodic log line. Just set::
+in the periodic log line. Just set:
 
 .. code-block:: ini
 
@@ -178,7 +178,7 @@ Training on CPUs
 
 TensorFlow Manager settings also affect training on CPUs.
 
-The line::
+The line:
 
 .. code-block:: ini
 

--- a/neuralmonkey/config/parsing.py
+++ b/neuralmonkey/config/parsing.py
@@ -19,7 +19,7 @@ FLOAT = re.compile(r"^[0-9]*\.[0-9]*(e[+-]?[0-9]+)?$")
 LIST = re.compile(r"\[([^]]*)\]")
 TUPLE = re.compile(r"\(([^]]+)\)")
 STRING = re.compile(r'^"(.*)"$')
-VAR_REF = re.compile(r'^\$([a-zA-Z][a-zA-Z0-9_]*)$')
+VAR_REF = re.compile(r"^\$([a-zA-Z][a-zA-Z0-9_]*)$")
 OBJECT_REF = re.compile(
     r"^<([a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)*)>$")
 CLASS_NAME = re.compile(
@@ -40,7 +40,7 @@ def _keyval_parser_dict() -> Dict[Any, Callable]:
         INTEGER: lambda x, _: int(x),
         FLOAT: lambda x, _: float(x),
         STRING: lambda x, vars_dict:
-            STRING.match(x).group(1).format(**vars_dict),
+                STRING.match(x).group(1).format(**vars_dict),
         VAR_REF: lambda x, vars_dict: vars_dict[VAR_REF.match(x).group(1)],
         CLASS_NAME: _parse_class_name,
         OBJECT_REF: lambda x, _: ObjectRef(OBJECT_REF.match(x).group(1)),
@@ -82,7 +82,7 @@ def _split_on_commas(string: str) -> List[str]:
     return items
 
 
-def _parse_list(string: str, vars_dict: Dict) -> List[Any]:
+def _parse_list(string: str, vars_dict: Dict[str, Any]) -> List[Any]:
     """Parse the string recursively as a list."""
 
     matched_content = LIST.match(string).group(1)
@@ -99,7 +99,7 @@ def _parse_list(string: str, vars_dict: Dict) -> List[Any]:
     return values
 
 
-def _parse_tuple(string: str, vars_dict: Dict) -> Tuple[Any, ...]:
+def _parse_tuple(string: str, vars_dict: Dict[str, Any]) -> Tuple[Any, ...]:
     """Parse the string recursively as a tuple."""
 
     items = _split_on_commas(TUPLE.match(string).group(1))
@@ -108,13 +108,13 @@ def _parse_tuple(string: str, vars_dict: Dict) -> Tuple[Any, ...]:
     return tuple(values)
 
 
-def _parse_class_name(string: str, vars_dict: Dict) -> ClassSymbol:
+def _parse_class_name(string: str, vars_dict: Dict[str, Any]) -> ClassSymbol:
     """Parse the string as a module or class name."""
     del vars_dict
     return ClassSymbol(string)
 
 
-def _parse_value(string: str, vars_dict: Dict) -> Any:
+def _parse_value(string: str, vars_dict: Dict[str, Any]) -> Any:
     """Parse the value recursively according to the Nerualmonkey grammar.
 
     Arguments:
@@ -185,10 +185,10 @@ def parse_file(config_file: Iterable[str],
         for change in changes:
             _apply_change(config, change)
 
-    vars_dict = OrderedDict()
-    vars_dict['TIME'] = time.strftime("%Y-%m-%d-%H-%M-%S")
+    vars_dict = OrderedDict()  # type: Dict[str, Any]
+    vars_dict["TIME"] = time.strftime("%Y-%m-%d-%H-%M-%S")
 
-    def parse_section(section: str, output_dict: OrderedDict):
+    def parse_section(section: str, output_dict: Dict[str, Any]):
         for key, (lineno, value_string) in config[section].items():
             try:
                 value = _parse_value(value_string, vars_dict)

--- a/neuralmonkey/config/parsing.py
+++ b/neuralmonkey/config/parsing.py
@@ -39,8 +39,8 @@ def _keyval_parser_dict() -> Dict[Any, Callable]:
     return {
         INTEGER: lambda x, _: int(x),
         FLOAT: lambda x, _: float(x),
-        STRING: lambda x, vars_dict:
-                STRING.match(x).group(1).format(**vars_dict),
+        STRING:
+            lambda x, vars_dict: STRING.match(x).group(1).format(**vars_dict),
         VAR_REF: lambda x, vars_dict: vars_dict[VAR_REF.match(x).group(1)],
         CLASS_NAME: _parse_class_name,
         OBJECT_REF: lambda x, _: ObjectRef(OBJECT_REF.match(x).group(1)),

--- a/neuralmonkey/config/parsing.py
+++ b/neuralmonkey/config/parsing.py
@@ -19,6 +19,7 @@ FLOAT = re.compile(r"^[0-9]*\.[0-9]*(e[+-]?[0-9]+)?$")
 LIST = re.compile(r"\[([^]]*)\]")
 TUPLE = re.compile(r"\(([^]]+)\)")
 STRING = re.compile(r'^"(.*)"$')
+VAR_REF = re.compile(r'^\$([a-zA-Z][a-zA-Z0-9_]*)$')
 OBJECT_REF = re.compile(
     r"^<([a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)*)>$")
 CLASS_NAME = re.compile(
@@ -36,11 +37,13 @@ CONSTANTS = {
 # functions which are not defined yet
 def _keyval_parser_dict() -> Dict[Any, Callable]:
     return {
-        INTEGER: int,
-        FLOAT: float,
-        STRING: lambda x: STRING.match(x).group(1),
+        INTEGER: lambda x, _: int(x),
+        FLOAT: lambda x, _: float(x),
+        STRING: lambda x, vars_dict:
+            STRING.match(x).group(1).format(**vars_dict),
+        VAR_REF: lambda x, vars_dict: vars_dict[VAR_REF.match(x).group(1)],
         CLASS_NAME: _parse_class_name,
-        OBJECT_REF: lambda x: ObjectRef(OBJECT_REF.match(x).group(1)),
+        OBJECT_REF: lambda x, _: ObjectRef(OBJECT_REF.match(x).group(1)),
         LIST: _parse_list,
         TUPLE: _parse_tuple
     }
@@ -79,7 +82,7 @@ def _split_on_commas(string: str) -> List[str]:
     return items
 
 
-def _parse_list(string: str) -> List[Any]:
+def _parse_list(string: str, vars_dict: Dict) -> List[Any]:
     """Parse the string recursively as a list."""
 
     matched_content = LIST.match(string).group(1)
@@ -87,7 +90,7 @@ def _parse_list(string: str) -> List[Any]:
         return []
 
     items = _split_on_commas(matched_content)
-    values = [_parse_value(val) for val in items]
+    values = [_parse_value(val, vars_dict) for val in items]
     types = [type(val) for val in values]
 
     if len(set(types)) > 1:
@@ -96,25 +99,27 @@ def _parse_list(string: str) -> List[Any]:
     return values
 
 
-def _parse_tuple(string: str) -> Tuple[Any, ...]:
+def _parse_tuple(string: str, vars_dict: Dict) -> Tuple[Any, ...]:
     """Parse the string recursively as a tuple."""
 
     items = _split_on_commas(TUPLE.match(string).group(1))
-    values = [_parse_value(val) for val in items]
+    values = [_parse_value(val, vars_dict) for val in items]
 
     return tuple(values)
 
 
-def _parse_class_name(string: str) -> ClassSymbol:
+def _parse_class_name(string: str, vars_dict: Dict) -> ClassSymbol:
     """Parse the string as a module or class name."""
+    del vars_dict
     return ClassSymbol(string)
 
 
-def _parse_value(string: str) -> Any:
+def _parse_value(string: str, vars_dict: Dict) -> Any:
     """Parse the value recursively according to the Nerualmonkey grammar.
 
     Arguments:
         string: the string to be parsed
+        vars_dict: a dictionary of variables for substitution
     """
 
     if string in CONSTANTS:
@@ -122,7 +127,7 @@ def _parse_value(string: str) -> Any:
 
     for matcher, parser in _keyval_parser_dict().items():
         if matcher.match(string):
-            return parser(string)
+            return parser(string, vars_dict)
 
     raise Exception("Cannot parse value: '{}'.".format(string)) from None
 
@@ -173,7 +178,6 @@ def parse_file(config_file: Iterable[str],
     """Parse an INI file and creates all values."""
 
     parsed_dicts = OrderedDict()  # type: Dict[str, Any]
-    time_stamp = time.strftime("%Y-%m-%d-%H-%M-%S")
 
     config = _parse_ini(config_file)
 
@@ -181,15 +185,13 @@ def parse_file(config_file: Iterable[str],
         for change in changes:
             _apply_change(config, change)
 
-    for section in config:
-        parsed_dicts[section] = OrderedDict()
-        for key, (lineno, value_string) in config[section].items():
-            # expansion
-            # TODO do this using **kwargs with dict from names to values
-            value_string = re.sub(r"\$TIME", time_stamp, value_string)
+    vars_dict = OrderedDict()
+    vars_dict['TIME'] = time.strftime("%Y-%m-%d-%H-%M-%S")
 
+    def parse_section(section: str, output_dict: OrderedDict):
+        for key, (lineno, value_string) in config[section].items():
             try:
-                value = _parse_value(value_string)
+                value = _parse_value(value_string, vars_dict)
             except IniError as exc:
                 raise
             except Exception as exc:
@@ -197,7 +199,15 @@ def parse_file(config_file: Iterable[str],
                     lineno, "Cannot parse value: '{}'.".format(value_string),
                     exc) from None
 
-            parsed_dicts[section][key] = value
+            output_dict[key] = value
+
+    if "vars" in config:
+        parse_section("vars", vars_dict)
+
+    for section in config:
+        if section != "vars":
+            parsed_dicts[section] = OrderedDict()
+            parse_section(section, parsed_dicts[section])
 
     # also return the unparsed config dict; need to remove line numbers
     raw_config = OrderedDict([

--- a/neuralmonkey/train.py
+++ b/neuralmonkey/train.py
@@ -58,9 +58,13 @@ def _main() -> None:
     parser.add_argument("config", metavar="INI-FILE",
                         help="the configuration file for the experiment")
     parser.add_argument("-s", "--set", type=str, metavar="SETTING",
-                        action="append", dest="config_changes",
+                        action="append", dest="config_changes", default=[],
                         help="override an option in the configuration; the "
                         "syntax is [section.]option=value")
+    parser.add_argument("-v", "--var", type=str, metavar="VAR", default=[],
+                        action="append", dest="config_vars",
+                        help="set a variable in the configuration; the "
+                        "syntax is var=value (shorthand for -s vars.var=value)")
     parser.add_argument("-i", "--init", dest="init_only", action="store_true",
                         help="initialize the experiment directory and exit "
                         "without building the model")
@@ -72,6 +76,7 @@ def _main() -> None:
     # define valid parameters and defaults
     cfg = create_config()
     # load the params from the config file, getting also the simple arguments
+    args.config_changes.extend('vars.{}'.format(s) for s in args.config_vars)
     cfg.load_file(args.config, changes=args.config_changes)
     # various things like randseed or summarywriter should be set up here
     # so that graph building can be recorded

--- a/neuralmonkey/train.py
+++ b/neuralmonkey/train.py
@@ -63,8 +63,8 @@ def _main() -> None:
                         "syntax is [section.]option=value")
     parser.add_argument("-v", "--var", type=str, metavar="VAR", default=[],
                         action="append", dest="config_vars",
-                        help="set a variable in the configuration; the "
-                        "syntax is var=value (shorthand for -s vars.var=value)")
+                        help="set a variable in the configuration; the syntax "
+                        "is var=value (shorthand for -s vars.var=value)")
     parser.add_argument("-i", "--init", dest="init_only", action="store_true",
                         help="initialize the experiment directory and exit "
                         "without building the model")
@@ -76,7 +76,7 @@ def _main() -> None:
     # define valid parameters and defaults
     cfg = create_config()
     # load the params from the config file, getting also the simple arguments
-    args.config_changes.extend('vars.{}'.format(s) for s in args.config_vars)
+    args.config_changes.extend("vars.{}".format(s) for s in args.config_vars)
     cfg.load_file(args.config, changes=args.config_changes)
     # various things like randseed or summarywriter should be set up here
     # so that graph building can be recorded

--- a/tests/small.ini
+++ b/tests/small.ini
@@ -1,9 +1,17 @@
 ;; Small training test
 
+[vars]
+; testing variable substitution
+parent_dir="tests/outputs"
+output_dir="{parent_dir}/small"
+drop_keep_p=0.5
+dropout=$drop_keep_p
+bleu=<bleu>
+
 [main]
-name="translation"
+name="translation at {TIME} with {dropout:.2f} dropout"
 tf_manager=<tf_manager>
-output="tests/outputs/small"
+output="{output_dir}"
 overwrite_output_dir=True
 batch_size=16
 epochs=2
@@ -12,7 +20,7 @@ val_dataset=<val_data>
 trainer=<trainer>
 runners=[<runner>]
 postprocess=None
-evaluation=[("target", <bleu>), ("target", evaluators.ter.TER), ("target", evaluators.chrf.ChrF3)]
+evaluation=[("target", $bleu), ("target", evaluators.ter.TER), ("target", evaluators.chrf.ChrF3)]
 logging_period=20
 validation_period=60
 runners_batch_size=1
@@ -56,7 +64,7 @@ name="sentence_encoder"
 rnn_size=7
 max_input_len=5
 embedding_size=11
-dropout_keep_prob=0.5
+dropout_keep_prob=$drop_keep_p
 data_id="source"
 vocabulary=<encoder_vocabulary>
 rnn_cell="NematusGRU"
@@ -78,7 +86,7 @@ encoders=[<encoder>]
 attentions=[<attention>]
 rnn_size=8
 embedding_size=9
-dropout_keep_prob=0.5
+dropout_keep_prob=$drop_keep_p
 data_id="target"
 max_output_len=1
 vocabulary=<decoder_vocabulary>


### PR DESCRIPTION
- Variable substitution in config files, both inside strings (using the `str.format` curly bracket syntax) and as raw values. Variables are defined in the `[vars]` section. (See [small.ini](https://github.com/ufal/neuralmonkey/pull/619/files#diff-39c41aeabf40399dbb436724b5ebac0d) for examples.)
- A convenience command-line option `-v` for setting variables.

Discussed in #576.