### PR TITLE
Refactor ImageNet wrapper such that it uses tensorflow/models

### DIFF
--- a/neuralmonkey/encoders/imagenet_encoder.py
+++ b/neuralmonkey/encoders/imagenet_encoder.py
@@ -128,7 +128,8 @@ class ImageNet(ModelPart, SpatialStatefulWithOutput):
         """
         check_argument_types()
 
-        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint)
+        ModelPart.__init__(self, name, load_checkpoint=load_checkpoint,
+                           initializers=initializers, save_checkpoint=None)
         sys.path.insert(0, slim_models_path)
 
         self.data_id = data_id

--- a/neuralmonkey/encoders/imagenet_encoder.py
+++ b/neuralmonkey/encoders/imagenet_encoder.py
@@ -105,7 +105,7 @@ class ImageNet(ModelPart, SpatialStatefulWithOutput):
                  network_type: str,
                  slim_models_path: str,
                  load_checkpoint: str = None,
-                 spacial_layer: str = None,
+                 spatial_layer: str = None,
                  encoded_layer: str = None,
                  initializers: InitializerSpecs = None) -> None:
         """Initialize pre-trained ImageNet network.
@@ -115,7 +115,7 @@ class ImageNet(ModelPart, SpatialStatefulWithOutput):
                 scope, independently on `name`).
             data_id: Id of series with images (list of 3D numpy arrays)
             network_type: Identifier of ImageNet network from TFSlim.
-            spacial_layer: String identifier of the convolutional map
+            spatial_layer: String identifier of the convolutional map
                 (model's endpoint). Check
                 TFSlim documentation for end point specifications.
             encoded_layer: String id of the network layer that will be used as
@@ -134,7 +134,7 @@ class ImageNet(ModelPart, SpatialStatefulWithOutput):
 
         self.data_id = data_id
         self.network_type = network_type
-        self.spacial_layer = spacial_layer
+        self.spatial_layer = spatial_layer
         self.encoded_layer = encoded_layer
 
         if self.network_type not in SUPPORTED_NETWORKS:
@@ -148,19 +148,19 @@ class ImageNet(ModelPart, SpatialStatefulWithOutput):
         with tf_slim.arg_scope(net_specification.scope()):
             _, self.end_points = net_specification.apply_net(self.input_image)
 
-        if (self.spacial_layer is not None and
-                self.spacial_layer not in self.end_points):
+        if (self.spatial_layer is not None and
+                self.spatial_layer not in self.end_points):
             raise ValueError(
                 "Network '{}' does not contain endpoint '{}'".format(
-                    self.network_type, self.spacial_layer))
+                    self.network_type, self.spatial_layer))
 
-        if spacial_layer is not None:
-            net_output = self.end_points[self.spacial_layer]
+        if spatial_layer is not None:
+            net_output = self.end_points[self.spatial_layer]
             if len(net_output.get_shape()) != 4:
                 raise ValueError(
                     ("Endpoint '{}' for network '{}' cannot be "
                      "a convolutional map, its dimensionality is: {}."
-                    ).format(self.spacial_layer, self.network_type,
+                    ).format(self.spatial_layer, self.network_type,
                              ", ".join([str(d.value) for d in
                                         net_output.get_shape()])))
 
@@ -177,16 +177,16 @@ class ImageNet(ModelPart, SpatialStatefulWithOutput):
 
     @tensor
     def spatial_states(self) -> Optional[tf.Tensor]:
-        if self.spacial_layer is None:
+        if self.spatial_layer is None:
             return None
 
-        net_output = self.end_points[self.spacial_layer]
+        net_output = self.end_points[self.spatial_layer]
         net_output = tf.stop_gradient(net_output)
         return net_output
 
     @tensor
     def spatial_mask(self) -> tf.Tensor:
-        if self.spacial_layer is None:
+        if self.spatial_layer is None:
             return None
         mask = tf.ones(tf.shape(self.spatial_states)[:3])
         # pylint: disable=no-member

--- a/neuralmonkey/encoders/imagenet_encoder.py
+++ b/neuralmonkey/encoders/imagenet_encoder.py
@@ -12,7 +12,6 @@ import tensorflow.contrib.slim as tf_slim
 import tensorflow.contrib.slim.nets
 # pylint: enable=unused-import
 
-from neuralmonkey.logging import warn
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.decorators import tensor
 from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
@@ -20,45 +19,43 @@ from neuralmonkey.model.stateful import SpatialStatefulWithOutput
 
 
 SUPPORTED_NETWORKS = {
-    "AlexNet": (tf_slim.nets.alexnet.alexnet_v2_arg_scope,
-                tf_slim.nets.alexnet.alexnet_v2),
-    "resnet_v1_50": (tf_slim.nets.resnet_v1.resnet_arg_scope,
-                     tf_slim.nets.resnet_v1.resnet_v1_50),
-    "resnet_v1_101": (tf_slim.nets.resnet_v1.resnet_arg_scope,
-                      tf_slim.nets.resnet_v1.resnet_v1_101),
-    "resnet_v1_152": (tf_slim.nets.resnet_v1.resnet_arg_scope,
-                      tf_slim.nets.resnet_v1.resnet_v1_152),
-    "InceptionV1": (tf_slim.nets.inception.inception_v1_arg_scope,
-                    tf_slim.nets.inception.inception_v1),
-    "InceptionV2": (tf_slim.nets.inception.inception_v2_arg_scope,
-                    tf_slim.nets.inception.inception_v2),
-    "InceptionV3": (tf_slim.nets.inception.inception_v3_arg_scope,
-                    tf_slim.nets.inception.inception_v3),
-    # "inception_v4": (tf_slim.nets.inception.inception_v4_arg_scope,
-    #                  tf_slim.nets.inception.inception_v4),
-    "vgg_16": (tf_slim.nets.vgg.vgg_arg_scope,
-               tf_slim.nets.vgg.vgg_16),
-    "vgg_19": (tf_slim.nets.vgg.vgg_arg_scope,
-               tf_slim.nets.vgg.vgg_19),
+    "AlexNet": (
+        tf_slim.nets.alexnet.alexnet_v2_arg_scope, (224, 224),
+        lambda image: tf_slim.nets.alexnet.alexnet_v2(image)),
+    "VGG16": (
+        tf_slim.nets.vgg.vgg_arg_scope, (224, 224),
+        lambda image: tf_slim.nets.vgg.vgg_16(
+            image, is_training=False, dropout_keep_prob=1.0)),
+    "VGG19": (
+        tf_slim.nets.vgg.vgg_arg_scope, (224, 224),
+        lambda image: tf_slim.nets.vgg.vgg_19(
+            image, is_training=False, dropout_keep_prob=1.0)),
+    "ResNet_v2_50": (
+        tf_slim.nets.resnet_v2.resnet_arg_scope, (229, 229),
+        lambda image: tf_slim.nets.resnet_v2.resnet_v2_50(
+            image, is_training=False, global_pool=False)),
+    "ResNet_v2_101": (
+        tf_slim.nets.resnet_v2.resnet_arg_scope, (229, 229),
+        lambda image: tf_slim.nets.resnet_v2.resnet_v2_101(
+            image, is_training=False, global_pool=False)),
+    "ResNet_v2_152": (
+        tf_slim.nets.resnet_v2.resnet_arg_scope, (229, 229),
+        lambda image: tf_slim.nets.resnet_v2.resnet_v2_152(
+            image, is_training=False, global_pool=False)),
 }
 
 
 class ImageNet(ModelPart, SpatialStatefulWithOutput):
     """Pre-trained ImageNet network."""
 
-    WIDTH = 224
-    HEIGHT = 224
-
     # pylint: disable=too-many-arguments
     def __init__(self,
                  name: str,
                  data_id: str,
                  network_type: str,
-                 attention_layer: Optional[str] = None,
-                 fine_tune: bool = False,
-                 encoded_layer: Optional[str] = None,
-                 save_checkpoint: Optional[str] = None,
-                 load_checkpoint: Optional[str] = None,
+                 load_checkpoint: str,
+                 spacial_layer: str = None,
+                 encoded_layer: str = None,
                  initializers: InitializerSpecs = None) -> None:
         """Initialize pre-trained ImageNet network.
 
@@ -67,58 +64,48 @@ class ImageNet(ModelPart, SpatialStatefulWithOutput):
                 scope, independently on `name`).
             data_id: Id of series with images (list of 3D numpy arrays)
             network_type: Identifier of ImageNet network from TFSlim.
-            attention_layer: String identifier of the convolutional map
-                (model's endpoint) that will be used for attention. Check
+            spacial_layer: String identifier of the convolutional map
+                (model's endpoint). Check
                 TFSlim documentation for end point specifications.
-            attention_state_size: Dimensionality of state projection in
-                attention computation.
-            fine_tune: Flag whether the network should be further trained with
-                the rest of the model.
             encoded_layer: String id of the network layer that will be used as
                 input of a decoder. `None` means averaging the convolutional
                 maps.
-            save_checkpoint: Checkpoint file where the encoder is saved after
-                the training. (Makes sense only if `fine_tune` is set to
-                `True`).
             load_checkpoint: Checkpoint file from which the pre-trained network
                 is loaded.
         """
         check_argument_types()
-        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint,
-                           initializers)
 
-        if save_checkpoint is not None and not fine_tune:
-            warn("The ImageNet network is not fine-tuned and still it is set "
-                 "to save after the training is finished.")
+        ModelPart.__init__(self, name, load_checkpoint, initializers,
+                           save_checkpoint=None)
 
         self.data_id = data_id
         self.network_type = network_type
-        self.attention_layer = attention_layer
+        self.spacial_layer = spacial_layer
         self.encoded_layer = encoded_layer
-        self.fine_tune = fine_tune
 
         if self.network_type not in SUPPORTED_NETWORKS:
             raise ValueError(
-                "Network '{}' is not among the supoort ones ({})".format(
+                "Network '{}' is not among the supported ones ({})".format(
                     self.network_type, ", ".join(SUPPORTED_NETWORKS.keys())))
 
-        scope, net_function = SUPPORTED_NETWORKS[self.network_type]
+        (scope, (self.height, self.width),
+         net_function) = SUPPORTED_NETWORKS[self.network_type]
         with tf_slim.arg_scope(scope()):
             _, self.end_points = net_function(self.input_image)
 
-        if (self.attention_layer is not None and
-                self.attention_layer not in self.end_points):
+        if (self.spacial_layer is not None and
+                self.spacial_layer not in self.end_points):
             raise ValueError(
                 "Network '{}' does not contain endpoint '{}'".format(
-                    self.network_type, self.attention_layer))
+                    self.network_type, self.spacial_layer))
 
-        if attention_layer is not None:
-            net_output = self.end_points[self.attention_layer]
+        if spacial_layer is not None:
+            net_output = self.end_points[self.spacial_layer]
             if len(net_output.get_shape()) != 4:
                 raise ValueError(
                     ("Endpoint '{}' for network '{}' cannot be "
                      "a convolutional map, its dimensionality is: {}."
-                    ).format(self.attention_layer, self.network_type,
+                    ).format(self.spacial_layer, self.network_type,
                              ", ".join([str(d.value) for d in
                                         net_output.get_shape()])))
 
@@ -131,22 +118,20 @@ class ImageNet(ModelPart, SpatialStatefulWithOutput):
     @tensor
     def input_image(self) -> tf.Tensor:
         return tf.placeholder(
-            tf.float32, [None, self.HEIGHT, self.WIDTH, 3])
+            tf.float32, [None, self.height, self.width, 3])
 
     @tensor
     def spatial_states(self) -> Optional[tf.Tensor]:
-        if self.attention_layer is None:
+        if self.spacial_layer is None:
             return None
 
-        net_output = self.end_points[self.attention_layer]
-
-        if not self.fine_tune:
-            net_output = tf.stop_gradient(net_output)
+        net_output = self.end_points[self.spacial_layer]
+        net_output = tf.stop_gradient(net_output)
         return net_output
 
     @tensor
     def spatial_mask(self) -> tf.Tensor:
-        if self.attention_layer is None:
+        if self.spacial_layer is None:
             return None
         mask = tf.ones(tf.shape(self.spatial_states)[:3])
         # pylint: disable=no-member
@@ -160,8 +145,7 @@ class ImageNet(ModelPart, SpatialStatefulWithOutput):
             return tf.reduce_mean(self.spatial_states, [1, 2])
 
         encoded = tf.squeeze(self.end_points[self.encoded_layer], [1, 2])
-        if not self.fine_tune:
-            encoded = tf.stop_gradient(encoded)
+        encoded = tf.stop_gradient(encoded)
         return encoded
 
     def _init_saver(self) -> None:
@@ -176,6 +160,6 @@ class ImageNet(ModelPart, SpatialStatefulWithOutput):
 
     def feed_dict(self, dataset: Dataset, train: bool = False) -> FeedDict:
         images = np.array(dataset.get_series(self.data_id))
-        assert images.shape[1:] == (self.HEIGHT, self.WIDTH, 3)
+        assert images.shape[1:] == (self.height, self.width, 3)
 
         return {self.input_image: images}

--- a/tests/captioning.ini
+++ b/tests/captioning.ini
@@ -23,11 +23,11 @@ num_threads=4
 num_sessions=1
 
 [image_reader]
-class=readers.image_reader.image_reader
+class=readers.image_reader.imagenet_reader
 prefix="tests/data/flickr30k"
-pad_h=224
-pad_w=224
-mode="RGB"
+target_width=224
+target_height=224
+vgg_normalization=True
 
 [train_data]
 class=dataset.load_dataset_from_files
@@ -47,8 +47,9 @@ s_images=("tests/data/flickr30k/val_images.txt", <image_reader>)
 class=encoders.imagenet_encoder.ImageNet
 name="imagenet_vgg"
 data_id="images"
-network_type="vgg_16"
-attention_layer="vgg_16/conv5/conv5_3"
+network_type="VGG16"
+spacial_layer="vgg_16/conv5/conv5_3"
+slim_models_path="tests/tensorflow-models/research/slim"
 
 [attention]
 class=attention.Attention

--- a/tests/flat-multiattention.ini
+++ b/tests/flat-multiattention.ini
@@ -25,8 +25,8 @@ num_sessions=1
 [image_reader]
 class=readers.image_reader.image_reader
 prefix="tests/data/flickr30k"
-pad_h=224
-pad_w=224
+pad_h=32
+pad_w=32
 mode="RGB"
 
 [train_data]
@@ -42,11 +42,14 @@ s_source="tests/data/flickr30k/val.en"
 s_images=("tests/data/flickr30k/val_images.txt", <image_reader>)
 
 [imagenet]
-class=encoders.imagenet_encoder.ImageNet
-name="imagenet_vgg"
+class=encoders.cnn_encoder.CNNEncoder
+name="cnn"
 data_id="images"
-network_type="vgg_16"
-attention_layer="vgg_16/conv5/conv5_3"
+batch_normalize=True
+image_height=32
+image_width=32
+pixel_dim=3
+convolutions=[("C", 3, 1, "valid", 4),  ("M", 2, 2, "same"), ("M", 2, 2, "same")]
 
 [encoder]
 class=encoders.recurrent.SentenceEncoder

--- a/tests/hier-multiattention.ini
+++ b/tests/hier-multiattention.ini
@@ -25,8 +25,8 @@ num_sessions=1
 [image_reader]
 class=readers.image_reader.image_reader
 prefix="tests/data/flickr30k"
-pad_h=224
-pad_w=224
+pad_h=32
+pad_w=32
 mode="RGB"
 
 [train_data]
@@ -42,11 +42,14 @@ s_source="tests/data/flickr30k/val.en"
 s_images=("tests/data/flickr30k/val_images.txt", <image_reader>)
 
 [imagenet]
-class=encoders.imagenet_encoder.ImageNet
-name="imagenet_vgg"
+class=encoders.cnn_encoder.CNNEncoder
+name="cnn"
 data_id="images"
-network_type="vgg_16"
-attention_layer="vgg_16/conv5/conv5_3"
+batch_normalize=True
+image_height=32
+image_width=32
+pixel_dim=3
+convolutions=[("C", 3, 1, "valid", 4),  ("M", 2, 2, "same"), ("M", 2, 2, "same")]
 
 [encoder]
 class=encoders.recurrent.SentenceEncoder

--- a/tests/tests_run.sh
+++ b/tests/tests_run.sh
@@ -43,7 +43,10 @@ curl 127.0.0.1:5000/run -H "Content-Type: application/json" -X POST -d '{"source
 kill $SERVER_PID
 
 bin/neuralmonkey-train tests/str.ini
-bin/neuralmonkey-train tests/captioning.ini
+
+# git clone https://github.com/tensorflow/models tests/tensorflow-models
+# bin/neuralmonkey-train tests/captioning.ini
+
 bin/neuralmonkey-train tests/flat-multiattention.ini
 bin/neuralmonkey-train tests/hier-multiattention.ini
 


### PR DESCRIPTION
The ImageNet wrapper is updated:

* the pre-trained networks are no longer from `tf.contrib.slim.nets`, but from [tensorflow/models repository](https://github.com/tensorflow/models) which needs to be cloned independently
* it is no longer possible to fine-tune the networks during training (there is no easy way, how to switch them between training/validation mode) and it in fact never worked
* `imagenet_reader` now has proper pre-processing for VGG nets and ResNet

Closes #425.