### PR TITLE
Default "name" argument

### DIFF
--- a/neuralmonkey/config/builder.py
+++ b/neuralmonkey/config/builder.py
@@ -7,7 +7,7 @@ specified by the experiment configuration.
 import collections
 import importlib
 from argparse import Namespace
-from inspect import signature, isclass, isfunction, _empty
+from inspect import signature, isclass, isfunction, Parameter
 from typing import Any, Dict, Set, Tuple
 
 from neuralmonkey.logging import debug, warn
@@ -171,14 +171,14 @@ def instantiate_class(name: str,
     if "name" in construct_sig.parameters and "name" not in arguments:
         annotation = construct_sig.parameters["name"].annotation
 
-        if annotation == _empty:
+        if annotation == Parameter.empty:
             warn("No type annotation for the 'name' parameter in "
-                "class/function {}. Default value will not be used."
-                .format(this_dict["class"].clazz))
+                 "class/function {}. Default value will not be used."
+                 .format(this_dict["class"].clazz))
         elif annotation != str:
             warn("Type annotation for the 'name' parameter in class/function "
-                "{} is not 'str'. Default value will not be used."
-                .format(this_dict["class"].clazz))
+                 "{} is not 'str'. Default value will not be used."
+                 .format(this_dict["class"].clazz))
             warn("Annotation is {}".format(str(annotation)))
         else:
             debug("Using default 'name' for object {}"

--- a/neuralmonkey/config/builder.py
+++ b/neuralmonkey/config/builder.py
@@ -172,14 +172,14 @@ def instantiate_class(name: str,
         annotation = construct_sig.parameters["name"].annotation
 
         if annotation == Parameter.empty:
-            warn("No type annotation for the 'name' parameter in "
-                 "class/function {}. Default value will not be used."
-                 .format(this_dict["class"].clazz))
+            debug("No type annotation for the 'name' parameter in "
+                  "class/function {}. Default value will not be used."
+                  .format(this_dict["class"].clazz), "configBuild")
         elif annotation != str:
-            warn("Type annotation for the 'name' parameter in class/function "
-                 "{} is not 'str'. Default value will not be used."
-                 .format(this_dict["class"].clazz))
-            warn("Annotation is {}".format(str(annotation)))
+            debug("Type annotation for the 'name' parameter in class/function "
+                  "{} is not 'str'. Default value will not be used."
+                  .format(this_dict["class"].clazz), "configBuild")
+            debug("Annotation is {}".format(str(annotation)))
         else:
             debug("Using default 'name' for object {}"
                   .format(this_dict["class"].clazz), "configBuild")

--- a/neuralmonkey/dataset.py
+++ b/neuralmonkey/dataset.py
@@ -320,7 +320,7 @@ class LazyDataset(Dataset):
 
 
 def from_files(
-        name: str, lazy: bool = False,
+        name: str = None, lazy: bool = False,
         preprocessors: List[Tuple[str, str, Callable]] = None,
         **kwargs) -> Dataset:
     """Load a dataset from the files specified by the provided arguments.

--- a/neuralmonkey/dataset.py
+++ b/neuralmonkey/dataset.py
@@ -320,7 +320,7 @@ class LazyDataset(Dataset):
 
 
 def from_files(
-        name: str = None, lazy: bool = False,
+        name: str, lazy: bool = False,
         preprocessors: List[Tuple[str, str, Callable]] = None,
         **kwargs) -> Dataset:
     """Load a dataset from the files specified by the provided arguments.
@@ -364,9 +364,6 @@ def from_files(
     log("Initializing dataset with: {}".format(
         ", ".join(series_paths_and_readers)))
 
-    if name is None:
-        name = _get_name_from_paths(series_paths_and_readers)
-
     if lazy:
         dataset = LazyDataset(name, series_paths_and_readers, series_outputs,
                               preprocessors)  # type: Dataset
@@ -383,23 +380,6 @@ def from_files(
 
 
 load_dataset_from_files = from_files  # pylint: disable=invalid-name
-
-
-def _get_name_from_paths(series_paths: Dict[str, Tuple[List[str],
-                                                       Reader]]) -> str:
-    """Construct name for a dataset using the paths to its files.
-
-    Arguments:
-        series_paths: A dictionary which maps serie names to the paths
-                      of their input files.
-
-    Returns:
-        The name for the dataset.
-    """
-    name = "dataset"
-    for paths, _ in series_paths.values():
-        name += "-{}".format("+".join(paths))
-    return name
 
 
 def _get_series_paths_and_readers(

--- a/neuralmonkey/evaluators/bleu.py
+++ b/neuralmonkey/evaluators/bleu.py
@@ -1,12 +1,12 @@
 from collections import Counter
-from typing import List, Tuple, Optional
+from typing import List, Tuple
 import numpy as np
 
 
 class BLEUEvaluator(object):
 
     def __init__(self, n: int = 4, deduplicate: bool = False,
-                 name: Optional[str] = None) -> None:
+                 name: str = None) -> None:
         self.n = n
         self.deduplicate = deduplicate
 

--- a/tests/bpe.ini
+++ b/tests/bpe.ini
@@ -104,6 +104,7 @@ optimizer=<adadelta>
 
 [adadelta]
 class=tf.train.AdadeltaOptimizer
+name="adadelta"
 learning_rate=1.0e-4
 epsilon=1.0e-6
 rho=0.95

--- a/tests/small.ini
+++ b/tests/small.ini
@@ -50,9 +50,8 @@ preprocessors=[("source", "source_chars", processors.helpers.preprocess_char_bas
 class=vocabulary.from_wordlist
 path="tests/outputs/vocab/encoder_vocab.tsv"
 
-[encoder]
+[my_encoder]
 class=encoders.SentenceEncoder
-name="sentence_encoder"
 rnn_size=7
 max_input_len=5
 embedding_size=11
@@ -67,10 +66,9 @@ class=tf.random_uniform_initializer
 minval=-0.5
 maxval=0.5
 
-[attention]
+[my_attention]
 class=attention.Attention
-name="attention_sentence_encoder"
-encoder=<encoder>
+encoder=<my_encoder>
 initializers=[("Attention/attn_query_projection", <query_projection_initializer>)]
 
 [query_projection_initializer]
@@ -81,12 +79,11 @@ stddev=0.001
 class=vocabulary.from_wordlist
 path="tests/outputs/vocab/decoder_vocab.tsv"
 
-[decoder]
+[my_decoder]
 class=decoders.Decoder
 conditional_gru=True
-name="decoder"
-encoders=[<encoder>]
-attentions=[<attention>]
+encoders=[<my_encoder>]
+attentions=[<my_attention>]
 rnn_size=8
 embedding_size=9
 dropout_keep_prob=$drop_keep_p
@@ -98,11 +95,11 @@ rnn_cell="NematusGRU"
 
 [trainer]
 class=trainers.CrossEntropyTrainer
-decoders=[<decoder>]
+decoders=[<my_decoder>]
 l2_weight=1.0e-8
 clip_norm=1.0
 
 [runner]
 class=runners.GreedyRunner
-decoder=<decoder>
+decoder=<my_decoder>
 output_series="target"

--- a/tests/tests_run.sh
+++ b/tests/tests_run.sh
@@ -27,7 +27,7 @@ NM_EXPERIMENT_NAME=small bin/neuralmonkey-train tests/small.ini
 export NM_EXPERIMENT_NAME='"small"'
 bin/neuralmonkey-run tests/small.ini tests/test_data.ini
 bin/neuralmonkey-run tests/small.ini tests/test_data.ini --json /dev/stdout \
-    | python -c 'import sys,json; print(json.load(sys.stdin)[0]["target/BLEU-4"])'
+    | python -c 'import sys,json; print(json.load(sys.stdin)[0]["target/bleu"])'
 unset NM_EXPERIMENT_NAME
 
 bin/neuralmonkey-train tests/small_sent_cnn.ini


### PR DESCRIPTION
If a function call/class constructor associated with a configuration object has a "name" attribute which is annotated as `str`, the default value for this argument will be inferred from the configration section header.