### PR TITLE
Update CTC

### DIFF
--- a/neuralmonkey/decoders/ctc_decoder.py
+++ b/neuralmonkey/decoders/ctc_decoder.py
@@ -2,6 +2,7 @@ from typing import cast, Iterable, List
 
 import numpy as np
 import tensorflow as tf
+from typeguard import check_argument_types
 
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.model.model_part import ModelPart, FeedDict
@@ -27,6 +28,7 @@ class CTCDecoder(ModelPart):
                  beam_width: int = 1,
                  save_checkpoint: str = None,
                  load_checkpoint: str = None) -> None:
+        check_argument_types()
         ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
 
         self.encoder = encoder

--- a/neuralmonkey/decoders/ctc_decoder.py
+++ b/neuralmonkey/decoders/ctc_decoder.py
@@ -1,4 +1,4 @@
-from typing import Any, cast, Iterable, List, Optional
+from typing import cast, Iterable, List, Optional
 
 import numpy as np
 import tensorflow as tf

--- a/neuralmonkey/vocabulary.py
+++ b/neuralmonkey/vocabulary.py
@@ -536,15 +536,15 @@ class Vocabulary(collections.Sized):
         Returns:
             List of lists of words.
         """
-        sentences = [[] for _ in
-                     range(vectors[0].shape[0])]  # type: List[List[str]]
+        sentences = [[] for _
+                     in range(vectors.shape[1])]  # type: List[List[str]]
 
         for vec in vectors:
             for sentence, word_i in zip(sentences, vec):
                 if not sentence or sentence[-1] != END_TOKEN:
                     sentence.append(self.index_to_word[word_i])
 
-        return [s[:-1] if s[-1] == END_TOKEN else s for s in sentences]
+        return [s[:-1] if s and s[-1] == END_TOKEN else s for s in sentences]
 
     def save_wordlist(self, path: str, overwrite: bool = False,
                       save_frequencies: bool = False,

--- a/neuralmonkey/vocabulary.py
+++ b/neuralmonkey/vocabulary.py
@@ -11,7 +11,7 @@ import os
 import random
 
 # pylint: disable=unused-import
-from typing import List, Optional, Tuple, Dict
+from typing import List, Optional, Tuple, Dict, Union
 # pylint: enable=unused-import
 
 import numpy as np
@@ -526,8 +526,9 @@ class Vocabulary(collections.Sized):
 
         return word_indices, weights
 
-    def vectors_to_sentences(self,
-                             vectors: np.ndarray) -> List[List[str]]:
+    def vectors_to_sentences(
+            self,
+            vectors: Union[List[np.ndarray], np.ndarray]) -> List[List[str]]:
         """Convert vectors of indexes of vocabulary items to lists of words.
 
         Arguments:
@@ -536,8 +537,15 @@ class Vocabulary(collections.Sized):
         Returns:
             List of lists of words.
         """
-        sentences = [[] for _
-                     in range(vectors.shape[1])]  # type: List[List[str]]
+        if isinstance(vectors, list):
+            batch_size = vectors[0].shape[0]
+        elif isinstance(vectors, np.ndarray):
+            batch_size = vectors.shape[1]
+        else:
+            raise TypeError(
+                "Unexpected type of decoder output: {}".format(type(vectors)))
+
+        sentences = [[] for _ in range(batch_size)]  # type: List[List[str]]
 
         for vec in vectors:
             for sentence, word_i in zip(sentences, vec):

--- a/neuralmonkey/vocabulary.py
+++ b/neuralmonkey/vocabulary.py
@@ -527,7 +527,7 @@ class Vocabulary(collections.Sized):
         return word_indices, weights
 
     def vectors_to_sentences(self,
-                             vectors: List[np.ndarray]) -> List[List[str]]:
+                             vectors: np.ndarray) -> List[List[str]]:
         """Convert vectors of indexes of vocabulary items to lists of words.
 
         Arguments:

--- a/neuralmonkey/vocabulary.py
+++ b/neuralmonkey/vocabulary.py
@@ -538,6 +538,10 @@ class Vocabulary(collections.Sized):
             List of lists of words.
         """
         if isinstance(vectors, list):
+            if not vectors:
+                raise ValueError(
+                    "Cannot infer batch size because decoder returned an "
+                    "empty output.")
             batch_size = vectors[0].shape[0]
         elif isinstance(vectors, np.ndarray):
             batch_size = vectors.shape[1]


### PR DESCRIPTION
This PR updates CTC decoder such that it does not assume `hiden_states` and `states_mask` on encoder, but uses the `TemporalStateful` abstract class instead.

On top of that, there is a small update in vocabulary that is now able to survive even if empty no symbols are on decoder output (it is sometimes this case in the early stages of training a CTC decoder).