### PR TITLE
Expose objects built from config

### DIFF
--- a/neuralmonkey/config/builder.py
+++ b/neuralmonkey/config/builder.py
@@ -8,7 +8,7 @@ import collections
 import importlib
 from argparse import Namespace
 from inspect import signature, isclass, isfunction
-from typing import Any, Dict, Set
+from typing import Any, Dict, Set, Tuple
 
 from neuralmonkey.logging import debug, warn
 from neuralmonkey.config.exceptions import (ConfigInvalidValueException,
@@ -191,7 +191,8 @@ def instantiate_class(name: str,
 
 def build_config(config_dicts: Dict[str, Any],
                  ignore_names: Set[str],
-                 warn_unused: bool = False) -> Dict[str, Any]:
+                 warn_unused: bool = False) -> Tuple[Dict[str, Any],
+                                                     Dict[str, Any]]:
     """Build the model from the configuration.
 
     Arguments:
@@ -226,4 +227,4 @@ def build_config(config_dicts: Dict[str, Any],
             warn("Configuration contains unused sections: "
                  + str(unused) + ".")
 
-    return configuration
+    return configuration, existing_objects

--- a/neuralmonkey/config/builder.py
+++ b/neuralmonkey/config/builder.py
@@ -199,6 +199,10 @@ def build_config(config_dicts: Dict[str, Any],
         config_dicts: The parsed configuration file
         ignore_names: A set of names that should be ignored during the loading.
         warn_unused: Emit a warning if there are unused sections.
+
+    Returns:
+        A tuple containing a dictionary corresponding to the main section and
+        a dictionary mapping section names to objects.
     """
     if "main" not in config_dicts:
         raise Exception("Configuration does not contain the main block.")

--- a/neuralmonkey/config/configuration.py
+++ b/neuralmonkey/config/configuration.py
@@ -22,6 +22,7 @@ class Configuration(object):
         self.ignored = set()
         self.raw_config = OrderedDict()
         self.config_dict = OrderedDict()
+        self.objects = None
         self.args = None
         self.model = None
 
@@ -87,7 +88,8 @@ class Configuration(object):
         log("Building model based on the config.")
         self._check_loaded_conf()
         try:
-            model = build_config(self.config_dict, self.ignored, warn_unused)
+            model, self.objects = build_config(self.config_dict, self.ignored,
+                                               warn_unused)
         # pylint: disable=broad-except
         except Exception as exc:
             log("Failed to build model: {}".format(exc), color="red")

--- a/scripts/build_config.py
+++ b/scripts/build_config.py
@@ -87,7 +87,7 @@ def main() -> None:
     if args.code:
         imports, statements = _patch_config_builder()
 
-    config = build_config(config_dict, ignore_names=set())
+    config, _ = build_config(config_dict, ignore_names=set())
 
     if args.code:
         print("import argparse\nimport tensorflow as tf")


### PR DESCRIPTION
Return the object dict from `build_config` and store it in `Configuration.objects`. This is to make the objects more easily accessible e.g. when playing with the model from a Jupyter notebook.