### PR TITLE
Super-duper tensor logging functionality

### DIFF
--- a/neuralmonkey/decorators.py
+++ b/neuralmonkey/decorators.py
@@ -1,6 +1,9 @@
 from functools import wraps
 
+import tensorflow as tf
+
 from neuralmonkey.model.model_part import ModelPart
+from neuralmonkey.tf_utils import tf_print
 
 
 def tensor(func):
@@ -12,6 +15,9 @@ def tensor(func):
                 # jump out of the caller's scope and into the ModelPart's scope
                 with self.use_scope():
                     value = func(self, *args, **kwargs)
+                    if isinstance(value, tf.Tensor):
+                        value = tf_print(
+                            value, "<{}.{}>".format(self.name, func.__name__))
             else:
                 value = func(self, *args, **kwargs)
             setattr(self, attribute_name, value)

--- a/neuralmonkey/decorators.py
+++ b/neuralmonkey/decorators.py
@@ -17,7 +17,8 @@ def tensor(func):
                     value = func(self, *args, **kwargs)
                     if isinstance(value, tf.Tensor):
                         value = tf_print(
-                            value, "<{}.{}>".format(self.name, func.__name__))
+                            value, "<{}.{}>".format(self.name, func.__name__),
+                            "tensorval")
             else:
                 value = func(self, *args, **kwargs)
             setattr(self, attribute_name, value)

--- a/neuralmonkey/logging.py
+++ b/neuralmonkey/logging.py
@@ -3,7 +3,7 @@ import sys
 import os
 
 # pylint: disable=unused-import
-from typing import Any, Optional, List
+from typing import Any, List
 # pylint: enable=unused-import
 
 from termcolor import colored
@@ -11,13 +11,13 @@ from termcolor import colored
 
 class Logging(object):
 
-    log_file = None  # type: Optional[Any]
+    log_file = None  # type: Any
 
     # 'all' and 'none' are special symbols,
     # others are filtered according the labels
-    debug_enabled = [
+    debug_enabled_for = [
         os.environ.get("NEURALMONKEY_DEBUG_ENABLE", "none")]  # type: List[str]
-    debug_disabled = [
+    debug_disabled_for = [
         os.environ.get("NEURALMONKEY_DEBUG_DISABLE", "")]  # type: List[str]
     strict_mode = os.environ.get("NEURALMONKEY_STRICT")  # type: str
 
@@ -76,15 +76,8 @@ class Logging(object):
         log_print("")
 
     @staticmethod
-    def debug(message: str, label: Optional[str] = None):
-        if "none" in Logging.debug_enabled:
-            return
-
-        if (label not in Logging.debug_enabled and
-                "all" not in Logging.debug_enabled):
-            return
-
-        if label in Logging.debug_disabled:
+    def debug(message: str, label: str = None):
+        if not debug_enabled(label):
             return
 
         if label:
@@ -94,6 +87,21 @@ class Logging(object):
 
         log_print("{}{}".format(colored(prefix, color="cyan"), message))
 
+    @staticmethod
+    def debug_enabled(label: str = None):
+        if "none" in Logging.debug_enabled_for:
+            return False
+
+        if label is None:
+            return True
+
+        if (label in Logging.debug_disabled_for
+                or ("all" not in Logging.debug_enabled_for
+                    and label not in Logging.debug_enabled_for)):
+            return False
+
+        return True
+
 
 # pylint: disable=invalid-name
 # we want these helper functions to have this exact name
@@ -102,3 +110,4 @@ log_print = Logging.log_print
 debug = Logging.debug
 warn = Logging.warn
 notice = Logging.notice
+debug_enabled = Logging.debug_enabled

--- a/neuralmonkey/logging.py
+++ b/neuralmonkey/logging.py
@@ -81,9 +81,9 @@ class Logging(object):
             return
 
         if label:
-            prefix = "DEBUG ({}):".format(label)
+            prefix = "{}: DEBUG ({}): ".format(Logging._get_time(), label)
         else:
-            prefix = "DEBUG:"
+            prefix = "{}: DEBUG: ".format(Logging._get_time())
 
         log_print("{}{}".format(colored(prefix, color="cyan"), message))
 

--- a/neuralmonkey/tf_utils.py
+++ b/neuralmonkey/tf_utils.py
@@ -3,7 +3,9 @@ from typing import Callable, Iterable, List, Optional, Tuple
 # pylint: disable=unused-import
 from typing import Dict, Set
 # pylint: enable=unused-import
+import numpy as np
 import tensorflow as tf
+
 from neuralmonkey.logging import debug, debug_enabled
 
 
@@ -63,11 +65,12 @@ def tf_print(tensor: tf.Tensor, message: str = None) -> tf.Tensor:
         As tf.Print, this function returns a tensor identical to the input
         tensor, with the printing side-effect added.
     """
-    def print_tensor(x: tf.Tensor) -> tf.Tensor:
+    def print_tensor(x: np.ndarray) -> tf.Tensor:
         if message is not None:
-            debug("{}: {}".format(message, x), "tensorval")
+            debug(
+                "{}, shape: {}:\n{}".format(message, x.shape, x), "tensorval")
         else:
-            debug(x, "tensorval")
+            debug("Shape: {}\n{}".format(x.shape, x), "tensorval")
         return x
 
     # To save time, check if debug will print something

--- a/neuralmonkey/tf_utils.py
+++ b/neuralmonkey/tf_utils.py
@@ -50,7 +50,9 @@ def get_variable(name: str,
         **kwargs)
 
 
-def tf_print(tensor: tf.Tensor, message: str = None) -> tf.Tensor:
+def tf_print(tensor: tf.Tensor,
+             message: str = None,
+             debug_label: str = None) -> tf.Tensor:
     """Print the value of a tensor to the debug log.
 
     Better than tf.Print, logs to console only when the "tensorval" debug
@@ -68,13 +70,13 @@ def tf_print(tensor: tf.Tensor, message: str = None) -> tf.Tensor:
     def print_tensor(x: np.ndarray) -> tf.Tensor:
         if message is not None:
             debug(
-                "{}, shape: {}:\n{}".format(message, x.shape, x), "tensorval")
+                "{}, shape: {}:\n{}".format(message, x.shape, x), debug_label)
         else:
-            debug("Shape: {}\n{}".format(x.shape, x), "tensorval")
+            debug("Shape: {}\n{}".format(x.shape, x), debug_label)
         return x
 
     # To save time, check if debug will print something
-    if not debug_enabled("tensorval"):
+    if not debug_enabled(debug_label):
         return tensor
 
     log_op = tf.py_func(print_tensor, [tensor], [tensor.dtype])[0]


### PR DESCRIPTION
This very simple pull request adds the `tf_utils.tf_print` function, which prints out the value of a tensor in the debug log under the label `tensorval`

So easy to use! Instead of `x = tf.Print(x, [x])`, just `from neuralmonkey.tf_utils import tf_print` and `x = tf_print(x: tf.Tensor, message: str = None)`!  

As a bonus, outputs of all `@tensor`-decorated functions that actually return a `tf.Tensor` are now `tf_print`ed automatically, with a nicely formatted message, like `<decoder.runtime_logprobs>: [[[ -1.91085453e+01  -1.91085453e+01  -1.94597607e+01, ...]`

You don't have to worry about calling the `py_func` when you are not interested in the tensor values. The `tf_print` function checks that beforehand.

So, how to summon this mighty feature? Just run neuralmonkey with `NEURALMONKEY_DEBUG_ENABLE=tensorval` environment variable.
