### PR TITLE
Fix image resize in image reader

### DIFF
--- a/neuralmonkey/readers/image_reader.py
+++ b/neuralmonkey/readers/image_reader.py
@@ -1,5 +1,6 @@
 from typing import Callable, Iterable, List, Optional
 import os
+from typeguard import check_argument_types
 import numpy as np
 from PIL import Image, ImageFile
 ImageFile.LOAD_TRUNCATED_IMAGES = True
@@ -33,6 +34,7 @@ def image_reader(prefix="",
         pad_h x pad_w x number of channels.
     """
 
+    check_argument_types()
     if not rescale_w and not rescale_h and keep_aspect_ratio:
         raise ValueError(
             "It does not make sense to keep the aspect ratio while not "
@@ -83,6 +85,8 @@ def imagenet_reader(prefix: str,
                     target_width: int = 227,
                     target_height: int = 227) -> Callable:
     """Load and prepare image the same way as Caffe scripts."""
+    check_argument_types()
+
     def load(list_files: List[str]) -> Iterable[np.ndarray]:
         for list_file in list_files:
             with open(list_file) as f_list:

--- a/neuralmonkey/readers/image_reader.py
+++ b/neuralmonkey/readers/image_reader.py
@@ -128,20 +128,20 @@ def _rescale_or_crop(image: Image.Image, pad_w: int, pad_h: int,
         return image
 
     if rescale_w and rescale_h and not keep_aspect_ratio:
-        image.thumbnail((pad_w, pad_h))
+        image = image.resize((pad_w, pad_h), Image.BILINEAR)
     elif rescale_w and rescale_h and keep_aspect_ratio:
         ratio = min(pad_h / orig_h, pad_w / orig_h)
-        image.thumbnail((int(orig_w * ratio), int(orig_h * ratio)))
+        image = image.resize((int(orig_w * ratio), int(orig_h * ratio)))
     elif rescale_w and not rescale_h:
         orig_w, orig_h = image.size
         if orig_w != pad_w:
             ratio = pad_w / orig_w
-            image.thumbnail((pad_w, int(orig_h * ratio)))
+            image = image.resize((pad_w, int(orig_h * ratio)))
     elif rescale_h and not rescale_w:
         orig_w, orig_h = image.size
         if orig_h != pad_h:
             ratio = pad_h / orig_h
-            image.thumbnail((int(orig_w * ratio), pad_h))
+            image = image.resize((int(orig_w * ratio), pad_h))
     return _crop(image, pad_w, pad_h)
 
 


### PR DESCRIPTION
This replaces deprecated function from PIL. Images were not resized as configured, so they were instead cropped or padded to fit the network input.