### PR TITLE
Configurable initializers

### DIFF
--- a/neuralmonkey/attention/base_attention.py
+++ b/neuralmonkey/attention/base_attention.py
@@ -28,7 +28,7 @@ from typing import NamedTuple, Dict, Optional, Any, Tuple, Union
 import tensorflow as tf
 
 from neuralmonkey.model.stateful import TemporalStateful, SpatialStateful
-from neuralmonkey.model.model_part import ModelPart, FeedDict
+from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
 from neuralmonkey.dataset import Dataset
 
 # pylint: disable=invalid-name
@@ -95,8 +95,10 @@ class BaseAttention(ModelPart):
     def __init__(self,
                  name: str,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
-        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
+        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint,
+                           initializers)
 
         self.query_state_size = None  # type: tf.Tensor
         self._histories = {}  # type: Dict[str, tf.Tensor]

--- a/neuralmonkey/attention/combination.py
+++ b/neuralmonkey/attention/combination.py
@@ -22,6 +22,7 @@ from neuralmonkey.attention.base_attention import (
     BaseAttention, AttentionLoopStateTA, empty_attention_loop_state,
     get_attention_states, get_attention_mask, Attendable)
 from neuralmonkey.checking import assert_shape
+from neuralmonkey.tf_utils import get_variable
 
 
 class MultiAttention(BaseAttention):
@@ -44,7 +45,7 @@ class MultiAttention(BaseAttention):
         self.att_scope_name = "attention_{}".format(name)
 
         with self.use_scope():
-            self.attn_v = tf.get_variable(
+            self.attn_v = get_variable(
                 "attn_v", [1, 1, self.attention_state_size],
                 initializer=tf.glorot_normal_initializer())
     # pylint: enable=unused-argument
@@ -71,7 +72,7 @@ class MultiAttention(BaseAttention):
         assert_shape(vector_value, [-1, -1])
 
         with tf.variable_scope("{}_logit".format(scope)):
-            vector_bias = tf.get_variable(
+            vector_bias = get_variable(
                 "vector_bias", [],
                 initializer=tf.zeros_initializer())
 
@@ -143,9 +144,9 @@ class FlatMultiAttention(MultiAttention):
                 self.get_encoder_projections("logits_projections")
 
             self.encoder_attn_biases = [
-                tf.get_variable(name="attn_bias_{}".format(i),
-                                shape=[],
-                                initializer=tf.zeros_initializer())
+                get_variable(name="attn_bias_{}".format(i),
+                             shape=[],
+                             initializer=tf.zeros_initializer())
                 for i in range(len(self._encoders_tensors))]
 
             if self._share_projections:
@@ -171,12 +172,12 @@ class FlatMultiAttention(MultiAttention):
                 encoder_state_size = encoder_tensor.get_shape()[2].value
                 encoder_tensor_shape = tf.shape(encoder_tensor)
 
-                proj_matrix = tf.get_variable(
+                proj_matrix = get_variable(
                     "proj_matrix_{}".format(i),
                     [encoder_state_size, self.attention_state_size],
                     initializer=tf.glorot_normal_initializer())
 
-                proj_bias = tf.get_variable(
+                proj_bias = get_variable(
                     "proj_bias_{}".format(i),
                     shape=[self.attention_state_size],
                     initializer=tf.zeros_initializer())

--- a/neuralmonkey/attention/combination.py
+++ b/neuralmonkey/attention/combination.py
@@ -22,6 +22,7 @@ from neuralmonkey.attention.base_attention import (
     BaseAttention, AttentionLoopStateTA, empty_attention_loop_state,
     get_attention_states, get_attention_mask, Attendable)
 from neuralmonkey.checking import assert_shape
+from neuralmonkey.model.model_part import InitializerSpecs
 from neuralmonkey.tf_utils import get_variable
 
 
@@ -35,8 +36,10 @@ class MultiAttention(BaseAttention):
                  share_attn_projections: bool = False,
                  use_sentinels: bool = False,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
-        BaseAttention.__init__(self, name, save_checkpoint, load_checkpoint)
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
+        BaseAttention.__init__(self, name, save_checkpoint, load_checkpoint,
+                               initializers)
         self.attentions_in_time = []  # type: List[tf.Tensor]
         self.attention_state_size = attention_state_size
         self._share_projections = share_attn_projections
@@ -108,6 +111,7 @@ class FlatMultiAttention(MultiAttention):
     See equations 8 to 10 in the Attention Combination Strategies paper.
     """
 
+    # pylint: disable=too-many-arguments
     def __init__(self,
                  name: str,
                  encoders: List[Attendable],
@@ -115,7 +119,8 @@ class FlatMultiAttention(MultiAttention):
                  share_attn_projections: bool = False,
                  use_sentinels: bool = False,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
         check_argument_types()
         MultiAttention.__init__(
             self,
@@ -124,7 +129,8 @@ class FlatMultiAttention(MultiAttention):
             share_attn_projections=share_attn_projections,
             use_sentinels=use_sentinels,
             save_checkpoint=save_checkpoint,
-            load_checkpoint=load_checkpoint)
+            load_checkpoint=load_checkpoint,
+            initializers=initializers)
         self._encoders = encoders
 
         # pylint: disable=protected-access
@@ -161,6 +167,7 @@ class FlatMultiAttention(MultiAttention):
                     tf.ones([tf.shape(self._encoders_masks[0])[0], 1]))
 
             self.masks_concat = tf.concat(self._encoders_masks, 1)
+    # pylint: enable=too-many-arguments
 
     def initial_loop_state(self) -> AttentionLoopStateTA:
         return empty_attention_loop_state()
@@ -318,6 +325,7 @@ class HierarchicalMultiAttention(MultiAttention):
     See equations 6 and 7 in the Attention Combination Strategies paper.
     """
 
+    # pylint: disable=too-many-arguments
     def __init__(self,
                  name: str,
                  attentions: List[BaseAttention],
@@ -325,7 +333,8 @@ class HierarchicalMultiAttention(MultiAttention):
                  use_sentinels: bool,
                  share_attn_projections: bool,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
         check_argument_types()
         MultiAttention.__init__(
             self,
@@ -334,9 +343,11 @@ class HierarchicalMultiAttention(MultiAttention):
             use_sentinels=use_sentinels,
             share_attn_projections=share_attn_projections,
             save_checkpoint=save_checkpoint,
-            load_checkpoint=load_checkpoint)
+            load_checkpoint=load_checkpoint,
+            initializers=initializers)
 
         self.attentions = attentions
+    # pylint: enable=too-many-arguments
 
     def initial_loop_state(self) -> HierarchicalLoopState:
         return HierarchicalLoopState(

--- a/neuralmonkey/attention/coverage.py
+++ b/neuralmonkey/attention/coverage.py
@@ -10,9 +10,11 @@ from typeguard import check_argument_types
 
 from neuralmonkey.attention.base_attention import Attendable
 from neuralmonkey.attention.feed_forward import Attention
+from neuralmonkey.model.model_part import InitializerSpecs
 
 
 class CoverageAttention(Attention):
+    # pylint: disable=too-many-arguments
     def __init__(self,
                  name: str,
                  encoder: Attendable,
@@ -20,10 +22,11 @@ class CoverageAttention(Attention):
                  state_size: int = None,
                  max_fertility: int = 5,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
         check_argument_types()
         Attention.__init__(self, name, encoder, dropout_keep_prob, state_size,
-                           save_checkpoint, load_checkpoint)
+                           save_checkpoint, load_checkpoint, initializers)
 
         self.max_fertility = max_fertility
 
@@ -34,6 +37,7 @@ class CoverageAttention(Attention):
 
         self.fertility = 1e-8 + self.max_fertility * tf.sigmoid(
             tf.reduce_sum(self.fertility_weights * self.attention_states, [2]))
+    # pylint: enable=too-many-arguments
 
     def get_energies(self, y: tf.Tensor, weights_in_time: tf.TensorArray):
         weight_sum = tf.cond(

--- a/neuralmonkey/attention/feed_forward.py
+++ b/neuralmonkey/attention/feed_forward.py
@@ -15,6 +15,7 @@ from neuralmonkey.attention.base_attention import (
 from neuralmonkey.decorators import tensor
 from neuralmonkey.nn.utils import dropout
 from neuralmonkey.logging import log
+from neuralmonkey.model.model_part import InitializerSpecs
 from neuralmonkey.tf_utils import get_variable
 
 
@@ -26,9 +27,11 @@ class Attention(BaseAttention):
                  dropout_keep_prob: float = 1.0,
                  state_size: int = None,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
         check_argument_types()
-        BaseAttention.__init__(self, name, save_checkpoint, load_checkpoint)
+        BaseAttention.__init__(self, name, save_checkpoint, load_checkpoint,
+                               initializers)
 
         self.encoder = encoder
         self.dropout_keep_prob = dropout_keep_prob

--- a/neuralmonkey/attention/feed_forward.py
+++ b/neuralmonkey/attention/feed_forward.py
@@ -15,6 +15,7 @@ from neuralmonkey.attention.base_attention import (
 from neuralmonkey.decorators import tensor
 from neuralmonkey.nn.utils import dropout
 from neuralmonkey.logging import log
+from neuralmonkey.tf_utils import get_variable
 
 
 class Attention(BaseAttention):
@@ -63,14 +64,14 @@ class Attention(BaseAttention):
     @tensor
     def query_projection_matrix(self) -> tf.Variable:
         with tf.variable_scope("Attention"):
-            return tf.get_variable(
+            return get_variable(
                 name="attn_query_projection",
                 shape=[self.query_state_size, self.state_size],
                 initializer=tf.glorot_normal_initializer())
 
     @tensor
     def key_projection_matrix(self) -> tf.Variable:
-        return tf.get_variable(
+        return get_variable(
             name="attn_key_projection",
             # TODO tohle neni spravne
             shape=[self.context_vector_size, self.state_size],
@@ -78,13 +79,13 @@ class Attention(BaseAttention):
 
     @tensor
     def similarity_bias_vector(self) -> tf.Variable:
-        return tf.get_variable(
+        return get_variable(
             name="attn_similarity_v", shape=[self.state_size],
             initializer=tf.glorot_normal_initializer())
 
     @tensor
     def projection_bias_vector(self) -> tf.Variable:
-        return tf.get_variable(
+        return get_variable(
             name="attn_projection_bias", shape=[self.state_size],
             initializer=tf.zeros_initializer())
 
@@ -92,7 +93,7 @@ class Attention(BaseAttention):
     # Implicit self use in tensor annotation
     @tensor
     def bias_term(self) -> tf.Variable:
-        return tf.get_variable(
+        return get_variable(
             name="attn_bias", shape=[],
             initializer=tf.zeros_initializer())
     # pylint: enable=no-self-use

--- a/neuralmonkey/attention/scaled_dot_product.py
+++ b/neuralmonkey/attention/scaled_dot_product.py
@@ -14,6 +14,7 @@ import numpy as np
 from typeguard import check_argument_types
 
 from neuralmonkey.nn.utils import dropout
+from neuralmonkey.model.model_part import InitializerSpecs
 from neuralmonkey.attention.base_attention import (
     BaseAttention, Attendable, get_attention_states, get_attention_mask)
 
@@ -210,6 +211,7 @@ def empty_multi_head_loop_state(num_heads: int) -> MultiHeadLoopStateTA:
 
 class MultiHeadAttention(BaseAttention):
 
+    # pylint: disable=too-many-arguments
     def __init__(self,
                  name: str,
                  n_heads: int,
@@ -217,9 +219,11 @@ class MultiHeadAttention(BaseAttention):
                  values_encoder: Attendable = None,
                  dropout_keep_prob: float = 1.0,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
         check_argument_types()
-        BaseAttention.__init__(self, name, save_checkpoint, load_checkpoint)
+        BaseAttention.__init__(self, name, save_checkpoint, load_checkpoint,
+                               initializers)
 
         self.n_heads = n_heads
         self.dropout_keep_prob = dropout_keep_prob
@@ -236,6 +240,7 @@ class MultiHeadAttention(BaseAttention):
         self.attention_keys = get_attention_states(keys_encoder)
         self.attention_mask = get_attention_mask(keys_encoder)
         self.attention_values = get_attention_states(values_encoder)
+    # pylint: enable=too-many-arguments
 
     def attention(self,
                   query: tf.Tensor,
@@ -327,8 +332,9 @@ class ScaledDotProdAttention(MultiHeadAttention):
                  values_encoder: Attendable = None,
                  dropout_keep_prob: float = 1.0,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
         check_argument_types()
         MultiHeadAttention.__init__(
             self, name, 1, keys_encoder, values_encoder, dropout_keep_prob,
-            save_checkpoint, load_checkpoint)
+            save_checkpoint, load_checkpoint, initializers)

--- a/neuralmonkey/checking.py
+++ b/neuralmonkey/checking.py
@@ -12,6 +12,7 @@ import tensorflow as tf
 from neuralmonkey.logging import log, debug
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.runners.base_runner import BaseRunner
+from neuralmonkey import tf_utils
 
 
 class CheckingException(Exception):
@@ -60,6 +61,14 @@ def check_dataset_and_coders(dataset: Dataset,
 
         raise CheckingException("Dataset '{}' is mising series {}:"
                                 .format(dataset.name, ", ".join(formated)))
+
+
+def check_unused_initializers() -> None:
+    unused_initializers = tf_utils.get_unused_initializers()
+    if unused_initializers:
+        raise CheckingException(
+            "Initializers were specified for the following non-existent "
+            "variables: " + ", ".join(unused_initializers))
 
 
 def assert_shape(tensor: tf.Tensor,

--- a/neuralmonkey/decoders/autoregressive.py
+++ b/neuralmonkey/decoders/autoregressive.py
@@ -14,7 +14,7 @@ import tensorflow as tf
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.decorators import tensor
 from neuralmonkey.logging import log
-from neuralmonkey.model.model_part import ModelPart, FeedDict
+from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
 from neuralmonkey.nn.utils import dropout
 from neuralmonkey.tf_utils import get_variable
 from neuralmonkey.vocabulary import Vocabulary, START_TOKEN
@@ -71,7 +71,8 @@ class AutoregressiveDecoder(ModelPart):
                  dropout_keep_prob: float = 1.0,
                  label_smoothing: float = None,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
         """Initialize parameters common for all autoregressive decoders.
 
         Arguments:
@@ -82,7 +83,8 @@ class AutoregressiveDecoder(ModelPart):
             max_output_len: Maximum length of an output sequence.
             dropout_keep_prob: Probability of keeping a value during dropout.
         """
-        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
+        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint,
+                           initializers)
 
         log("Initializing decoder, name: '{}'".format(name))
 

--- a/neuralmonkey/decoders/autoregressive.py
+++ b/neuralmonkey/decoders/autoregressive.py
@@ -16,6 +16,7 @@ from neuralmonkey.decorators import tensor
 from neuralmonkey.logging import log
 from neuralmonkey.model.model_part import ModelPart, FeedDict
 from neuralmonkey.nn.utils import dropout
+from neuralmonkey.tf_utils import get_variable
 from neuralmonkey.vocabulary import Vocabulary, START_TOKEN
 
 
@@ -117,7 +118,7 @@ class AutoregressiveDecoder(ModelPart):
     @tensor
     def decoding_w(self) -> tf.Variable:
         with tf.name_scope("output_projection"):
-            return tf.get_variable(
+            return get_variable(
                 "logit_matrix",
                 [self.output_dimension, len(self.vocabulary)],
                 initializer=tf.glorot_uniform_initializer())
@@ -125,7 +126,7 @@ class AutoregressiveDecoder(ModelPart):
     @tensor
     def decoding_b(self) -> tf.Variable:
         with tf.name_scope("output_projection"):
-            return tf.get_variable(
+            return get_variable(
                 "logit_bias", [len(self.vocabulary)],
                 initializer=tf.zeros_initializer())
 

--- a/neuralmonkey/decoders/beam_search_decoder.py
+++ b/neuralmonkey/decoders/beam_search_decoder.py
@@ -30,7 +30,7 @@ from typing import NamedTuple, List, Callable, Any
 import tensorflow as tf
 from typeguard import check_argument_types
 
-from neuralmonkey.model.model_part import ModelPart, FeedDict
+from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.decoders.autoregressive import (
     LoopState, AutoregressiveDecoder)
@@ -76,6 +76,7 @@ class BeamSearchDecoder(ModelPart):
     alpha from equation 14.
     """
 
+    # pylint: disable=too-many-arguments
     def __init__(self,
                  name: str,
                  parent_decoder: AutoregressiveDecoder,
@@ -83,9 +84,11 @@ class BeamSearchDecoder(ModelPart):
                  length_normalization: float,
                  max_steps: int = None,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
         check_argument_types()
-        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
+        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint,
+                           initializers)
 
         self.parent_decoder = parent_decoder
         self._beam_size = beam_size
@@ -109,6 +112,7 @@ class BeamSearchDecoder(ModelPart):
 
         # Output
         self.outputs = self._decoding_loop()
+    # pylint: enable=too-many-arguments
 
     @property
     def batch_size(self):

--- a/neuralmonkey/decoders/classifier.py
+++ b/neuralmonkey/decoders/classifier.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.vocabulary import Vocabulary
-from neuralmonkey.model.model_part import ModelPart, FeedDict
+from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
 from neuralmonkey.model.stateful import Stateful
 from neuralmonkey.nn.mlp import MultilayerPerceptron
 from neuralmonkey.decorators import tensor
@@ -27,7 +27,8 @@ class Classifier(ModelPart):
                  activation_fn: Callable[[tf.Tensor], tf.Tensor] = tf.nn.relu,
                  dropout_keep_prob: float = 0.5,
                  save_checkpoint: Optional[str] = None,
-                 load_checkpoint: Optional[str] = None) -> None:
+                 load_checkpoint: Optional[str] = None,
+                 initializers: InitializerSpecs = None) -> None:
         """Construct a new instance of the sequence classifier.
 
         Args:
@@ -44,7 +45,8 @@ class Classifier(ModelPart):
                            hidden layer.
             dropout_keep_prob: Probability of keeping a value during dropout
         """
-        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
+        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint,
+                           initializers)
 
         self.encoders = encoders
         self.vocabulary = vocabulary

--- a/neuralmonkey/decoders/ctc_decoder.py
+++ b/neuralmonkey/decoders/ctc_decoder.py
@@ -6,7 +6,7 @@ from typeguard import check_argument_types
 
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.decorators import tensor
-from neuralmonkey.model.model_part import ModelPart, FeedDict
+from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
 from neuralmonkey.model.stateful import TemporalStateful
 from neuralmonkey.tf_utils import get_variable
 from neuralmonkey.vocabulary import Vocabulary, END_TOKEN
@@ -28,9 +28,11 @@ class CTCDecoder(ModelPart):
                  merge_repeated_outputs: bool = True,
                  beam_width: int = 1,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
         check_argument_types()
-        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
+        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint,
+                           initializers)
 
         self.encoder = encoder
         self.vocabulary = vocabulary

--- a/neuralmonkey/decoders/ctc_decoder.py
+++ b/neuralmonkey/decoders/ctc_decoder.py
@@ -5,10 +5,11 @@ import tensorflow as tf
 from typeguard import check_argument_types
 
 from neuralmonkey.dataset import Dataset
+from neuralmonkey.decorators import tensor
 from neuralmonkey.model.model_part import ModelPart, FeedDict
 from neuralmonkey.model.stateful import TemporalStateful
+from neuralmonkey.tf_utils import get_variable
 from neuralmonkey.vocabulary import Vocabulary, END_TOKEN
-from neuralmonkey.decorators import tensor
 
 
 class CTCDecoder(ModelPart):
@@ -91,12 +92,12 @@ class CTCDecoder(ModelPart):
 
         encoder_states = self.encoder.temporal_states
 
-        weights = tf.get_variable(
+        weights = get_variable(
             name="state_to_word_W",
             shape=[encoder_states.shape[2], vocabulary_size + 1],
             initializer=tf.glorot_uniform_initializer())
 
-        biases = tf.get_variable(
+        biases = get_variable(
             name="state_to_word_b",
             shape=[vocabulary_size + 1],
             initializer=tf.zeros_initializer())

--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -20,6 +20,7 @@ from neuralmonkey.decoders.encoder_projection import (
 from neuralmonkey.decoders.output_projection import (
     OutputProjectionSpec, OutputProjection, nonlinear_output)
 from neuralmonkey.decorators import tensor
+from neuralmonkey.tf_utils import get_variable
 
 
 RNN_CELL_TYPES = {
@@ -224,7 +225,7 @@ class Decoder(AutoregressiveDecoder):
         if self.embeddings_source is not None:
             return self.embeddings_source.embedding_matrix
 
-        return tf.get_variable(
+        return get_variable(
             name="word_embeddings",
             shape=[len(self.vocabulary), self.embedding_size],
             initializer=tf.glorot_uniform_initializer())

--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -11,6 +11,7 @@ from neuralmonkey.vocabulary import (
     Vocabulary, END_TOKEN_INDEX, PAD_TOKEN_INDEX)
 from neuralmonkey.model.sequence import EmbeddedSequence
 from neuralmonkey.model.stateful import Stateful
+from neuralmonkey.model.model_part import InitializerSpecs
 from neuralmonkey.logging import log, warn
 from neuralmonkey.nn.ortho_gru_cell import OrthoGRUCell, NematusGRUCell
 from neuralmonkey.nn.utils import dropout
@@ -68,7 +69,8 @@ class Decoder(AutoregressiveDecoder):
                  rnn_cell: str = "GRU",
                  conditional_gru: bool = False,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
         """Create a refactored version of monster decoder.
 
         Arguments:
@@ -105,7 +107,8 @@ class Decoder(AutoregressiveDecoder):
             dropout_keep_prob=dropout_keep_prob,
             label_smoothing=label_smoothing,
             save_checkpoint=save_checkpoint,
-            load_checkpoint=load_checkpoint)
+            load_checkpoint=load_checkpoint,
+            initializers=initializers)
 
         self.encoders = encoders
         self.embedding_size = embedding_size

--- a/neuralmonkey/decoders/encoder_projection.py
+++ b/neuralmonkey/decoders/encoder_projection.py
@@ -23,6 +23,7 @@ from neuralmonkey.model.stateful import Stateful, TemporalStatefulWithOutput
 from neuralmonkey.nn.utils import dropout
 from neuralmonkey.nn.ortho_gru_cell import orthogonal_initializer
 from neuralmonkey.logging import log, warn
+from neuralmonkey.tf_utils import get_initializer
 
 
 # pylint: disable=invalid-name
@@ -135,9 +136,10 @@ def nematus_projection(dropout_keep_prob: float = 1.0) -> EncoderProjection:
             warn("Using nematus projection on nonequal encoder and decoder "
                  "state sizes ({} vs {})".format(encoder_rnn_size, rnn_size))
 
-        return tf.layers.dense(means, rnn_size,
-                               activation=tf.tanh,
-                               kernel_initializer=kernel_initializer,
-                               name="encoders_projection")
+        return tf.layers.dense(
+            means, rnn_size, activation=tf.tanh,
+            kernel_initializer=get_initializer(
+                "encoders_projection/kernel", kernel_initializer),
+            name="encoders_projection")
 
     return cast(EncoderProjection, func)

--- a/neuralmonkey/decoders/output_projection.py
+++ b/neuralmonkey/decoders/output_projection.py
@@ -20,6 +20,7 @@ from typeguard import check_argument_types
 
 from neuralmonkey.nn.projection import multilayer_projection, maxout
 from neuralmonkey.nn.utils import dropout
+from neuralmonkey.tf_utils import get_initializer
 
 
 # pylint: disable=invalid-name
@@ -95,17 +96,20 @@ def nematus_output(
 
         logit_rnn = tf.layers.dense(
             prev_state, output_size,
-            kernel_initializer=tf.glorot_normal_initializer(),
+            kernel_initializer=get_initializer(
+                "rnn_state/kernel", tf.glorot_normal_initializer()),
             name="rnn_state")
 
         logit_emb = tf.layers.dense(
             prev_output, output_size,
-            kernel_initializer=tf.glorot_normal_initializer(),
+            kernel_initializer=get_initializer(
+                "prev_out/kernel", tf.glorot_normal_initializer()),
             name="prev_out")
 
         logit_ctx = tf.layers.dense(
             ctx, output_size,
-            kernel_initializer=tf.glorot_normal_initializer(),
+            kernel_initializer=get_initializer(
+                "context/kernel", tf.glorot_normal_initializer()),
             name="context")
 
         return activation_fn(logit_rnn + logit_emb + logit_ctx)

--- a/neuralmonkey/decoders/sequence_labeler.py
+++ b/neuralmonkey/decoders/sequence_labeler.py
@@ -3,7 +3,7 @@ from typing import cast, Iterable, List, Optional, Union
 import tensorflow as tf
 
 from neuralmonkey.dataset import Dataset
-from neuralmonkey.model.model_part import ModelPart, FeedDict
+from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
 from neuralmonkey.encoders.recurrent import RecurrentEncoder
 from neuralmonkey.encoders.facebook_conv import SentenceEncoder
 from neuralmonkey.vocabulary import Vocabulary
@@ -14,6 +14,7 @@ from neuralmonkey.tf_utils import get_variable
 class SequenceLabeler(ModelPart):
     """Classifier assing a label to each encoder's state."""
 
+    # pylint: disable=too-many-arguments
     def __init__(self,
                  name: str,
                  encoder: Union[RecurrentEncoder, SentenceEncoder],
@@ -21,8 +22,10 @@ class SequenceLabeler(ModelPart):
                  data_id: str,
                  dropout_keep_prob: float = 1.0,
                  save_checkpoint: Optional[str] = None,
-                 load_checkpoint: Optional[str] = None) -> None:
-        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
+                 load_checkpoint: Optional[str] = None,
+                 initializers: InitializerSpecs = None) -> None:
+        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint,
+                           initializers)
 
         self.encoder = encoder
         self.vocabulary = vocabulary
@@ -30,6 +33,7 @@ class SequenceLabeler(ModelPart):
         self.dropout_keep_prob = dropout_keep_prob
 
         self.rnn_size = int(self.encoder.temporal_states.get_shape()[-1])
+    # pylint: enable=too-many-arguments
 
     # pylint: disable=no-self-use
     @tensor

--- a/neuralmonkey/decoders/sequence_labeler.py
+++ b/neuralmonkey/decoders/sequence_labeler.py
@@ -8,6 +8,7 @@ from neuralmonkey.encoders.recurrent import RecurrentEncoder
 from neuralmonkey.encoders.facebook_conv import SentenceEncoder
 from neuralmonkey.vocabulary import Vocabulary
 from neuralmonkey.decorators import tensor
+from neuralmonkey.tf_utils import get_variable
 
 
 class SequenceLabeler(ModelPart):
@@ -48,14 +49,14 @@ class SequenceLabeler(ModelPart):
 
     @tensor
     def decoding_w(self) -> tf.Variable:
-        return tf.get_variable(
+        return get_variable(
             name="state_to_word_W",
             shape=[self.rnn_size, len(self.vocabulary)],
             initializer=tf.glorot_normal_initializer())
 
     @tensor
     def decoding_b(self) -> tf.Variable:
-        return tf.get_variable(
+        return get_variable(
             name="state_to_word_b",
             shape=[len(self.vocabulary)],
             initializer=tf.zeros_initializer())
@@ -63,7 +64,7 @@ class SequenceLabeler(ModelPart):
     @tensor
     def decoding_residual_w(self) -> tf.Variable:
         input_dim = self.encoder.input_sequence.dimension
-        return tf.get_variable(
+        return get_variable(
             name="emb_to_word_W",
             shape=[input_dim, len(self.vocabulary)],
             initializer=tf.glorot_normal_initializer())

--- a/neuralmonkey/decoders/sequence_regressor.py
+++ b/neuralmonkey/decoders/sequence_regressor.py
@@ -5,7 +5,7 @@ import tensorflow as tf
 from typeguard import check_argument_types
 from neuralmonkey.nn.projection import multilayer_projection
 from neuralmonkey.dataset import Dataset
-from neuralmonkey.model.model_part import ModelPart, FeedDict
+from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
 from neuralmonkey.model.stateful import Stateful
 from neuralmonkey.decorators import tensor
 
@@ -27,8 +27,10 @@ class SequenceRegressor(ModelPart):
                  dropout_keep_prob: float = 1.0,
                  dimension: int = 1,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
-        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
+        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint,
+                           initializers)
         assert check_argument_types()
 
         self.encoders = encoders

--- a/neuralmonkey/decoders/word_alignment_decoder.py
+++ b/neuralmonkey/decoders/word_alignment_decoder.py
@@ -7,7 +7,7 @@ from neuralmonkey.dataset import Dataset
 from neuralmonkey.encoders.recurrent import RecurrentEncoder
 from neuralmonkey.decoders.decoder import Decoder
 from neuralmonkey.logging import warn
-from neuralmonkey.model.model_part import ModelPart, FeedDict
+from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
 from neuralmonkey.model.sequence import Sequence
 from neuralmonkey.decorators import tensor
 
@@ -22,8 +22,9 @@ class WordAlignmentDecoder(ModelPart):
                  encoder: RecurrentEncoder,
                  decoder: Decoder,
                  data_id: str,
-                 name: str) -> None:
-        ModelPart.__init__(self, name, None, None)
+                 name: str,
+                 initializers: InitializerSpecs = None) -> None:
+        ModelPart.__init__(self, name, None, None, initializers)
 
         self.encoder = encoder
         self.decoder = decoder

--- a/neuralmonkey/encoders/attentive.py
+++ b/neuralmonkey/encoders/attentive.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 from typeguard import check_argument_types
 
 from neuralmonkey.model.stateful import TemporalStatefulWithOutput
-from neuralmonkey.model.model_part import ModelPart, FeedDict
+from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
 from neuralmonkey.nn.utils import dropout
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.decorators import tensor
@@ -36,10 +36,12 @@ class AttentiveEncoder(ModelPart, TemporalStatefulWithOutput):
                  state_proj_size: int = None,
                  dropout_keep_prob: float = 1.0,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
         """Initialize an instance of the encoder."""
         check_argument_types()
-        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
+        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint,
+                           initializers)
 
         self.input_sequence = input_sequence
         self.hidden_size = hidden_size

--- a/neuralmonkey/encoders/cnn_encoder.py
+++ b/neuralmonkey/encoders/cnn_encoder.py
@@ -10,7 +10,7 @@ from tensorflow.contrib.layers import conv2d, max_pool2d
 from neuralmonkey.checking import assert_shape
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.decorators import tensor
-from neuralmonkey.model.model_part import ModelPart, FeedDict
+from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
 from neuralmonkey.model.stateful import SpatialStatefulWithOutput
 from neuralmonkey.nn.projection import multilayer_projection
 
@@ -32,7 +32,8 @@ class CNNEncoder(ModelPart, SpatialStatefulWithOutput):
                  fully_connected: Optional[List[int]] = None,
                  dropout_keep_prob: float = 0.5,
                  save_checkpoint: Optional[str] = None,
-                 load_checkpoint: Optional[str] = None) -> None:
+                 load_checkpoint: Optional[str] = None,
+                 initializers: InitializerSpecs = None) -> None:
         """Initialize a convolutional network for image processing.
 
         Args:
@@ -49,7 +50,8 @@ class CNNEncoder(ModelPart, SpatialStatefulWithOutput):
                 dropout. Dropout is done between all convolutional layers and
                 fully connected layer.
         """
-        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
+        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint,
+                           initializers)
 
         self.data_id = data_id
         self.dropout_keep_prob = dropout_keep_prob

--- a/neuralmonkey/encoders/facebook_conv.py
+++ b/neuralmonkey/encoders/facebook_conv.py
@@ -7,7 +7,7 @@ import tensorflow as tf
 import numpy as np
 from typeguard import check_argument_types
 
-from neuralmonkey.model.model_part import ModelPart, FeedDict
+from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
 from neuralmonkey.logging import log
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.decorators import tensor
@@ -28,9 +28,11 @@ class SentenceEncoder(ModelPart, TemporalStatefulWithOutput):
                  kernel_width: int = 5,
                  dropout_keep_prob: float = 1.0,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
         check_argument_types()
-        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
+        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint,
+                           initializers)
 
         self.input_sequence = input_sequence
         self.encoder_layers = encoder_layers

--- a/neuralmonkey/encoders/facebook_conv.py
+++ b/neuralmonkey/encoders/facebook_conv.py
@@ -14,6 +14,7 @@ from neuralmonkey.decorators import tensor
 from neuralmonkey.nn.projection import glu
 from neuralmonkey.model.sequence import EmbeddedSequence
 from neuralmonkey.model.stateful import TemporalStatefulWithOutput
+from neuralmonkey.tf_utils import get_variable
 
 
 class SentenceEncoder(ModelPart, TemporalStatefulWithOutput):
@@ -77,7 +78,7 @@ class SentenceEncoder(ModelPart, TemporalStatefulWithOutput):
     def order_embeddings(self) -> tf.Tensor:
         # initialization in the same way as in original CS2S implementation
         with tf.variable_scope("input_projection"):
-            return tf.get_variable(
+            return get_variable(
                 "order_embeddings", [self.input_sequence.max_length,
                                      self.input_sequence.embedding_sizes[0]],
                 initializer=tf.glorot_normal_initializer())
@@ -96,13 +97,13 @@ class SentenceEncoder(ModelPart, TemporalStatefulWithOutput):
             # Initialized as described in the paper.
             # Note: this should be equivalent to tf.glorot_normal_initializer
             init_deviat = np.sqrt(4 / self.conv_features)
-            convolution_filters = tf.get_variable(
+            convolution_filters = get_variable(
                 "convolution_filters",
                 [self.kernel_width, self.conv_features,
                  2 * self.conv_features],
                 initializer=tf.random_normal_initializer(stddev=init_deviat))
 
-            bias = tf.get_variable(
+            bias = get_variable(
                 name="conv_bias",
                 shape=[2 * self.conv_features],
                 initializer=tf.zeros_initializer())

--- a/neuralmonkey/encoders/imagenet_encoder.py
+++ b/neuralmonkey/encoders/imagenet_encoder.py
@@ -15,7 +15,7 @@ import tensorflow.contrib.slim.nets
 from neuralmonkey.logging import warn
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.decorators import tensor
-from neuralmonkey.model.model_part import ModelPart, FeedDict
+from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
 from neuralmonkey.model.stateful import SpatialStatefulWithOutput
 
 
@@ -57,8 +57,9 @@ class ImageNet(ModelPart, SpatialStatefulWithOutput):
                  attention_layer: Optional[str] = None,
                  fine_tune: bool = False,
                  encoded_layer: Optional[str] = None,
+                 save_checkpoint: Optional[str] = None,
                  load_checkpoint: Optional[str] = None,
-                 save_checkpoint: Optional[str] = None) -> None:
+                 initializers: InitializerSpecs = None) -> None:
         """Initialize pre-trained ImageNet network.
 
         Args:
@@ -76,14 +77,15 @@ class ImageNet(ModelPart, SpatialStatefulWithOutput):
             encoded_layer: String id of the network layer that will be used as
                 input of a decoder. `None` means averaging the convolutional
                 maps.
-            load_checkpoint: Checkpoint file from which the pre-trained network
-                is loaded.
             save_checkpoint: Checkpoint file where the encoder is saved after
                 the training. (Makes sense only if `fine_tune` is set to
                 `True`).
+            load_checkpoint: Checkpoint file from which the pre-trained network
+                is loaded.
         """
         check_argument_types()
-        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
+        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint,
+                           initializers)
 
         if save_checkpoint is not None and not fine_tune:
             warn("The ImageNet network is not fine-tuned and still it is set "

--- a/neuralmonkey/encoders/numpy_encoder.py
+++ b/neuralmonkey/encoders/numpy_encoder.py
@@ -7,6 +7,7 @@ from neuralmonkey.dataset import Dataset
 from neuralmonkey.decorators import tensor
 from neuralmonkey.model.model_part import ModelPart, FeedDict
 from neuralmonkey.model.stateful import Stateful, SpatialStatefulWithOutput
+from neuralmonkey.tf_utils import get_variable
 
 
 # pylint: disable=too-few-public-methods
@@ -35,10 +36,10 @@ class VectorEncoder(ModelPart, Stateful):
 
         with self.use_scope():
             if output_shape is not None and dimension != output_shape:
-                project_w = tf.get_variable(
+                project_w = get_variable(
                     shape=[dimension, output_shape],
                     name="img_init_proj_W")
-                project_b = tf.get_variable(
+                project_b = get_variable(
                     name="img_init_b", shape=[output_shape],
                     initializer=tf.zeros_initializer())
 
@@ -84,11 +85,11 @@ class PostCNNImageEncoder(ModelPart, SpatialStatefulWithOutput):
                                        axis=[1, 2],
                                        name="average_image")
 
-            self.project_w = tf.get_variable(
+            self.project_w = get_variable(
                 name="img_init_proj_W",
                 shape=[input_shape[2], output_shape],
                 initializer=tf.glorot_normal_initializer())
-            self.project_b = tf.get_variable(
+            self.project_b = get_variable(
                 name="img_init_b", shape=[output_shape],
                 initializer=tf.zeros_initializer())
 

--- a/neuralmonkey/encoders/numpy_encoder.py
+++ b/neuralmonkey/encoders/numpy_encoder.py
@@ -5,7 +5,7 @@ import tensorflow as tf
 
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.decorators import tensor
-from neuralmonkey.model.model_part import ModelPart, FeedDict
+from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
 from neuralmonkey.model.stateful import Stateful, SpatialStatefulWithOutput
 from neuralmonkey.tf_utils import get_variable
 
@@ -21,8 +21,10 @@ class VectorEncoder(ModelPart, Stateful):
                  data_id: str,
                  output_shape: int = None,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
-        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
+        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint,
+                           initializers)
         check_argument_types()
 
         if dimension <= 0:
@@ -65,9 +67,11 @@ class PostCNNImageEncoder(ModelPart, SpatialStatefulWithOutput):
                  output_shape: int,
                  data_id: str,
                  save_checkpoint: Optional[str] = None,
-                 load_checkpoint: Optional[str] = None) -> None:
+                 load_checkpoint: Optional[str] = None,
+                 initializers: InitializerSpecs = None) -> None:
         check_argument_types()
-        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
+        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint,
+                           initializers)
 
         assert len(input_shape) == 3
         if output_shape <= 0:

--- a/neuralmonkey/encoders/raw_rnn_encoder.py
+++ b/neuralmonkey/encoders/raw_rnn_encoder.py
@@ -5,7 +5,7 @@ import tensorflow as tf
 from tensorflow.contrib.rnn import RNNCell
 from typeguard import check_argument_types
 
-from neuralmonkey.model.model_part import ModelPart, FeedDict
+from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
 from neuralmonkey.model.stateful import TemporalStatefulWithOutput
 from neuralmonkey.logging import log
 from neuralmonkey.nn.ortho_gru_cell import OrthoGRUCell
@@ -55,7 +55,8 @@ class RawRNNEncoder(ModelPart, TemporalStatefulWithOutput):
                  max_input_len: Optional[int] = None,
                  dropout_keep_prob: float = 1.0,
                  save_checkpoint: Optional[str] = None,
-                 load_checkpoint: Optional[str] = None) -> None:
+                 load_checkpoint: Optional[str] = None,
+                 initializers: InitializerSpecs = None) -> None:
         """Create a new instance of the encoder.
 
         Arguments:
@@ -70,7 +71,8 @@ class RawRNNEncoder(ModelPart, TemporalStatefulWithOutput):
                 (default 1.0)
         """
         check_argument_types()
-        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
+        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint,
+                           initializers)
 
         self.data_id = data_id
 

--- a/neuralmonkey/encoders/recurrent.py
+++ b/neuralmonkey/encoders/recurrent.py
@@ -197,7 +197,8 @@ class SentenceEncoder(RecurrentEncoder):
                  dropout_keep_prob: float = 1.0,
                  save_checkpoint: str = None,
                  load_checkpoint: str = None,
-                 initializers: InitializerSpecs = None) -> None:
+                 initializers: InitializerSpecs = None,
+                 embedding_initializer: Callable = None) -> None:
         """Create a new instance of the sentence encoder.
 
         Arguments:
@@ -222,6 +223,10 @@ class SentenceEncoder(RecurrentEncoder):
         check_argument_types()
         s_ckp = "input_{}".format(save_checkpoint) if save_checkpoint else None
         l_ckp = "input_{}".format(load_checkpoint) if load_checkpoint else None
+        input_initializers = []
+        if embedding_initializer is not None:
+            input_initializers.append(
+                ("embedding_matrix_0", embedding_initializer))
 
         # TODO! Representation runner needs this. It is not simple to do it in
         # recurrent encoder since there may be more source data series. The
@@ -236,7 +241,8 @@ class SentenceEncoder(RecurrentEncoder):
             embedding_size=embedding_size,
             max_length=max_input_len,
             save_checkpoint=s_ckp,
-            load_checkpoint=l_ckp)
+            load_checkpoint=l_ckp,
+            initializers=input_initializers)
 
         RecurrentEncoder.__init__(
             self,
@@ -266,7 +272,8 @@ class FactoredEncoder(RecurrentEncoder):
                  dropout_keep_prob: float = 1.0,
                  save_checkpoint: str = None,
                  load_checkpoint: str = None,
-                 initializers: InitializerSpecs = None) -> None:
+                 initializers: InitializerSpecs = None,
+                 input_initializers: InitializerSpecs = None) -> None:
         """Create a new instance of the factored encoder.
 
         Arguments:
@@ -299,7 +306,8 @@ class FactoredEncoder(RecurrentEncoder):
             embedding_sizes=embedding_sizes,
             max_length=max_input_len,
             save_checkpoint=s_ckp,
-            load_checkpoint=l_ckp)
+            load_checkpoint=l_ckp,
+            initializers=input_initializers)
 
         RecurrentEncoder.__init__(
             self,
@@ -329,7 +337,8 @@ class DeepSentenceEncoder(SentenceEncoder):
                  dropout_keep_prob: float = 1.0,
                  save_checkpoint: str = None,
                  load_checkpoint: str = None,
-                 initializers: InitializerSpecs = None) -> None:
+                 initializers: InitializerSpecs = None,
+                 embedding_initializer: Callable = None) -> None:
         """Create a new instance of the deep sentence encoder.
 
         Arguments:
@@ -376,7 +385,8 @@ class DeepSentenceEncoder(SentenceEncoder):
             dropout_keep_prob=dropout_keep_prob,
             save_checkpoint=save_checkpoint,
             load_checkpoint=load_checkpoint,
-            initializers=initializers)
+            initializers=initializers,
+            embedding_initializer=embedding_initializer)
 
     @tensor
     def rnn(self) -> Tuple[tf.Tensor, tf.Tensor]:

--- a/neuralmonkey/encoders/recurrent.py
+++ b/neuralmonkey/encoders/recurrent.py
@@ -5,7 +5,7 @@ from typeguard import check_argument_types
 
 from neuralmonkey.model.stateful import (
     TemporalStatefulWithOutput, TemporalStateful)
-from neuralmonkey.model.model_part import ModelPart, FeedDict
+from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
 from neuralmonkey.nn.ortho_gru_cell import OrthoGRUCell, NematusGRUCell
 from neuralmonkey.nn.utils import dropout
 from neuralmonkey.vocabulary import Vocabulary
@@ -108,7 +108,8 @@ class RecurrentEncoder(ModelPart, TemporalStatefulWithOutput):
                  rnn_direction: str = "bidirectional",
                  dropout_keep_prob: float = 1.0,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
         """Create a new instance of a recurrent encoder.
 
         Arguments:
@@ -126,7 +127,8 @@ class RecurrentEncoder(ModelPart, TemporalStatefulWithOutput):
             load_checkpoint: ModelPart load checkpoint file.
         """
         check_argument_types()
-        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
+        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint,
+                           initializers)
         TemporalStatefulWithOutput.__init__(self)
 
         self.input_sequence = input_sequence

--- a/neuralmonkey/encoders/recurrent.py
+++ b/neuralmonkey/encoders/recurrent.py
@@ -196,7 +196,8 @@ class SentenceEncoder(RecurrentEncoder):
                  max_input_len: int = None,
                  dropout_keep_prob: float = 1.0,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
         """Create a new instance of the sentence encoder.
 
         Arguments:
@@ -246,7 +247,8 @@ class SentenceEncoder(RecurrentEncoder):
             rnn_direction=rnn_direction,
             dropout_keep_prob=dropout_keep_prob,
             save_checkpoint=save_checkpoint,
-            load_checkpoint=load_checkpoint)
+            load_checkpoint=load_checkpoint,
+            initializers=initializers)
     # pylint: enable=too-many-arguments,too-many-locals
 
 
@@ -263,7 +265,8 @@ class FactoredEncoder(RecurrentEncoder):
                  max_input_len: int = None,
                  dropout_keep_prob: float = 1.0,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
         """Create a new instance of the factored encoder.
 
         Arguments:
@@ -307,7 +310,8 @@ class FactoredEncoder(RecurrentEncoder):
             rnn_direction=rnn_direction,
             dropout_keep_prob=dropout_keep_prob,
             save_checkpoint=save_checkpoint,
-            load_checkpoint=load_checkpoint)
+            load_checkpoint=load_checkpoint,
+            initializers=initializers)
     # pylint: enable=too-many-arguments,too-many-locals
 
 
@@ -324,7 +328,8 @@ class DeepSentenceEncoder(SentenceEncoder):
                  max_input_len: int = None,
                  dropout_keep_prob: float = 1.0,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
         """Create a new instance of the deep sentence encoder.
 
         Arguments:
@@ -370,7 +375,8 @@ class DeepSentenceEncoder(SentenceEncoder):
             max_input_len=max_input_len,
             dropout_keep_prob=dropout_keep_prob,
             save_checkpoint=save_checkpoint,
-            load_checkpoint=load_checkpoint)
+            load_checkpoint=load_checkpoint,
+            initializers=initializers)
 
     @tensor
     def rnn(self) -> Tuple[tf.Tensor, tf.Tensor]:

--- a/neuralmonkey/encoders/sentence_cnn_encoder.py
+++ b/neuralmonkey/encoders/sentence_cnn_encoder.py
@@ -6,7 +6,7 @@ import tensorflow as tf
 from typeguard import check_argument_types
 
 from neuralmonkey.encoders.recurrent import RNNCellTuple
-from neuralmonkey.model.model_part import ModelPart, FeedDict
+from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
 from neuralmonkey.model.sequence import Sequence
 from neuralmonkey.model.stateful import TemporalStatefulWithOutput
 from neuralmonkey.nn.noisy_gru_cell import NoisyGRUCell
@@ -44,7 +44,8 @@ class SentenceCNNEncoder(ModelPart, TemporalStatefulWithOutput):
                  dropout_keep_prob: float = 1.0,
                  use_noisy_activations: bool = False,
                  save_checkpoint: Optional[str] = None,
-                 load_checkpoint: Optional[str] = None) -> None:
+                 load_checkpoint: Optional[str] = None,
+                 initializers: InitializerSpecs = None) -> None:
         """Create a new instance of the sentence encoder.
 
         Arguments:
@@ -63,7 +64,8 @@ class SentenceCNNEncoder(ModelPart, TemporalStatefulWithOutput):
             dropout_keep_prob: The dropout keep probability
                 (default 1.0)
         """
-        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
+        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint,
+                           initializers)
         check_argument_types()
 
         self.input_sequence = input_sequence

--- a/neuralmonkey/encoders/sentence_cnn_encoder.py
+++ b/neuralmonkey/encoders/sentence_cnn_encoder.py
@@ -15,6 +15,7 @@ from neuralmonkey.nn.utils import dropout
 from neuralmonkey.nn.highway import highway
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.decorators import tensor
+from neuralmonkey.tf_utils import get_variable
 
 
 # pylint: disable=too-many-instance-attributes
@@ -113,10 +114,10 @@ class SentenceCNNEncoder(ModelPart, TemporalStatefulWithOutput):
             with tf.variable_scope("conv-maxpool-%s" % filter_size):
                 filter_shape = [filter_size, self.input_sequence.dimension,
                                 num_filters]
-                w_filter = tf.get_variable(
+                w_filter = get_variable(
                     "conv_W", filter_shape,
                     initializer=tf.glorot_uniform_initializer())
-                b_filter = tf.get_variable(
+                b_filter = get_variable(
                     "conv_bias", [num_filters],
                     initializer=tf.zeros_initializer())
                 conv = tf.nn.conv1d(

--- a/neuralmonkey/encoders/sequence_cnn_encoder.py
+++ b/neuralmonkey/encoders/sequence_cnn_encoder.py
@@ -11,6 +11,7 @@ from neuralmonkey.model.model_part import ModelPart, FeedDict
 from neuralmonkey.model.stateful import Stateful
 from neuralmonkey.nn.utils import dropout
 from neuralmonkey.vocabulary import Vocabulary
+from neuralmonkey.tf_utils import get_variable
 
 
 class SequenceCNNEncoder(ModelPart, Stateful):
@@ -73,7 +74,7 @@ class SequenceCNNEncoder(ModelPart, Stateful):
     @tensor
     def embedded_inputs(self) -> tf.Tensor:
         with tf.variable_scope("input_projection"):
-            embedding_matrix = tf.get_variable(
+            embedding_matrix = get_variable(
                 "word_embeddings",
                 [len(self.vocabulary), self.embedding_size],
                 initializer=tf.glorot_uniform_initializer())
@@ -89,10 +90,10 @@ class SequenceCNNEncoder(ModelPart, Stateful):
             with tf.variable_scope("conv-maxpool-%s" % filter_size):
                 # Convolution Layer
                 filter_shape = [filter_size, self.embedding_size, num_filters]
-                w_filter = tf.get_variable(
+                w_filter = get_variable(
                     "conv_W", filter_shape,
                     initializer=tf.glorot_uniform_initializer())
-                b_filter = tf.get_variable(
+                b_filter = get_variable(
                     "conv_bias", [num_filters],
                     initializer=tf.zeros_initializer())
                 conv = tf.nn.conv1d(

--- a/neuralmonkey/encoders/sequence_cnn_encoder.py
+++ b/neuralmonkey/encoders/sequence_cnn_encoder.py
@@ -7,7 +7,7 @@ import tensorflow as tf
 
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.decorators import tensor
-from neuralmonkey.model.model_part import ModelPart, FeedDict
+from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
 from neuralmonkey.model.stateful import Stateful
 from neuralmonkey.nn.utils import dropout
 from neuralmonkey.vocabulary import Vocabulary
@@ -27,7 +27,8 @@ class SequenceCNNEncoder(ModelPart, Stateful):
                  max_input_len: Optional[int] = None,
                  dropout_keep_prob: float = 1.0,
                  save_checkpoint: Optional[str] = None,
-                 load_checkpoint: Optional[str] = None) -> None:
+                 load_checkpoint: Optional[str] = None,
+                 initializers: InitializerSpecs = None) -> None:
         """Create a new instance of the CNN sequence encoder.
 
         Based on: Yoon Kim: Convolutional Neural Networks for Sentence
@@ -46,7 +47,8 @@ class SequenceCNNEncoder(ModelPart, Stateful):
                 (default 1.0)
         """
         check_argument_types()
-        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
+        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint,
+                           initializers)
 
         self.vocabulary = vocabulary
         self.data_id = data_id

--- a/neuralmonkey/model/model_part.py
+++ b/neuralmonkey/model/model_part.py
@@ -33,7 +33,7 @@ class ModelPart(metaclass=ABCMeta):
         with tf.variable_scope(name) as scope:
             self._variable_scope = scope
             if initializers is not None:
-                tf_utils.initializers.update(
+                tf_utils.update_initializers(
                     (scope.name + "/" + name, initializer)
                     for name, initializer in initializers)
 

--- a/neuralmonkey/model/model_part.py
+++ b/neuralmonkey/model/model_part.py
@@ -2,15 +2,17 @@
 
 from abc import ABCMeta
 from contextlib import contextmanager
-from typing import Any, Dict, Set
+from typing import Any, Callable, Dict, List, Set, Tuple
 
 import tensorflow as tf
 
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.logging import log
+from neuralmonkey import tf_utils
 
 # pylint: disable=invalid-name
 FeedDict = Dict[tf.Tensor, Any]
+InitializerSpecs = List[Tuple[str, Callable]]
 # pylint: disable=invalid-name
 
 
@@ -20,7 +22,8 @@ class ModelPart(metaclass=ABCMeta):
     def __init__(self,
                  name: str,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
         self._name = name
         self._save_checkpoint = save_checkpoint
         self._load_checkpoint = load_checkpoint
@@ -29,6 +32,9 @@ class ModelPart(metaclass=ABCMeta):
 
         with tf.variable_scope(name) as scope:
             self._variable_scope = scope
+            tf_utils.initializers.update(
+                (scope.name + "/" + name, initializer)
+                for name, initializer in initializers)
 
     @property
     def name(self) -> str:

--- a/neuralmonkey/model/model_part.py
+++ b/neuralmonkey/model/model_part.py
@@ -32,9 +32,10 @@ class ModelPart(metaclass=ABCMeta):
 
         with tf.variable_scope(name) as scope:
             self._variable_scope = scope
-            tf_utils.initializers.update(
-                (scope.name + "/" + name, initializer)
-                for name, initializer in initializers)
+            if initializers is not None:
+                tf_utils.initializers.update(
+                    (scope.name + "/" + name, initializer)
+                    for name, initializer in initializers)
 
     @property
     def name(self) -> str:

--- a/neuralmonkey/model/sequence.py
+++ b/neuralmonkey/model/sequence.py
@@ -7,7 +7,7 @@ import tensorflow as tf
 from tensorflow.contrib.tensorboard.plugins import projector
 from typeguard import check_argument_types
 
-from neuralmonkey.model.model_part import ModelPart, FeedDict
+from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
 from neuralmonkey.model.stateful import TemporalStateful
 from neuralmonkey.vocabulary import Vocabulary
 from neuralmonkey.decorators import tensor
@@ -31,7 +31,8 @@ class Sequence(ModelPart, TemporalStateful):
                  name: str,
                  max_length: int = None,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
         """Construct a new `Sequence` object.
 
         Arguments:
@@ -40,7 +41,8 @@ class Sequence(ModelPart, TemporalStateful):
             save_checkpoint: The save_checkpoint parameter for `ModelPart`
             load_checkpoint: The load_checkpoint parameter for `ModelPart`
         """
-        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
+        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint,
+                           initializers)
 
         self.max_length = max_length
         if self.max_length is not None and self.max_length <= 0:
@@ -61,7 +63,8 @@ class EmbeddedFactorSequence(Sequence):
                  add_start_symbol: bool = False,
                  add_end_symbol: bool = False,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
         """Construct a new instance of `EmbeddedFactorSequence`.
 
         Takes three lists of vocabularies, data series IDs, and embedding
@@ -84,7 +87,8 @@ class EmbeddedFactorSequence(Sequence):
         """
         check_argument_types()
         Sequence.__init__(
-            self, name, max_length, save_checkpoint, load_checkpoint)
+            self, name, max_length, save_checkpoint, load_checkpoint,
+            initializers)
 
         self.vocabularies = vocabularies
         self.vocabulary_sizes = [len(vocab) for vocab in self.vocabularies]
@@ -218,7 +222,8 @@ class EmbeddedSequence(EmbeddedFactorSequence):
                  add_start_symbol: bool = False,
                  add_end_symbol: bool = False,
                  save_checkpoint: str = None,
-                 load_checkpoint: str = None) -> None:
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
         """Construct a new instance of `EmbeddedSequence`.
 
         Arguments:
@@ -244,7 +249,8 @@ class EmbeddedSequence(EmbeddedFactorSequence):
             add_start_symbol=add_start_symbol,
             add_end_symbol=add_end_symbol,
             save_checkpoint=save_checkpoint,
-            load_checkpoint=load_checkpoint)
+            load_checkpoint=load_checkpoint,
+            initializers=initializers)
     # pylint: enable=too-many-arguments
 
     @property

--- a/neuralmonkey/model/sequence.py
+++ b/neuralmonkey/model/sequence.py
@@ -12,6 +12,7 @@ from neuralmonkey.model.stateful import TemporalStateful
 from neuralmonkey.vocabulary import Vocabulary
 from neuralmonkey.decorators import tensor
 from neuralmonkey.dataset import Dataset
+from neuralmonkey.tf_utils import get_variable
 
 
 # pylint: disable=abstract-method
@@ -140,7 +141,7 @@ class EmbeddedFactorSequence(Sequence):
         # experiments
 
         return [
-            tf.get_variable(
+            get_variable(
                 name="embedding_matrix_{}".format(i),
                 shape=[vocab_size, emb_size],
                 initializer=tf.glorot_uniform_initializer())

--- a/neuralmonkey/nn/highway.py
+++ b/neuralmonkey/nn/highway.py
@@ -1,5 +1,6 @@
 """Module implementing the highway networks."""
 import tensorflow as tf
+from neuralmonkey.tf_utils import get_variable
 
 
 def highway(inputs, activation=tf.nn.relu, scope="HighwayNetwork"):
@@ -34,20 +35,20 @@ def highway(inputs, activation=tf.nn.relu, scope="HighwayNetwork"):
         W_shape = [vec_size, vec_size]
         b_shape = [vec_size]
 
-        W_H = tf.get_variable(
+        W_H = get_variable(
             "weight_H",
             shape=W_shape,
             initializer=tf.glorot_normal_initializer())
-        b_H = tf.get_variable(
+        b_H = get_variable(
             "bias_H",
             shape=b_shape,
             initializer=tf.constant_initializer(-1.0))
 
-        W_T = tf.get_variable(
+        W_T = get_variable(
             "weight_T",
             shape=W_shape,
             initializer=tf.glorot_normal_initializer())
-        b_T = tf.get_variable(
+        b_T = get_variable(
             "bias_T",
             shape=b_shape,
             initializer=tf.constant_initializer(-1.0))

--- a/neuralmonkey/tf_utils.py
+++ b/neuralmonkey/tf_utils.py
@@ -84,11 +84,12 @@ def gpu_memusage() -> str:
 _initializers = {}  # type: Dict[str, Callable]
 
 
-def update_initializers(initializers: Iterable[Tuple[str, Callable]]):
+def update_initializers(initializers: Iterable[Tuple[str, Callable]]) -> None:
     _initializers.update(initializers)
 
 
-def get_initializer(var_name: str, default: Callable = None):
+def get_initializer(var_name: str,
+                    default: Callable = None) -> Optional[Callable]:
     """Return the initializer associated with the given variable name."""
     full_name = tf.get_variable_scope().name + "/" + var_name
     initializer = _initializers.get(full_name, default)
@@ -101,7 +102,7 @@ def get_variable(name: str,
                  shape: List[Optional[int]] = None,
                  dtype: tf.DType = None,
                  initializer: Callable = None,
-                 *args, **kwargs):
+                 *args, **kwargs) -> tf.Variable:
     """Get an existing variable with these parameters or create a new one.
 
     This is a wrapper around `tf.get_variable`. The `initializer` parameter is

--- a/neuralmonkey/tf_utils.py
+++ b/neuralmonkey/tf_utils.py
@@ -11,6 +11,8 @@ from subprocess import check_output
 from tensorflow.python.client import device_lib as _device_lib
 import tensorflow as tf
 
+from neuralmonkey.logging import debug
+
 
 __HAS_GPU_RESULT = None
 
@@ -85,7 +87,10 @@ initializers = {}  # type: Dict[str, Callable]
 def get_initializer(var_name: str, default: Callable = None):
     """Returns the initializer associated with the given variable name."""
     full_name = tf.get_variable_scope().name + "/" + var_name
-    return initializers.get(full_name, default)
+    initializer = initializers.get(full_name, default)
+    if initializer is not default:
+        debug("Using {} for variable {}".format(initializer, full_name))
+    return initializer
 
 
 def get_variable(name: str,
@@ -96,7 +101,7 @@ def get_variable(name: str,
     """A wrapper around tf.get_variable which uses the right initializer.
 
     The `initializer` parameter is treated as a default which can be overriden
-    by a call to `set_initializers`.
+    by updating the `initializers` dictionary.
     """
     return tf.get_variable(
         name=name, shape=shape, dtype=dtype,

--- a/neuralmonkey/tf_utils.py
+++ b/neuralmonkey/tf_utils.py
@@ -81,13 +81,17 @@ def gpu_memusage() -> str:
     return 'MiB:' + ",".join(info)
 
 
-initializers = {}  # type: Dict[str, Callable]
+_initializers = {}  # type: Dict[str, Callable]
+
+
+def update_initializers(initializers: Iterable[Tuple[str, Callable]]):
+    _initializers.update(initializers)
 
 
 def get_initializer(var_name: str, default: Callable = None):
     """Returns the initializer associated with the given variable name."""
     full_name = tf.get_variable_scope().name + "/" + var_name
-    initializer = initializers.get(full_name, default)
+    initializer = _initializers.get(full_name, default)
     if initializer is not default:
         debug("Using {} for variable {}".format(initializer, full_name))
     return initializer
@@ -101,7 +105,7 @@ def get_variable(name: str,
     """A wrapper around tf.get_variable which uses the right initializer.
 
     The `initializer` parameter is treated as a default which can be overriden
-    by updating the `initializers` dictionary.
+    by a call to `update_initializers`.
     """
     return tf.get_variable(
         name=name, shape=shape, dtype=dtype,

--- a/neuralmonkey/tf_utils.py
+++ b/neuralmonkey/tf_utils.py
@@ -89,7 +89,7 @@ def update_initializers(initializers: Iterable[Tuple[str, Callable]]):
 
 
 def get_initializer(var_name: str, default: Callable = None):
-    """Returns the initializer associated with the given variable name."""
+    """Return the initializer associated with the given variable name."""
     full_name = tf.get_variable_scope().name + "/" + var_name
     initializer = _initializers.get(full_name, default)
     if initializer is not default:
@@ -102,10 +102,11 @@ def get_variable(name: str,
                  dtype: tf.DType = None,
                  initializer: Callable = None,
                  *args, **kwargs):
-    """A wrapper around tf.get_variable which uses the right initializer.
+    """Get an existing variable with these parameters or create a new one.
 
-    The `initializer` parameter is treated as a default which can be overriden
-    by a call to `update_initializers`.
+    This is a wrapper around `tf.get_variable`. The `initializer` parameter is
+    treated as a default which can be overriden by a call to
+    `update_initializers`.
     """
     return tf.get_variable(
         name=name, shape=shape, dtype=dtype,

--- a/neuralmonkey/tf_utils.py
+++ b/neuralmonkey/tf_utils.py
@@ -5,7 +5,7 @@
 
 import os
 from collections import defaultdict
-from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 from subprocess import check_output
 from tensorflow.python.client import device_lib as _device_lib
@@ -82,6 +82,7 @@ def gpu_memusage() -> str:
 
 
 _initializers = {}  # type: Dict[str, Callable]
+_initialized_variables = set()  # type: Set[str]
 
 
 def update_initializers(initializers: Iterable[Tuple[str, Callable]]) -> None:
@@ -95,7 +96,14 @@ def get_initializer(var_name: str,
     initializer = _initializers.get(full_name, default)
     if initializer is not default:
         debug("Using {} for variable {}".format(initializer, full_name))
+    _initialized_variables.add(full_name)
     return initializer
+
+
+def get_unused_initializers() -> List[str]:
+    """Return the names of unused initializers."""
+    return [name for name in _initializers
+            if name not in _initialized_variables]
 
 
 def get_variable(name: str,

--- a/neuralmonkey/train.py
+++ b/neuralmonkey/train.py
@@ -11,7 +11,8 @@ import numpy as np
 import tensorflow as tf
 from tensorflow.contrib.tensorboard.plugins import projector
 
-from neuralmonkey.checking import CheckingException, check_dataset_and_coders
+from neuralmonkey.checking import (CheckingException, check_dataset_and_coders,
+                                   check_unused_initializers)
 from neuralmonkey.logging import Logging, log
 from neuralmonkey.config.configuration import Configuration
 from neuralmonkey.learning_utils import training_loop
@@ -189,6 +190,8 @@ def _main() -> None:
         else:
             for val_dataset in cfg.model.val_dataset:
                 check_dataset_and_coders(val_dataset, cfg.model.runners)
+
+        check_unused_initializers()
     except CheckingException as exc:
         log(str(exc), color="red")
         exit(1)

--- a/tests/small.ini
+++ b/tests/small.ini
@@ -68,6 +68,12 @@ dropout_keep_prob=$drop_keep_p
 data_id="source"
 vocabulary=<encoder_vocabulary>
 rnn_cell="NematusGRU"
+embedding_initializer=<embedding_initializer>
+
+[embedding_initializer]
+class=tf.random_uniform_initializer
+minval=0.0
+maxval=0.5
 
 [attention]
 class=attention.Attention

--- a/tests/small.ini
+++ b/tests/small.ini
@@ -72,7 +72,7 @@ embedding_initializer=<embedding_initializer>
 
 [embedding_initializer]
 class=tf.random_uniform_initializer
-minval=0.0
+minval=-0.5
 maxval=0.5
 
 [attention]

--- a/tests/small.ini
+++ b/tests/small.ini
@@ -73,6 +73,11 @@ rnn_cell="NematusGRU"
 class=attention.Attention
 name="attention_sentence_encoder"
 encoder=<encoder>
+initializers=[("Attention/attn_query_projection", <query_projection_initializer>)]
+
+[query_projection_initializer]
+class=tf.random_normal_initializer
+stddev=0.001
 
 [decoder_vocabulary]
 class=vocabulary.from_wordlist


### PR DESCRIPTION
- Add the `initializers` argument to `ModelPart.__init__`. This is a list of tuples pairing variable names (in the model part's scope) with initializers.
- Add `tf_utils.get_variable`, a wrapper around `tf.get_variable`, which makes sure the right initializer is used.

It's still not very convenient: you need to create a section in the ini file for every initializer.