### PR TITLE
Batched Beam Search with Attentive Models

### DIFF
--- a/neuralmonkey/attention/base_attention.py
+++ b/neuralmonkey/attention/base_attention.py
@@ -5,23 +5,37 @@ See http://arxiv.org/abs/1606.07481
 The attention mechanisms used in Neural Monkey are inherited from the
 ``BaseAttention`` class defined in this module.
 
-Each attention object has the ``attention`` function which operates on the
-``attention_states`` tensor.  The attention function receives the query tensor,
-the decoder previous state and input, and its inner state, which could bear an
-arbitrary structure of information. The default structure for this is the
-``AttentionLoopState``, which contains a growing array of attention
-distributions and context vectors in time. That's why there is the
-``initial_loop_state`` function in the ``BaseAttention`` class.
+The attention function can be viewed as a soft lookup over an associative
+memory. The *query* vector is used to compute a similarity score of the *keys*
+of the associative memory and the resulting scores are used as weights in a
+weighted sum of the *values* associated with the keys. We call the
+(unnormalized) similarity scores *energies*, we call *attention distribution*
+the energies after (softmax) normalization, and we call the resulting
+weighted sum of states a *context vector*.
 
-Mainly for illustration purposes, the attention objects can keep their
-*histories*, which is a dictionary populated with attention distributions in
-time for every decoder, that used this attention object. This is because for
-example the recurrent decoder is can be run twice for each sentence - once in
-the *training* mode, in which the decoder gets the reference tokens on the
-input, and once in the *running* mode, in which it gets its own outputs. The
-histories object is constructed *after* the decoding and its construction
-should be triggered manually from the decoder by calling the ``finalize_loop``
-method.
+Note that it is possible (and true in most cases) that the attention keys
+are equal to the values. In case of self-attention, even queries are from the
+same set of vectors.
+
+To abstract over different flavors of attention mechanism, we conceptualize the
+procedure as follows: Each attention object has the ``attention`` function
+which operates on the query tensor. The attention function receives the query
+tensor (the decoder state) and optionally the previous state of the decoder,
+and computes the context vector. The function also receives a *loop state*,
+which is used to store data in an autoregressive loop that generates a
+sequence.
+
+The attention uses the loop state to store to store attention distributions
+and context vectors in time. This structure is called ``AttentionLoopState``.
+To be able to initialize the loop state, each attention object that uses this
+feature defines the ``initial_loop_state`` function with empty tensors.
+
+Since there can be many *modes* in which the decoder that uses the attention
+operates, the attention objects have the ``finalize_loop`` method, which takes
+the last attention loop state and the name of the mode (a string) and processes
+this data to be available in the ``histories`` dictionary. The single and most
+used example of two *modes* are the *train* and *runtime* modes of the
+autoregressive decoder.
 """
 from typing import NamedTuple, Dict, Optional, Any, Tuple, Union
 
@@ -33,49 +47,63 @@ from neuralmonkey.model.model_part import ModelPart, InitializerSpecs
 
 # pylint: disable=invalid-name
 Attendable = Union[TemporalStateful, SpatialStateful]
-AttentionLoopState = NamedTuple("AttentionLoopState",
-                                [("contexts", tf.Tensor),
-                                 ("weights", tf.Tensor)])
+AttentionLoopState = NamedTuple(
+    "AttentionLoopState", [("contexts", tf.Tensor), ("weights", tf.Tensor)])
 # pylint: enable=invalid-name
 
 
-def empty_attention_loop_state(batch_size: int) -> AttentionLoopState:
+def empty_attention_loop_state(
+        batch_size: Union[int, tf.Tensor]) -> AttentionLoopState:
     """Create an empty attention loop state.
 
     The attention loop state is a technical object for storing the attention
     distributions and the context vectors in time. It is used with the
-    ``tf.while_loop`` dynamic implementation of the decoder.
+    ``tf.while_loop`` dynamic implementation of decoders.
 
-    This function returns an empty attention loop state which means there are
-    two empty arrays, one for attention distributions in time, and one for
-    the attention context vectors in time.
+    Arguments:
+        batch_size: The size of the batch. This is needed to
+
+    Returns:
+        This function returns an empty attention loop state which means
+        there are two empty Tensors one for attention distributions in time,
+        and one for the attention context vectors in time.
     """
     return AttentionLoopState(
-        contexts=tf.zeros(
-            shape=[0, batch_size],
-            dtype=tf.float32,
-            name="contexts"),
-        weights=tf.zeros(
-            shape=[0, batch_size],
-            dtype=tf.float32,
-            name="distributions"))
+        contexts=tf.zeros(shape=[0, batch_size], name="contexts"),
+        weights=tf.zeros(shape=[0, batch_size], name="distributions"))
 
 
 def get_attention_states(encoder: Attendable) -> tf.Tensor:
+    """Return the temporal or spatial states of an encoder.
+
+    Arguments:
+        encoder: The encoder with the states to attend.
+
+    Returns:
+        Either a 3D or a 4D tensor, depending on whether the encoder is
+        temporal (e.g. recurrent encoder) or spatial (e.g. a CNN encoder).
+    """
     if isinstance(encoder, TemporalStateful):
         return encoder.temporal_states
 
     elif isinstance(encoder, SpatialStateful):
-        # pylint: disable=no-member
         shape = encoder.spatial_states.get_shape().as_list()
-        # pylint: enable=no-member
         return tf.reshape(encoder.spatial_states,
                           [-1, shape[1] * shape[2], shape[3]])
     else:
-        raise AssertionError("Unknown encoder type")
+        raise TypeError("Unknown encoder type")
 
 
 def get_attention_mask(encoder: Attendable) -> Optional[tf.Tensor]:
+    """Return the temporal or spatial mask of an encoder.
+
+    Arguments:
+        encoder: The encoder to get the mask from.
+
+    Returns:
+        Either a 2D or a 3D tensor, depending on whether the encoder is
+        temporal (e.g. recurrent encoder) or spatial (e.g. a CNN encoder).
+    """
     if isinstance(encoder, TemporalStateful):
         if encoder.temporal_mask is None:
             raise ValueError("The encoder temporal mask should not be none")
@@ -84,29 +112,36 @@ def get_attention_mask(encoder: Attendable) -> Optional[tf.Tensor]:
     elif isinstance(encoder, SpatialStateful):
         if encoder.spatial_mask is None:
             return None
-
-        # pylint: disable=no-member
         shape = encoder.spatial_states.get_shape().as_list()
-        # pylint: enable=no-member
         return tf.reshape(encoder.spatial_mask, [-1, shape[1] * shape[2]])
     else:
-        raise AssertionError("Unknown encoder type")
+        raise TypeError("Unknown encoder type")
 
 
 class BaseAttention(ModelPart):
+    """The abstract class for the attenion mechanism flavors."""
+
     def __init__(self,
                  name: str,
                  save_checkpoint: str = None,
                  load_checkpoint: str = None,
                  initializers: InitializerSpecs = None) -> None:
-        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint,
-                           initializers)
+        """Create a new ``BaseAttention`` object."""
+        ModelPart.__init__(
+            self, name, save_checkpoint, load_checkpoint, initializers)
 
         self.query_state_size = None  # type: tf.Tensor
         self._histories = {}  # type: Dict[str, tf.Tensor]
 
     @property
     def histories(self) -> Dict[str, tf.Tensor]:
+        """Return the attention histories dictionary.
+
+        Use this property after it has been populated.
+
+        Returns:
+            The attention histories dictionary.
+        """
         return self._histories
 
     def attention(self,
@@ -118,23 +153,61 @@ class BaseAttention(ModelPart):
         raise NotImplementedError("Abstract method")
 
     def initial_loop_state(self) -> Any:
-        """Get initial loop state for the attention object."""
+        """Get initial loop state for the attention object.
+
+        Returns:
+            The newly created initial loop state object.
+        """
         raise NotImplementedError("Abstract method")
 
     def finalize_loop(self, key: str, last_loop_state: Any) -> None:
+        """Store the attention histories from loop state under a given key.
+
+        Arguments:
+            key: The key to the histories dictionary to store the data in.
+            last_loop_state: The loop state object from the last state of
+                the decoding loop.
+        """
         raise NotImplementedError("Abstract method")
 
     @property
     def context_vector_size(self) -> int:
+        """Return the static size of the context vector.
+
+        Returns:
+            An integer specifying the context vector dimension.
+        """
         raise NotImplementedError("Abstract property")
 
-    def visualize_attention(self, key: str) -> None:
+    def visualize_attention(self, key: str, max_outputs: int = 256) -> None:
+        """Include the attention histories under a given key into a summary.
+
+        Arguments:
+            key: The key to the attention histories dictionary.
+            max_outputs: Maximum number of images to save.
+        """
         if key not in self.histories:
-            raise ValueError(
+            raise KeyError(
                 "Key {} not among attention histories".format(key))
 
         alignments = tf.expand_dims(
             tf.transpose(self.histories[key], perm=[1, 2, 0]), -1)
 
-        tf.summary.image(self.name, alignments,
-                         collections=["summary_att_plots"], max_outputs=256)
+        summary_name = "{}.{}".format(self.name, key)
+
+        tf.summary.image(
+            summary_name, alignments, collections=["summary_att_plots"],
+            max_outputs=max_outputs)
+
+    def feed_dict(self, dataset: Dataset, train: bool = False) -> FeedDict:
+        """Return the feed dictionary of this ``ModelPart`` object.
+
+        Arguments:
+            dataset: The dataset (unused)
+            train: Specifies the mode (training / inference). Used e.g. for
+                dropout application.
+
+        Returns:
+            A feed dictionary with the train mode placeholder specified.
+        """
+        return {self.train_mode: train}

--- a/neuralmonkey/attention/base_attention.py
+++ b/neuralmonkey/attention/base_attention.py
@@ -41,7 +41,6 @@ from typing import NamedTuple, Dict, Optional, Any, Tuple, Union
 
 import tensorflow as tf
 
-from neuralmonkey.decorators import tensor
 from neuralmonkey.model.stateful import TemporalStateful, SpatialStateful
 from neuralmonkey.model.model_part import ModelPart, InitializerSpecs
 
@@ -203,16 +202,3 @@ class BaseAttention(ModelPart):
         tf.summary.image(
             summary_name, alignments, collections=["summary_att_plots"],
             max_outputs=max_outputs)
-
-    def feed_dict(self, dataset: Dataset, train: bool = False) -> FeedDict:
-        """Return the feed dictionary of this ``ModelPart`` object.
-
-        Arguments:
-            dataset: The dataset (unused)
-            train: Specifies the mode (training / inference). Used e.g. for
-                dropout application.
-
-        Returns:
-            A feed dictionary with the train mode placeholder specified.
-        """
-        return {self.train_mode: train}

--- a/neuralmonkey/attention/base_attention.py
+++ b/neuralmonkey/attention/base_attention.py
@@ -183,7 +183,7 @@ class BaseAttention(ModelPart):
         """
         raise NotImplementedError("Abstract property")
 
-    def visualize_attention(self, key: str, max_outputs: int = 256) -> None:
+    def visualize_attention(self, key: str, max_outputs: int = 16) -> None:
         """Include the attention histories under a given key into a summary.
 
         Arguments:

--- a/neuralmonkey/attention/base_attention.py
+++ b/neuralmonkey/attention/base_attention.py
@@ -53,7 +53,9 @@ AttentionLoopState = NamedTuple(
 
 
 def empty_attention_loop_state(
-        batch_size: Union[int, tf.Tensor]) -> AttentionLoopState:
+        batch_size: Union[int, tf.Tensor],
+        length: Union[int, tf.Tensor],
+        dimension: Union[int, tf.Tensor]) -> AttentionLoopState:
     """Create an empty attention loop state.
 
     The attention loop state is a technical object for storing the attention
@@ -61,7 +63,9 @@ def empty_attention_loop_state(
     ``tf.while_loop`` dynamic implementation of decoders.
 
     Arguments:
-        batch_size: The size of the batch. This is needed to
+        batch_size: The size of the batch.
+        length: The number of encoder states (keys).
+        dimension: The dimension of the context vector
 
     Returns:
         This function returns an empty attention loop state which means
@@ -69,8 +73,8 @@ def empty_attention_loop_state(
         and one for the attention context vectors in time.
     """
     return AttentionLoopState(
-        contexts=tf.zeros(shape=[0, batch_size], name="contexts"),
-        weights=tf.zeros(shape=[0, batch_size], name="distributions"))
+        contexts=tf.zeros(shape=[0, batch_size, dimension], name="contexts"),
+        weights=tf.zeros(shape=[0, batch_size, length], name="distributions"))
 
 
 def get_attention_states(encoder: Attendable) -> tf.Tensor:
@@ -82,6 +86,7 @@ def get_attention_states(encoder: Attendable) -> tf.Tensor:
     Returns:
         Either a 3D or a 4D tensor, depending on whether the encoder is
         temporal (e.g. recurrent encoder) or spatial (e.g. a CNN encoder).
+        The first two dimensions are (batch, time).
     """
     if isinstance(encoder, TemporalStateful):
         return encoder.temporal_states

--- a/neuralmonkey/attention/combination.py
+++ b/neuralmonkey/attention/combination.py
@@ -174,7 +174,10 @@ class FlatMultiAttention(MultiAttention):
         return tf.shape(self._encoders_tensors[0])[0]
 
     def initial_loop_state(self) -> AttentionLoopState:
-        return empty_attention_loop_state(self.batch_size)
+        return empty_attention_loop_state(
+            self.batch_size,
+            sum(tf.shape(s)[1] for s in self._encoders_tensors),
+            self.context_vector_size)
 
     def get_encoder_projections(self, scope):
         encoder_projections = []
@@ -367,7 +370,9 @@ class HierarchicalMultiAttention(MultiAttention):
         return HierarchicalLoopState(
             child_loop_states=[a.initial_loop_state()
                                for a in self.attentions],
-            loop_state=empty_attention_loop_state(self.batch_size))
+            loop_state=empty_attention_loop_state(
+                self.batch_size, len(self.attentions),
+                self.context_vector_size))
 
     # pylint: disable=too-many-locals
     def attention(self,

--- a/neuralmonkey/attention/combination.py
+++ b/neuralmonkey/attention/combination.py
@@ -218,8 +218,9 @@ class FlatMultiAttention(MultiAttention):
                   query: tf.Tensor,
                   decoder_prev_state: tf.Tensor,
                   decoder_input: tf.Tensor,
-                  loop_state: AttentionLoopState) -> Tuple[tf.Tensor,
-                                                           AttentionLoopState]:
+                  loop_state: AttentionLoopState) -> Tuple[
+                      tf.Tensor, AttentionLoopState]:
+
         with tf.variable_scope(self.att_scope_name):
             projected_state = tf.layers.dense(query, self.attention_state_size)
             projected_state = tf.expand_dims(projected_state, 1)
@@ -374,8 +375,8 @@ class HierarchicalMultiAttention(MultiAttention):
                   query: tf.Tensor,
                   decoder_prev_state: tf.Tensor,
                   decoder_input: tf.Tensor,
-                  loop_state: HierarchicalLoopState) -> Tuple[tf.Tensor,
-                                                              HierarchicalLoopState]:
+                  loop_state: HierarchicalLoopState) -> Tuple[
+                      tf.Tensor, HierarchicalLoopState]:
 
         with tf.variable_scope(self.att_scope_name):
             projected_state = tf.layers.dense(query, self.attention_state_size)

--- a/neuralmonkey/attention/combination.py
+++ b/neuralmonkey/attention/combination.py
@@ -171,7 +171,6 @@ class FlatMultiAttention(MultiAttention):
 
     @tensor
     def batch_size(self) -> tf.Tensor:
-        # TODO: find a better solution
         return tf.shape(self._encoders_tensors[0])[0]
 
     def initial_loop_state(self) -> AttentionLoopState:
@@ -384,8 +383,7 @@ class HierarchicalMultiAttention(MultiAttention):
 
             assert_shape(projected_state, [-1, 1, self.attention_state_size])
             attn_ctx_vectors, child_loop_states = zip(*[
-                a.attention(query, decoder_prev_state, decoder_input,
-                            ls)
+                a.attention(query, decoder_prev_state, decoder_input, ls)
                 for a, ls in zip(self.attentions,
                                  loop_state.child_loop_states)])
 
@@ -428,10 +426,9 @@ class HierarchicalMultiAttention(MultiAttention):
             prev_loop_state = loop_state.loop_state
 
             next_contexts = tf.concat(
-                [prev_loop_state.contexts, tf.expand_dims(context, 0)], 0)
+                [prev_loop_state.contexts, tf.expand_dims(context, 0)], axis=0)
             next_weights = tf.concat(
-                [prev_loop_state.weights,
-                 tf.expand_dims(attention_distr, 0)],
+                [prev_loop_state.weights, tf.expand_dims(attention_distr, 0)],
                 axis=0)
 
             next_loop_state = AttentionLoopState(

--- a/neuralmonkey/attention/combination.py
+++ b/neuralmonkey/attention/combination.py
@@ -18,7 +18,6 @@ from typing import Any, List, Tuple, NamedTuple
 from typeguard import check_argument_types
 import tensorflow as tf
 
-from neuralmonkey.decorators import tensor
 from neuralmonkey.attention.base_attention import (
     BaseAttention, AttentionLoopState, empty_attention_loop_state,
     get_attention_states, get_attention_mask, Attendable)
@@ -168,10 +167,6 @@ class FlatMultiAttention(MultiAttention):
 
             self.masks_concat = tf.concat(self._encoders_masks, 1)
     # pylint: enable=too-many-arguments
-
-    @tensor
-    def batch_size(self) -> tf.Tensor:
-        return tf.shape(self._encoders_tensors[0])[0]
 
     def initial_loop_state(self) -> AttentionLoopState:
 
@@ -364,10 +359,6 @@ class HierarchicalMultiAttention(MultiAttention):
 
         self.attentions = attentions
     # pylint: enable=too-many-arguments
-
-    @tensor
-    def batch_size(self) -> tf.Tensor:
-        return self.attentions[0].batch_size
 
     def initial_loop_state(self) -> HierarchicalLoopState:
         length = len(self.attentions)

--- a/neuralmonkey/attention/coverage.py
+++ b/neuralmonkey/attention/coverage.py
@@ -39,10 +39,10 @@ class CoverageAttention(Attention):
             tf.reduce_sum(self.fertility_weights * self.attention_states, [2]))
     # pylint: enable=too-many-arguments
 
-    def get_energies(self, y: tf.Tensor, weights_in_time: tf.TensorArray):
+    def get_energies(self, y: tf.Tensor, weights_in_time: tf.Tensor):
         weight_sum = tf.cond(
             tf.greater(weights_in_time.size(), 0),
-            lambda: tf.reduce_sum(weights_in_time.stack(), axis=0),
+            lambda: tf.reduce_sum(weights_in_time, axis=0),
             lambda: 0.0)
 
         coverage = weight_sum / self.fertility * self.attention_mask

--- a/neuralmonkey/attention/feed_forward.py
+++ b/neuralmonkey/attention/feed_forward.py
@@ -169,7 +169,10 @@ class Attention(BaseAttention):
         return context, next_loop_state
 
     def initial_loop_state(self) -> AttentionLoopState:
-        return empty_attention_loop_state(self.batch_size)
+        return empty_attention_loop_state(
+            self.batch_size,
+            tf.shape(self.attention_states)[1],
+            self.context_vector_size)
 
     def finalize_loop(self, key: str,
                       last_loop_state: AttentionLoopState) -> None:

--- a/neuralmonkey/attention/feed_forward.py
+++ b/neuralmonkey/attention/feed_forward.py
@@ -42,10 +42,6 @@ class Attention(BaseAttention):
         log("Attention mask: {}".format(self.attention_mask))
 
     @tensor
-    def batch_size(self) -> tf.Tensor:
-        return tf.shape(self.attention_states)[0]
-
-    @tensor
     def attention_states(self) -> tf.Tensor:
         return dropout(get_attention_states(self.encoder),
                        self.dropout_keep_prob,

--- a/neuralmonkey/attention/feed_forward.py
+++ b/neuralmonkey/attention/feed_forward.py
@@ -10,7 +10,7 @@ import tensorflow as tf
 from typeguard import check_argument_types
 
 from neuralmonkey.attention.base_attention import (
-    BaseAttention, AttentionLoopStateTA, empty_attention_loop_state,
+    BaseAttention, AttentionLoopState, empty_attention_loop_state,
     get_attention_states, get_attention_mask, Attendable)
 from neuralmonkey.decorators import tensor
 from neuralmonkey.nn.utils import dropout
@@ -40,6 +40,10 @@ class Attention(BaseAttention):
         # TODO blessing
         log("Hidden features: {}".format(self.hidden_features))
         log("Attention mask: {}".format(self.attention_mask))
+
+    @tensor
+    def batch_size(self) -> tf.Tensor:
+        return tf.shape(self.attention_states)[0]
 
     @tensor
     def attention_states(self) -> tf.Tensor:
@@ -125,8 +129,8 @@ class Attention(BaseAttention):
                   query: tf.Tensor,
                   decoder_prev_state: tf.Tensor,
                   decoder_input: tf.Tensor,
-                  loop_state: AttentionLoopStateTA,
-                  step: tf.Tensor) -> Tuple[tf.Tensor, AttentionLoopStateTA]:
+                  loop_state: AttentionLoopState) -> Tuple[tf.Tensor,
+                                                           AttentionLoopState]:
         self.query_state_size = query.get_shape()[-1].value
 
         y = tf.matmul(query, self.query_projection_matrix)
@@ -154,15 +158,19 @@ class Attention(BaseAttention):
             * self._att_states_reshaped, [1, 2])
         context = tf.reshape(context, [-1, self.context_vector_size])
 
-        next_loop_state = AttentionLoopStateTA(
-            contexts=loop_state.contexts.write(step, context),
-            weights=loop_state.weights.write(step, weights))
+        next_contexts = tf.concat(
+            [loop_state.contexts, tf.expand_dims(context, 0)], 0)
+        next_weights = tf.concat(
+            [loop_state.weights, tf.expand_dims(weights, 0)], 0)
+        next_loop_state = AttentionLoopState(
+            contexts=next_contexts,
+            weights=next_weights)
 
         return context, next_loop_state
 
-    def initial_loop_state(self) -> AttentionLoopStateTA:
-        return empty_attention_loop_state()
+    def initial_loop_state(self) -> AttentionLoopState:
+        return empty_attention_loop_state(self.batch_size)
 
     def finalize_loop(self, key: str,
-                      last_loop_state: AttentionLoopStateTA) -> None:
-        self.histories[key] = last_loop_state.weights.stack()
+                      last_loop_state: AttentionLoopState) -> None:
+        self.histories[key] = last_loop_state.weights

--- a/neuralmonkey/attention/feed_forward.py
+++ b/neuralmonkey/attention/feed_forward.py
@@ -30,8 +30,8 @@ class Attention(BaseAttention):
                  load_checkpoint: str = None,
                  initializers: InitializerSpecs = None) -> None:
         check_argument_types()
-        BaseAttention.__init__(self, name, save_checkpoint, load_checkpoint,
-                               initializers)
+        BaseAttention.__init__(
+            self, name, save_checkpoint, load_checkpoint, initializers)
 
         self.encoder = encoder
         self.dropout_keep_prob = dropout_keep_prob
@@ -129,15 +129,15 @@ class Attention(BaseAttention):
                   query: tf.Tensor,
                   decoder_prev_state: tf.Tensor,
                   decoder_input: tf.Tensor,
-                  loop_state: AttentionLoopState) -> Tuple[tf.Tensor,
-                                                           AttentionLoopState]:
+                  loop_state: AttentionLoopState) -> Tuple[
+                      tf.Tensor, AttentionLoopState]:
         self.query_state_size = query.get_shape()[-1].value
 
         y = tf.matmul(query, self.query_projection_matrix)
         y = y + self.projection_bias_vector
         y = tf.reshape(y, [-1, 1, 1, self.state_size])
 
-        energies = self.get_energies(y, loop_state.weights.identity())
+        energies = self.get_energies(y, loop_state.weights)
 
         if self.attention_mask is None:
             weights = tf.nn.softmax(energies)

--- a/neuralmonkey/attention/scaled_dot_product.py
+++ b/neuralmonkey/attention/scaled_dot_product.py
@@ -344,7 +344,7 @@ class MultiHeadAttention(BaseAttention):
     def context_vector_size(self) -> int:
         return self.attention_values.get_shape()[-1].value
 
-    def visualize_attention(self, key: str, max_outputs: int = 256) -> None:
+    def visualize_attention(self, key: str, max_outputs: int = 16) -> None:
         for i in range(self.n_heads):
             head_key = "{}_head{}".format(key, i)
             if head_key not in self.histories:

--- a/neuralmonkey/attention/scaled_dot_product.py
+++ b/neuralmonkey/attention/scaled_dot_product.py
@@ -12,7 +12,6 @@ from typing import Tuple, List, NamedTuple, Callable, Union
 import tensorflow as tf
 from typeguard import check_argument_types
 
-from neuralmonkey.decorators import tensor
 from neuralmonkey.nn.utils import dropout
 from neuralmonkey.model.model_part import InitializerSpecs
 from neuralmonkey.attention.base_attention import (
@@ -274,10 +273,6 @@ class MultiHeadAttention(BaseAttention):
         self.attention_mask = get_attention_mask(keys_encoder)
         self.attention_values = get_attention_states(values_encoder)
     # pylint: enable=too-many-arguments
-
-    @tensor
-    def batch_size(self) -> tf.Tensor:
-        return tf.shape(self.attention_keys)[0]
 
     def attention(self,
                   query: tf.Tensor,

--- a/neuralmonkey/attention/scaled_dot_product.py
+++ b/neuralmonkey/attention/scaled_dot_product.py
@@ -318,11 +318,11 @@ class MultiHeadAttention(BaseAttention):
         head_weights = [tf.squeeze(w, axis=[1, 2]) for w in head_weights_3d]
 
         next_contexts = tf.concat(
-            [loop_state.contexts, tf.expand_dims(context, 0)], 0)
-        next_head_weights = [tf.concat([loop_state.head_weights[i],
-                                        tf.expand_dims(head_weights[i], 0)],
-                                       axis=0)
-                             for i in range(self.n_heads)]
+            [loop_state.contexts, tf.expand_dims(context, 0)], axis=0)
+        next_head_weights = [
+            tf.concat([loop_state.head_weights[i],
+                       tf.expand_dims(head_weights[i], 0)], axis=0)
+            for i in range(self.n_heads)]
 
         next_loop_state = MultiHeadLoopState(
             contexts=next_contexts,
@@ -343,7 +343,7 @@ class MultiHeadAttention(BaseAttention):
     def context_vector_size(self) -> int:
         return self.attention_values.get_shape()[-1].value
 
-    def visualize_attention(self, key: str) -> None:
+    def visualize_attention(self, key: str, max_outputs: int = 256) -> None:
         for i in range(self.n_heads):
             head_key = "{}_head{}".format(key, i)
             if head_key not in self.histories:
@@ -355,7 +355,7 @@ class MultiHeadAttention(BaseAttention):
 
             tf.summary.image("{}_head{}".format(self.name, i), alignments,
                              collections=["summary_att_plots"],
-                             max_outputs=256)
+                             max_outputs=max_outputs)
 
 
 class ScaledDotProdAttention(MultiHeadAttention):

--- a/neuralmonkey/attention/stateful_context.py
+++ b/neuralmonkey/attention/stateful_context.py
@@ -35,10 +35,6 @@ class StatefulContext(BaseAttention):
         self.encoder = encoder
 
     @tensor
-    def batch_size(self) -> tf.Tensor:
-        return tf.shape(self.attention_states)[0]
-
-    @tensor
     def attention_states(self) -> tf.Tensor:
         return tf.expand_dims(self.encoder.output, 1)
 

--- a/neuralmonkey/attention/stateful_context.py
+++ b/neuralmonkey/attention/stateful_context.py
@@ -80,7 +80,10 @@ class StatefulContext(BaseAttention):
         return context, next_loop_state
 
     def initial_loop_state(self) -> AttentionLoopState:
-        return empty_attention_loop_state(self.batch_size)
+        return empty_attention_loop_state(
+            self.batch_size,
+            tf.shape(self.attention_states)[1],
+            self.context_vector_size)
 
     def finalize_loop(self, key: str,
                       last_loop_state: AttentionLoopState) -> None:

--- a/neuralmonkey/attention/stateful_context.py
+++ b/neuralmonkey/attention/stateful_context.py
@@ -86,5 +86,5 @@ class StatefulContext(BaseAttention):
                       last_loop_state: AttentionLoopState) -> None:
         pass
 
-    def visualize_attention(self, key: str) -> None:
+    def visualize_attention(self, key: str, max_outputs: int = 256) -> None:
         pass

--- a/neuralmonkey/attention/stateful_context.py
+++ b/neuralmonkey/attention/stateful_context.py
@@ -85,5 +85,5 @@ class StatefulContext(BaseAttention):
                       last_loop_state: AttentionLoopState) -> None:
         pass
 
-    def visualize_attention(self, key: str, max_outputs: int = 256) -> None:
+    def visualize_attention(self, key: str, max_outputs: int = 16) -> None:
         pass

--- a/neuralmonkey/decoders/autoregressive.py
+++ b/neuralmonkey/decoders/autoregressive.py
@@ -63,7 +63,7 @@ DecoderFeedables = NamedTuple(
 # pylint: disable=too-many-public-methods,too-many-instance-attributes
 class AutoregressiveDecoder(ModelPart):
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,too-many-instance-attributes
     def __init__(self,
                  name: str,
                  vocabulary: Vocabulary,
@@ -110,6 +110,9 @@ class AutoregressiveDecoder(ModelPart):
         self.tie_embeddings = tie_embeddings
         self.supress_unk = supress_unk
 
+        self.encoder_states = None
+        self.encoder_mask = None
+
         # check the values of the parameters (max_output_len, ...)
         if max_output_len <= 0:
             raise ValueError("Maximum sequence length must be "
@@ -140,7 +143,7 @@ class AutoregressiveDecoder(ModelPart):
                 tf.int32, [None, None], "train_inputs")
             self.train_mask = tf.placeholder(
                 tf.float32, [None, None], "train_mask")
-    # pylint: enable=too-many-arguments
+    # pylint: enable=too-many-arguments,too-many-instance-attributes
 
     @tensor
     def decoding_w(self) -> tf.Variable:

--- a/neuralmonkey/decoders/autoregressive.py
+++ b/neuralmonkey/decoders/autoregressive.py
@@ -10,9 +10,6 @@ from typing import (
 
 import numpy as np
 import tensorflow as tf
-# pylint: disable=no-name-in-module
-from tensorflow.python.util import nest
-# pylint: enable=no-name-in-module
 
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.decorators import tensor
@@ -401,7 +398,7 @@ class AutoregressiveDecoder(ModelPart):
             self.loop_continue_criterion,
             self.get_body(train_mode, sample, temperature),
             initial_loop_state,
-            shape_invariants=nest.map_structure(
+            shape_invariants=tf.contrib.framework.nest.map_structure(
                 get_state_shape_invariants, initial_loop_state))
 
         self.finalize_loop(final_loop_state, train_mode)

--- a/neuralmonkey/decoders/autoregressive.py
+++ b/neuralmonkey/decoders/autoregressive.py
@@ -10,6 +10,9 @@ from typing import (
 
 import numpy as np
 import tensorflow as tf
+# pylint: disable=no-name-in-module
+from tensorflow.python.util import nest
+# pylint: enable=no-name-in-module
 
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.decorators import tensor
@@ -17,7 +20,7 @@ from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
 from neuralmonkey.logging import log, warn
 from neuralmonkey.model.sequence import EmbeddedSequence
 from neuralmonkey.nn.utils import dropout
-from neuralmonkey.tf_utils import get_variable
+from neuralmonkey.tf_utils import get_variable, get_state_shape_invariants
 from neuralmonkey.vocabulary import Vocabulary, START_TOKEN, UNK_TOKEN_INDEX
 
 
@@ -43,10 +46,10 @@ LoopState = NamedTuple(
 # pylint: disable=invalid-name
 DecoderHistories = NamedTuple(
     "DecoderHistories",
-    [("logits", tf.TensorArray),
-     ("decoder_outputs", tf.TensorArray),
-     ("outputs", tf.TensorArray),
-     ("mask", tf.TensorArray)])  # float matrix, 0s and 1s
+    [("logits", tf.Tensor),
+     ("decoder_outputs", tf.Tensor),
+     ("outputs", tf.Tensor),
+     ("mask", tf.Tensor)])  # float matrix, 0s and 1s
 
 DecoderConstants = NamedTuple(
     "DecoderConstants",
@@ -303,17 +306,25 @@ class AutoregressiveDecoder(ModelPart):
 
     def get_initial_loop_state(self) -> LoopState:
 
-        dec_output_ta = tf.TensorArray(dtype=tf.float32, dynamic_size=True,
-                                       size=0, name="decoder_outputs")
+        dec_output = tf.zeros(
+            shape=[0, self.batch_size, self.embedding_size],
+            dtype=tf.float32,
+            name="hist_decoder_outputs")
 
-        logit_ta = tf.TensorArray(dtype=tf.float32, dynamic_size=True,
-                                  size=0, name="logits")
+        logit = tf.zeros(
+            shape=[0, self.batch_size, len(self.vocabulary)],
+            dtype=tf.float32,
+            name="hist_logits")
 
-        mask_ta = tf.TensorArray(dtype=tf.bool, dynamic_size=True,
-                                 size=0, name="mask")
+        mask = tf.zeros(
+            shape=[0, self.batch_size],
+            dtype=tf.bool,
+            name="mask")
 
-        outputs_ta = tf.TensorArray(dtype=tf.int32, dynamic_size=True,
-                                    size=0, name="outputs")
+        outputs = tf.zeros(
+            shape=[0, self.batch_size],
+            dtype=tf.int32,
+            name="outputs")
 
         feedables = DecoderFeedables(
             step=tf.constant(0, tf.int32),
@@ -322,10 +333,10 @@ class AutoregressiveDecoder(ModelPart):
             prev_logits=tf.zeros([self.batch_size, len(self.vocabulary)]))
 
         histories = DecoderHistories(
-            logits=logit_ta,
-            decoder_outputs=dec_output_ta,
-            mask=mask_ta,
-            outputs=outputs_ta)
+            logits=logit,
+            decoder_outputs=dec_output,
+            mask=mask,
+            outputs=outputs)
 
         constants = DecoderConstants(train_inputs=self.train_inputs)
 
@@ -375,7 +386,7 @@ class AutoregressiveDecoder(ModelPart):
 
         After finishing the tf.while_loop, it calls finalize_loop
         to further postprocess the final decoder loop state (usually
-        by stacking TensorArrays containing decoding histories).
+        by stacking Tensors containing decoding histories).
 
         Arguments:
             train_mode: Boolean flag, telling whether this is
@@ -389,16 +400,18 @@ class AutoregressiveDecoder(ModelPart):
         final_loop_state = tf.while_loop(
             self.loop_continue_criterion,
             self.get_body(train_mode, sample, temperature),
-            initial_loop_state)
+            initial_loop_state,
+            shape_invariants=nest.map_structure(
+                get_state_shape_invariants, initial_loop_state))
 
         self.finalize_loop(final_loop_state, train_mode)
 
-        logits = final_loop_state.histories.logits.stack()
-        decoder_outputs = final_loop_state.histories.decoder_outputs.stack()
-        decoded = final_loop_state.histories.outputs.stack()
+        logits = final_loop_state.histories.logits
+        decoder_outputs = final_loop_state.histories.decoder_outputs
+        decoded = final_loop_state.histories.outputs
 
         # TODO mask should include also the end symbol
-        mask = final_loop_state.histories.mask.stack()
+        mask = final_loop_state.histories.mask
 
         return logits, decoder_outputs, mask, decoded
 

--- a/neuralmonkey/decoders/beam_search_decoder.py
+++ b/neuralmonkey/decoders/beam_search_decoder.py
@@ -65,6 +65,9 @@ BeamSearchOutput = NamedTuple("SearchStepOutput",
                                ("last_search_state", SearchState),
                                ("attention_loop_states", List[Any])])
 
+# Constant we use in place of the np.inf
+INF = 1e9
+
 
 # pylint: enable=invalid-name
 class BeamSearchDecoder(ModelPart):
@@ -187,7 +190,7 @@ class BeamSearchDecoder(ModelPart):
         # We want to feed these values in ensembles
         self._search_state = SearchState(
             logprob_sum=tf.tile(
-                tf.constant([0.0] + [-1e9] * (self.beam_size - 1)),
+                tf.constant([0.0] + [-INF] * (self.beam_size - 1)),
                 [self.batch_size],
                 name="bs_logprob_sum"),
             prev_logprobs=tf.nn.log_softmax(dec_ls.feedables.prev_logits),

--- a/neuralmonkey/decoders/beam_search_decoder.py
+++ b/neuralmonkey/decoders/beam_search_decoder.py
@@ -1,101 +1,107 @@
 """Beam search decoder.
 
-This module implements the beam search algorithm for the recurrent decoder.
+This module implements the beam search algorithm for autoregressive decoders.
 
-As well as the recurrent decoder, this decoder works dynamically, which means
+As any autoregressive decoder, this decoder works dynamically, which means
 it uses the ``tf.while_loop`` function conditioned on both maximum output
 length and list of finished hypotheses.
 
-The beam search decoder works by appending data to a ``SearchStepOutput``
-object. The ``SearchStepOutput`` object
-stores information about the hypotheses in the beam. Each hypothesis keeps its
-score, its final token, and a pointer to a "parent" hypothesis, which is a
-one-token-shorter hypothesis which shares the tokens with the child hypothesis.
+The beam search decoder uses four data strcutures during the decoding process:
 
-For the beam search decoder to work, it must keep an inner state which stores
-information about hypotheses in the beam. It is an object of type
-``SearchState`` which stores, *for each hypothesis*, its sum of log
-probabilities of the tokens, its length, finished flag, ID of the last token,
-and the last decoder and attention states.
+- ``SearchState`` - this structure keeps track of a current state of the beam
+  search algorithm. The search state contains tensors that represent hypotheses
+  in the beam, namely their log probability, length, and distribution over the
+  vocabulary when decoding the last word, as well as if the hypothesis is
+  finished or not.
 
-There is another inner state object here, the ``BeamSearchLoopState``. It is a
-technical structure used with the ``tf.while_loop`` function. It stores all the
-previously mentioned information, plus the decoder ``LoopState``, which is used
-in the decoder when its own ``tf.while_loop`` function is used - this is not
-the case when using beam search because we want to run the decoder's steps
-manually.
+- ``SearchResults`` - a cummulative structure that holds the actual decoded
+  tokens and hypotheses scores (after applying a length penalty term).
+
+- ``BeamSearchLoopState`` - a loop state object that is used for transferring
+  data between cycles through the symbolic while loop. It groups together the
+  ``SearchState`` and ``SearchResults`` structures and also keeps track of the
+  underlying decoder loop state.
+
+- ``BeamSearchOutput`` - the final structure that is returned from the while
+  loop.
+
+These structures help the decoder to keep track of the decoding, enabling it
+to be called e.g. during ensembling, when the content of the structures can be
+changed and then fed back to the model.
+
+The implementation mimics the API of the ``AutoregressiveDecoder`` class. There
+are functions that prepare and return values that are supplied to the
+``tf.while_loop`` function.
+
 """
 from typing import NamedTuple, List, Callable, Any, Optional
 
 import tensorflow as tf
-
-# pylint: disable=no-name-in-module
-from tensorflow.python.util import nest
-# pylint: enable=no-name-in-module
 from typeguard import check_argument_types
 
-from neuralmonkey.model.model_part import ModelPart, InitializerSpecs
 from neuralmonkey.decoders.autoregressive import (
-    LoopState, AutoregressiveDecoder)
+    AutoregressiveDecoder, LoopState)
+from neuralmonkey.decorators import tensor
+from neuralmonkey.model.model_part import ModelPart
+from neuralmonkey.tf_utils import (
+    append_tensor, gather_flat, get_state_shape_invariants, partial_transpose,
+    get_shape_list)
 from neuralmonkey.vocabulary import (
     Vocabulary, END_TOKEN_INDEX, PAD_TOKEN_INDEX)
-from neuralmonkey.decorators import tensor
-from neuralmonkey.tf_utils import (
-    append_tensor, expand_to_beam, gather_flat, get_state_shape_invariants,
-    partial_transpose)
-
-# pylint: disable=invalid-name
-SearchState = NamedTuple("SearchState",
-                         [("logprob_sum", tf.Tensor),  # [batch, beam]
-                          ("prev_logprobs", tf.Tensor),  # [batch, beam, Vocab]
-                          ("lengths", tf.Tensor),  # [batch, beam]
-                          ("finished", tf.Tensor)])  # [batch, beam]
-
-SearchStepOutput = NamedTuple("SearchStepOutput",
-                              [("scores", tf.Tensor),  # [batch, beam]
-                               ("token_ids", tf.Tensor)])  # [batch, beam]
-
-BeamSearchLoopState = NamedTuple("BeamSearchLoopState",
-                                 [("bs_state", SearchState),
-                                  ("bs_output", SearchStepOutput),
-                                  ("decoder_loop_state", LoopState)])
-
-BeamSearchOutput = NamedTuple("SearchStepOutput",
-                              [("last_search_step_output", SearchStepOutput),
-                               ("last_dec_loop_state", NamedTuple),
-                               ("last_search_state", SearchState),
-                               ("attention_loop_states", List[Any])])
 
 # Constant we use in place of the np.inf
 INF = 1e9
 
+# pylint: disable=invalid-name
+SearchState = NamedTuple(
+    "SearchState",
+    [("logprob_sum", tf.Tensor),  # [batch, beam]
+     ("prev_logprobs", tf.Tensor),  # [batch, beam, Vocab]
+     ("lengths", tf.Tensor),  # [batch, beam]
+     ("finished", tf.Tensor)])  # [batch, beam]
 
+SearchResults = NamedTuple(
+    "SearchResults",
+    [("scores", tf.Tensor),  # [batch, beam]
+     ("token_ids", tf.Tensor)])  # [batch, beam]
+
+BeamSearchLoopState = NamedTuple(
+    "BeamSearchLoopState",
+    [("search_state", SearchState),
+     ("search_results", SearchResults),
+     ("decoder_loop_state", LoopState)])
+
+BeamSearchOutput = NamedTuple(
+    "SearchResults",
+    [("last_search_step_output", SearchResults),
+     ("last_dec_loop_state", NamedTuple),
+     ("last_search_state", SearchState),
+     ("attention_loop_states", List[Any])])
 # pylint: enable=invalid-name
+
+
 class BeamSearchDecoder(ModelPart):
-    """In-graph beam search for batch size 1.
+    """In-graph beam search decoder.
 
     The hypothesis scoring algorithm is taken from
     https://arxiv.org/pdf/1609.08144.pdf. Length normalization is parameter
     alpha from equation 14.
     """
 
-    # pylint: disable=too-many-arguments
     def __init__(self,
                  name: str,
                  parent_decoder: AutoregressiveDecoder,
                  beam_size: int,
-                 length_normalization: float,
-                 max_steps: int = None,
-                 save_checkpoint: str = None,
-                 load_checkpoint: str = None,
-                 initializers: InitializerSpecs = None) -> None:
+                 max_steps: int,
+                 length_normalization: float) -> None:
         check_argument_types()
-        ModelPart.__init__(self, name, save_checkpoint, load_checkpoint,
-                           initializers)
+        ModelPart.__init__(self, name)
 
         self.parent_decoder = parent_decoder
-        self._beam_size = beam_size
-        self._length_normalization = length_normalization
+        self.beam_size = beam_size
+        self.length_normalization = length_normalization
+        self.max_steps = tf.placeholder_with_default(max_steps, [])
+        self.max_steps_int = max_steps
 
         has_encoder = (hasattr(self.parent_decoder, "encoder_states")
                        and hasattr(self.parent_decoder, "encoder_mask"))
@@ -105,12 +111,10 @@ class BeamSearchDecoder(ModelPart):
             enc_mask = self.parent_decoder.encoder_mask
 
         if has_encoder and enc_states is not None and enc_mask is not None:
-            setattr(self.parent_decoder,
-                    "encoder_states",
-                    expand_to_beam(enc_states, beam_size=self.beam_size))
-            setattr(self.parent_decoder,
-                    "encoder_mask",
-                    expand_to_beam(enc_mask, beam_size=self.beam_size))
+            setattr(self.parent_decoder, "encoder_states",
+                    self.expand_to_beam(enc_states))
+            setattr(self.parent_decoder, "encoder_mask",
+                    self.expand_to_beam(enc_mask))
 
         # The parent_decoder is one step ahead. This is required for ensembling
         # support.
@@ -119,16 +123,9 @@ class BeamSearchDecoder(ModelPart):
         # ensembled outside of the session.run before finishing the N+1th
         # step of the beam_search_decoder (collecting topk outputs, selecting
         # beams and running next parent_decoder step based on the chosen beam).
-        if max_steps is None:
-            max_steps = parent_decoder.max_output_len - 1
-        self._max_steps = tf.constant(max_steps)
-        self.max_output_len = max_steps
 
         # Feedables
-        # TODO: replace these by a single nested object
-        self._search_state = None  # type: Optional[SearchState]
-        self._decoder_state = None  # type: Optional[LoopState]
-        self._bs_output = None  # type: Optional[SearchStepOutput]
+        self.initial_loop_state = None  # type: Optional[BeamSearchLoopState]
 
         # Output
         self.outputs = self._decoding_loop()
@@ -137,49 +134,104 @@ class BeamSearchDecoder(ModelPart):
         if has_encoder:
             setattr(self.parent_decoder, "encoder_states", enc_states)
             setattr(self.parent_decoder, "encoder_mask", enc_mask)
-    # pylint: enable=too-many-arguments
-
-    @property
-    def beam_size(self) -> int:
-        return self._beam_size
 
     @property
     def vocabulary(self) -> Vocabulary:
         return self.parent_decoder.vocabulary
 
     @tensor
-    def search_state(self) -> Optional[SearchState]:
-        return self._search_state
+    def search_state(self) -> SearchState:
+        assert self.initial_loop_state is not None
+        return self.initial_loop_state.search_state
 
     @tensor
     def decoder_state(self) -> Optional[LoopState]:
-        return self._decoder_state
+        assert self.initial_loop_state is not None
+        return self.initial_loop_state.decoder_loop_state
 
     @tensor
-    def bs_output(self) -> Optional[SearchStepOutput]:
-        return self._bs_output
-
-    @tensor
-    def max_steps(self) -> int:
-        return self._max_steps
+    def search_results(self) -> Optional[SearchResults]:
+        assert self.initial_loop_state is not None
+        return self.initial_loop_state.search_results
 
     def get_initial_loop_state(self) -> BeamSearchLoopState:
-        dec_ls = self.parent_decoder.get_initial_loop_state()
+        """Construct the initial loop state for the beam search decoder.
 
-        # We need to stretch parent_decoder feedables
-        # to (batch_size * beam_size)
-        # feedables have shape [batch, ...]
-        feedables = nest.map_structure(
-            lambda x: expand_to_beam(x, 0, self.beam_size),
-            dec_ls.feedables)
-        # histories have shape [len, batch, ...]
-        histories = nest.map_structure(
-            lambda x: expand_to_beam(x, 1, self.beam_size),
-            dec_ls.histories)
+        During the construction, the body function of the underlying decoder
+        is called once to retrieve the initial log probabilities of the first
+        token.
 
-        # We add input_symbol during token_ids initialization
-        # for simpler beam_body implementation.
-        self._bs_output = SearchStepOutput(
+        The values are initialized as follows:
+
+        - ``search_state``
+            - ``logprob_sum`` - For each sentence in batch, logprob sum of the
+              first hypothesis in the beam is set to zero while the others are
+              set to negative infinity.
+            - ``prev_logprobs`` - This is the softmax over the logits from the
+              initial decoder step.
+            - ``lengths`` - All zeros.
+            - ``finshed`` - All false.
+
+        - ``search_results``
+            - ``scores`` - A (batch, beam)-sized tensor of zeros.
+            - ``token_ids`` - A (1, batch, beam)-sized tensor filled with
+              indices of decoder-specific initial input symbols (usually start
+              symbol IDs).
+
+        - ``decoder_loop_state`` - The loop state of the underlying
+            autoregressive decoder, as returned from the initial call to the
+            body function.
+
+        Returns:
+            A populated ``BeamSearchLoopState`` structure.
+        """
+        # Get the initial loop state of the underlying decoder. Then, expand
+        # the tensors from the loop state to (batch * beam) and inject them
+        # back into the decoder loop state.
+
+        dec_init_ls = self.parent_decoder.get_initial_loop_state()
+
+        feedables = tf.contrib.framework.nest.map_structure(
+            self.expand_to_beam, dec_init_ls.feedables)
+        histories = tf.contrib.framework.nest.map_structure(
+            lambda x: self.expand_to_beam(x, dim=1), dec_init_ls.histories)
+
+        dec_init_ls = dec_init_ls._replace(
+            feedables=feedables,
+            histories=histories,
+            constants=tf.constant(0))  # TODO(@varisd) what is this?!
+
+        # Call the decoder body function with the expanded loop state to get
+        # the log probabilities of the possible first tokens.
+
+        decoder_body = self.parent_decoder.get_body(False)
+        dec_next_ls = decoder_body(*dec_init_ls)
+
+        # Construct the initial loop state of the beam search decoder. To allow
+        # ensembling, the values are replaced with placeholders with a default
+        # value. NOTE that this is necessary only for variables that grow in
+        # time
+        # TODO(@varisd) Explain the NOTE, please!
+
+        search_state = SearchState(
+            logprob_sum=tf.tile(
+                tf.expand_dims([0.0] + [-INF] * (self.beam_size - 1), 0),
+                [self.batch_size, 1],
+                name="bs_logprob_sum"),
+            prev_logprobs=tf.reshape(
+                tf.nn.log_softmax(dec_next_ls.feedables.prev_logits),
+                [self.batch_size, self.beam_size, len(self.vocabulary)]),
+            lengths=tf.zeros(
+                [self.batch_size, self.beam_size], dtype=tf.int32,
+                name="bs_lengths"),
+            finished=tf.zeros(
+                [self.batch_size, self.beam_size], dtype=tf.bool))
+
+        # We add input_symbol during token_ids initialization for simpler
+        # beam_body implementation.
+        # TODO(@varisd) explain!
+
+        search_results = SearchResults(
             scores=tf.zeros(
                 shape=[self.batch_size, self.beam_size],
                 dtype=tf.float32,
@@ -189,78 +241,66 @@ class BeamSearchDecoder(ModelPart):
                 [1, self.batch_size, self.beam_size],
                 name="beam_tokens"))
 
-        dec_ls = dec_ls._replace(
-            feedables=feedables,
-            histories=histories,
-            constants=tf.constant(0))
-
-        decoder_body = self.parent_decoder.get_body(False)
-        dec_ls = decoder_body(*dec_ls)
-
-        # We want to feed these values in ensembles
-        self._search_state = SearchState(
-            logprob_sum=tf.tile(
-                tf.expand_dims([0.0] + [-INF] * (self.beam_size - 1), 0),
-                [self.batch_size, 1],
-                name="bs_logprob_sum"),
-            prev_logprobs=tf.reshape(
-                tf.nn.log_softmax(dec_ls.feedables.prev_logits),
-                [self.batch_size, self.beam_size, len(self.vocabulary)]),
-            lengths=tf.zeros(
-                [self.batch_size, self.beam_size],
-                dtype=tf.int32,
-                name="bs_lengths"),
-            finished=tf.zeros(
-                [self.batch_size, self.beam_size],
-                dtype=tf.bool))
-
-        self._decoder_state = dec_ls
-
-        # replace the tensors with actual placeholders for ensembling
-        # NOTE: this is necessary only for variables that grow in time
-        self._decoder_state = nest.map_structure(
+        dec_next_ls = tf.contrib.framework.nest.map_structure(
             lambda x: tf.placeholder_with_default(
                 x, get_state_shape_invariants(x)),
-            self._decoder_state)
+            dec_next_ls)
 
-        self._bs_output = nest.map_structure(
+        search_results = tf.contrib.framework.nest.map_structure(
             lambda x: tf.placeholder_with_default(
                 x, get_state_shape_invariants(x)),
-            self._bs_output)
+            search_results)
 
-        assert self._decoder_state is not None
-        assert self._bs_output is not None
+        # TODO(@varisd) why don't we do the map_structure thing for
+        # ``search_state``?
 
         return BeamSearchLoopState(
-            bs_state=self._search_state,
-            bs_output=self._bs_output,
-            decoder_loop_state=self._decoder_state)
+            search_state=search_state,
+            search_results=search_results,
+            decoder_loop_state=dec_next_ls)
+
+    def loop_continue_criterion(self, *args) -> tf.Tensor:
+        """Decide whether to break out of the while loop.
+
+        The criterion for stopping the loop is that either all hypotheses are
+        finished or a maximum number of steps has been reached. Here the number
+        of steps is the number of steps of the underlying decoder minus one
+        because this function is evaluated after the decoder step has been
+        called and its step has been incremented.
+
+        TODO(@varisd) check this please
+
+        Arguments:
+            args: A ``BeamSearchLoopState`` instance.
+
+        Returns:
+            A scalar boolean ``Tensor``.
+        """
+        loop_state = BeamSearchLoopState(*args)
+
+        beam_step = loop_state.decoder_loop_state.feedables.step - 1
+        finished = loop_state.search_state.finished
+
+        max_step_cond = tf.less(beam_step, self.max_steps)
+        unfinished_cond = tf.logical_not(tf.reduce_all(finished))
+
+        return tf.logical_and(max_step_cond, unfinished_cond)
 
     def _decoding_loop(self) -> BeamSearchOutput:
 
-        beam_body = self.get_body()
-        initial_loop_state = self.get_initial_loop_state()
-
-        def cond(*args) -> tf.Tensor:
-            bsls = BeamSearchLoopState(*args)
-            max_step_cond = tf.less(
-                bsls.decoder_loop_state.feedables.step - 1, self._max_steps)
-            unfinished_cond = tf.logical_not(
-                tf.reduce_all(bsls.bs_state.finished))
-            return tf.logical_and(max_step_cond, unfinished_cond)
-
-        final_state = tf.while_loop(
-            cond,
-            beam_body,
-            initial_loop_state,
-            shape_invariants=nest.map_structure(
-                get_state_shape_invariants, initial_loop_state))
+        self.initial_loop_state = self.get_initial_loop_state()
+        final_loop_state = tf.while_loop(
+            self.loop_continue_criterion,
+            self.get_body(),
+            self.initial_loop_state,
+            shape_invariants=tf.contrib.framework.nest.map_structure(
+                get_state_shape_invariants, self.initial_loop_state))
 
         # TODO: return att_loop_states properly
         return BeamSearchOutput(
-            last_search_step_output=final_state.bs_output,
-            last_dec_loop_state=final_state.decoder_loop_state,
-            last_search_state=final_state.bs_state,
+            last_search_step_output=final_loop_state.search_results,
+            last_dec_loop_state=final_loop_state.decoder_loop_state,
+            last_search_state=final_loop_state.search_state,
             attention_loop_states=[])
 
     def get_body(self) -> Callable:
@@ -289,8 +329,8 @@ class BeamSearchDecoder(ModelPart):
             # for n+1 steps, if you want to generate n steps by the decoder.
             loop_state = BeamSearchLoopState(*args)
             dec_loop_state = loop_state.decoder_loop_state
-            bs_state = loop_state.bs_state
-            bs_output = loop_state.bs_output
+            search_state = loop_state.search_state
+            search_results = loop_state.search_results
 
             # TODO(varisd) throw this away?
             # Don't want to use this decoder with uninitialized parent
@@ -298,9 +338,10 @@ class BeamSearchDecoder(ModelPart):
 
             # mask the probabilities
             # shape(logprobs) = [batch, beam, vocabulary]
-            logprobs = bs_state.prev_logprobs
+            logprobs = search_state.prev_logprobs
 
-            finished_mask = tf.expand_dims(tf.to_float(bs_state.finished), 2)
+            finished_mask = tf.expand_dims(
+                tf.to_float(search_state.finished), 2)
             unfinished_logprobs = (1. - finished_mask) * logprobs
 
             finished_row = tf.one_hot(
@@ -315,10 +356,11 @@ class BeamSearchDecoder(ModelPart):
 
             # update hypothesis scores
             # shape(hyp_probs) = [batch, beam, vocabulary]
-            hyp_probs = tf.expand_dims(bs_state.logprob_sum, 2) + logprobs
+            hyp_probs = tf.expand_dims(search_state.logprob_sum, 2) + logprobs
 
             # update hypothesis lengths
-            hyp_lengths = bs_state.lengths + 1 - tf.to_int32(bs_state.finished)
+            hyp_lengths = search_state.lengths + 1 - tf.to_int32(
+                search_state.finished)
 
             # shape(scores) = [batch, beam, vocabulary]
             scores = hyp_probs / tf.expand_dims(
@@ -356,13 +398,13 @@ class BeamSearchDecoder(ModelPart):
 
             # mark finished beams
             next_finished = tf.gather_nd(
-                bs_state.finished,
+                search_state.finished,
                 batch_beam_ids)
             next_just_finished = tf.equal(next_word_ids, END_TOKEN_INDEX)
             next_finished = tf.logical_or(next_finished, next_just_finished)
 
             # we need to flatten the feedables for the parent_decoder
-            next_feedables = nest.map_structure(
+            next_feedables = tf.contrib.framework.nest.map_structure(
                 lambda x: gather_flat(x, batch_beam_ids,
                                       self.batch_size, self.beam_size),
                 dec_loop_state.feedables)
@@ -380,7 +422,7 @@ class BeamSearchDecoder(ModelPart):
                         self.beam_size),
                     [1, 0])
 
-            next_histories = nest.map_structure(
+            next_histories = tf.contrib.framework.nest.map_structure(
                 gather_fn, dec_loop_state.histories)
 
             dec_loop_state = dec_loop_state._replace(
@@ -399,22 +441,54 @@ class BeamSearchDecoder(ModelPart):
                 lengths=next_beam_lengths,
                 finished=next_finished)
 
-            next_token_ids = tf.transpose(bs_output.token_ids, [1, 2, 0])
+            next_token_ids = tf.transpose(search_results.token_ids, [1, 2, 0])
             next_token_ids = tf.gather_nd(next_token_ids, batch_beam_ids)
             next_token_ids = tf.transpose(next_token_ids, [2, 0, 1])
-            next_output = SearchStepOutput(
+            next_output = SearchResults(
                 scores=topk_scores,
                 token_ids=append_tensor(next_token_ids, next_word_ids))
 
             return BeamSearchLoopState(
-                bs_state=next_search_state,
-                bs_output=next_output,
+                search_state=next_search_state,
+                search_results=next_output,
                 decoder_loop_state=next_loop_state)
         # pylint: enable=too-many-locals
 
         return body
 
-    def _length_penalty(self, lengths):
-        """Apply lp term from eq. 14."""
+    def _length_penalty(self, lengths: tf.Tensor) -> tf.Tensor:
+        """Apply length penalty ("lp") term from Eq. 14.
 
-        return ((5. + tf.to_float(lengths)) / 6.) ** self._length_normalization
+        https://arxiv.org/pdf/1609.08144.pdf
+
+        Arguments:
+            lengths: A ``Tensor`` of lengths of the hypotheses in the beam.
+
+        Returns:
+            A float ``Tensor`` with the length penalties for each hypothesis
+            in the beam.
+        """
+        return ((5. + tf.to_float(lengths)) / 6.) ** self.length_normalization
+
+    def expand_to_beam(self, val: tf.Tensor, dim: int = 0) -> tf.Tensor:
+        """Copy a tensor along a new beam dimension.
+
+        Arguments:
+            val: The ``Tensor`` to expand.
+            dim: The dimension along which to expand. Usually, the batch axis.
+
+        Returns:
+            The expanded tensor.
+        """
+        orig_shape = get_shape_list(val)
+        if val.shape.ndims == 0:
+            return val
+
+        orig_shape[dim] *= self.beam_size
+        tile_shape = [1] * (len(orig_shape) + 1)
+        tile_shape[dim + 1] = self.beam_size
+
+        val = tf.tile(tf.expand_dims(val, 1), tile_shape)
+        val = tf.reshape(val, orig_shape)
+
+        return val

--- a/neuralmonkey/decoders/beam_search_decoder.py
+++ b/neuralmonkey/decoders/beam_search_decoder.py
@@ -236,9 +236,8 @@ class BeamSearchDecoder(ModelPart):
             decoder_loop_state=self._decoder_state)
 
     def _decoding_loop(self) -> BeamSearchOutput:
-        # collect attention objects
-        beam_body = self.get_body()
 
+        beam_body = self.get_body()
         initial_loop_state = self.get_initial_loop_state()
 
         def cond(*args) -> tf.Tensor:
@@ -248,18 +247,6 @@ class BeamSearchDecoder(ModelPart):
             unfinished_cond = tf.logical_not(
                 tf.reduce_all(bsls.bs_state.finished))
             return tf.logical_and(max_step_cond, unfinished_cond)
-
-        # First step has to be run manually because while_loop needs the same
-        # shapes between steps and the first beam state is not beam-sized, but
-        # just a single state.
-        #
-        # When running ensembles, we want to provide
-        # ensembled logprobs to the beam_body before manually running
-        # the first step
-        next_bs_loop_state = tf.cond(
-            cond(*initial_loop_state),
-            lambda: beam_body(*initial_loop_state),
-            lambda: initial_loop_state)
 
         final_state = tf.while_loop(
             cond,

--- a/neuralmonkey/decoders/beam_search_decoder.py
+++ b/neuralmonkey/decoders/beam_search_decoder.py
@@ -41,7 +41,8 @@ from neuralmonkey.vocabulary import (
     Vocabulary, END_TOKEN_INDEX, PAD_TOKEN_INDEX)
 from neuralmonkey.decorators import tensor
 from neuralmonkey.tf_utils import (
-    expand_to_beam, gather_flat, get_state_shape_invariants, partial_transpose)
+    append_tensor, expand_to_beam, gather_flat, get_state_shape_invariants,
+    partial_transpose)
 
 # pylint: disable=invalid-name
 SearchState = NamedTuple("SearchState",
@@ -403,9 +404,7 @@ class BeamSearchDecoder(ModelPart):
             next_token_ids = tf.transpose(next_token_ids, [2, 0, 1])
             next_output = SearchStepOutput(
                 scores=topk_scores,
-                token_ids=tf.concat(
-                    [next_token_ids, tf.expand_dims(next_word_ids, 0)],
-                    axis=0))
+                token_ids=append_tensor(next_token_ids, next_word_ids))
 
             return BeamSearchLoopState(
                 bs_state=next_search_state,

--- a/neuralmonkey/decoders/beam_search_decoder.py
+++ b/neuralmonkey/decoders/beam_search_decoder.py
@@ -36,18 +36,19 @@ from neuralmonkey.decoders.autoregressive import (
 from neuralmonkey.vocabulary import (
     Vocabulary, END_TOKEN_INDEX, PAD_TOKEN_INDEX)
 from neuralmonkey.decorators import tensor
+from neuralmonkey.tf_utils import get_shape_list
 
 # pylint: disable=invalid-name
 SearchState = NamedTuple("SearchState",
-                         [("logprob_sum", tf.Tensor),  # (batch*beam)
-                          ("prev_logprobs", tf.Tensor),  # (batch*beam) x Vocab
-                          ("lengths", tf.Tensor),  # (batch*beam)
-                          ("finished", tf.Tensor)])  # (batch*beam)
+                         [("logprob_sum", tf.Tensor),  # [batch, beam]
+                          ("prev_logprobs", tf.Tensor),  # [batch, beam, Vocab]
+                          ("lengths", tf.Tensor),  # [batch, beam]
+                          ("finished", tf.Tensor)])  # [batch, beam]
 
 SearchStepOutput = NamedTuple("SearchStepOutput",
-                              [("scores", tf.Tensor),  # batch x beam
-                               ("parent_ids", tf.Tensor),  # batch x beam
-                               ("token_ids", tf.Tensor)])  # batch x beam
+                              [("scores", tf.Tensor),  # [batch, beam]
+                               ("parent_ids", tf.Tensor),  # [batch, beam]
+                               ("token_ids", tf.Tensor)])  # [batch, beam]
 
 SearchStepOutputTA = NamedTuple("SearchStepOutputTA",
                                 [("scores", tf.TensorArray),
@@ -98,16 +99,10 @@ class BeamSearchDecoder(ModelPart):
 
         if (hasattr(self.parent_decoder, "encoder_states")
                 and self.parent_decoder.encoder_states is not None):
-            enc_states = self.parent_decoder.encoder_states
-            enc_states_shape = tf.shape(enc_states)
-            self.parent_decoder.encoder_states = tf.reshape(
-                tf.tile(enc_states, [1, self.beam_size, 1]),
-                [-1, enc_states_shape[1], enc_states.shape[2]])  # type: ignore
-            enc_mask = self.parent_decoder.encoder_mask
-            enc_mask_shape = tf.shape(enc_mask)
-            self.parent_decoder.encoder_mask = tf.reshape(
-                tf.tile(enc_mask, [1, self.beam_size]),
-                [-1, enc_mask_shape[1]])
+            self.parent_decoder.encoder_states = self._expand_to_beam(
+                self.parent_decoder.encoder_states)
+            self.parent_decoder.encoder_mask = self._expand_to_beam(
+                self.parent_decoder.encoder_mask)
 
         # The parent_decoder is one step ahead. This is required for ensembling
         # support.
@@ -162,23 +157,19 @@ class BeamSearchDecoder(ModelPart):
         dec_ls = self.parent_decoder.get_initial_loop_state()
 
         # We need to stretch parent_decoder feedables
-        # to batch_size * beam_size
+        # to (batch_size * beam_size)
         feedables_dict = dec_ls.feedables._asdict()
         for name in feedables_dict:
             if name == "step":
                 continue
             if not isinstance(feedables_dict[name], list):
-                rank = feedables_dict[name].get_shape().ndims
-                feedables_dict[name] = tf.tile(
-                    feedables_dict[name],
-                    [self.beam_size] + [1] * (rank - 1))
+                feedables_dict[name] = self._expand_to_beam(
+                    feedables_dict[name])
             else:
                 extended = []
                 for element in feedables_dict[name]:
-                    rank = element.get_shape().ndims
-                    extended.append(tf.tile(
-                        element,
-                        [self.beam_size] + [1] * (rank - 1)))
+                    element = self._expand_to_beam(element)
+                    extended.append(element)
                 feedables_dict[name] = extended
 
         feedables = dec_ls.feedables._replace(**feedables_dict)
@@ -190,16 +181,18 @@ class BeamSearchDecoder(ModelPart):
         # We want to feed these values in ensembles
         self._search_state = SearchState(
             logprob_sum=tf.tile(
-                tf.constant([0.0] + [-INF] * (self.beam_size - 1)),
-                [self.batch_size],
+                tf.expand_dims([0.0] + [-INF] * (self.beam_size - 1), 0),
+                [self.batch_size, 1],
                 name="bs_logprob_sum"),
-            prev_logprobs=tf.nn.log_softmax(dec_ls.feedables.prev_logits),
+            prev_logprobs=tf.reshape(
+                tf.nn.log_softmax(dec_ls.feedables.prev_logits),
+                [self.batch_size, self.beam_size, len(self.vocabulary)]),
             lengths=tf.zeros(
-                [self.beam_size * self.batch_size],
+                [self.batch_size, self.beam_size],
                 dtype=tf.int32,
                 name="bs_lengths"),
             finished=tf.zeros(
-                [self.beam_size * self.batch_size],
+                [self.batch_size, self.beam_size],
                 dtype=tf.bool))
 
         self._decoder_state = dec_ls.feedables
@@ -302,10 +295,10 @@ class BeamSearchDecoder(ModelPart):
             step = dec_loop_state.feedables.step - 1
 
             # mask the probabilities
-            # shape(logprobs) = (batch*beam) x vocabulary
+            # shape(logprobs) = [batch, beam, vocabulary]
             logprobs = bs_state.prev_logprobs
 
-            finished_mask = tf.expand_dims(tf.to_float(bs_state.finished), 1)
+            finished_mask = tf.expand_dims(tf.to_float(bs_state.finished), 2)
             unfinished_logprobs = (1. - finished_mask) * logprobs
 
             finished_row = tf.one_hot(
@@ -313,116 +306,59 @@ class BeamSearchDecoder(ModelPart):
                 len(self.vocabulary),
                 dtype=tf.float32,
                 on_value=0.,
-                off_value=tf.float32.min)
+                off_value=-INF)
 
             finished_logprobs = finished_mask * finished_row
             logprobs = unfinished_logprobs + finished_logprobs
 
             # update hypothesis scores
-            # shape(hyp_probs) = (batch*beam) x vocabulary
-            hyp_probs = tf.expand_dims(bs_state.logprob_sum, 1) + logprobs
+            # shape(hyp_probs) = [batch, beam, vocabulary]
+            hyp_probs = tf.expand_dims(bs_state.logprob_sum, 2) + logprobs
 
             # update hypothesis lengths
             hyp_lengths = bs_state.lengths + 1 - tf.to_int32(bs_state.finished)
 
-            # shape(scores) = (batch*beam) x vocabulary
+            # shape(scores) = [batch, beam, vocabulary]
             scores = hyp_probs / tf.expand_dims(
-                self._length_penalty(hyp_lengths), 1)
+                self._length_penalty(hyp_lengths), 2)
 
-            # reshape to batch x (beam*vocabulary) for topk
+            # reshape to [batch, beam * vocabulary] for topk
             scores_flat = tf.reshape(
                 scores, [-1, self.beam_size * len(self.vocabulary)])
 
-            # shape(both) = batch x beam
+            # shape(both) = [batch, beam]
             topk_scores, topk_indices = tf.nn.top_k(
-                scores_flat, self._beam_size)
-            topk_indices.set_shape([None, self._beam_size])
-            topk_scores.set_shape([None, self._beam_size])
+                scores_flat, k=self.beam_size)
+            topk_indices.set_shape([None, self.beam_size])
+            topk_scores.set_shape([None, self.beam_size])
 
-            # flatten the hypothesis probabilities
-            hyp_probs_flat = tf.reshape(hyp_probs, [-1])
-
-            # First, we need the starting offsets of each batch
-            # with respect to the shape(hyp_probs)[-1] to flatten topk
-            # indices so we can gather correct hyp_probs values.
-            #
-            # ("|" marks beam border, "||" marks batch border)
-            # e.g. scores (vocabulary=2, beam_size=3, batch_size=2):
-            #
-            # [ 2.0, 3.0 | 1.0, 4.0 | 2.0, 5.0 ]
-            # [ 1.0, 2.0 | 3.0, 4.0 | 5.0, 1.0 ]
-            #
-            # topk(k=3) produces following indices:
-            # [ 5, 3, 1 ]
-            # [ 4, 3, 2 ]
-            #
-            # To correctly gather values from flattened hyp_probs
-            # shape(hyp_probs_flat) = (batch*beam*vocabulary) we compute
-            # the offsets of the values starting at each batch (||), so
-            # the following holds:
-            # [ 0 .. (beam*voc) - 1 || (beam*voc) + 0 .. 2*(beam*voc) - 1 ||
-            #   2*(beam*voc) + 0 .. 3*(beam*voc) - 1 || .. ]
-            #
-            # In the case of topk from above:
-            # [ 0*(3*2) + 5, 0*(3*2) + 3, 0*(3*2) + 1 ||
-            #   1*(3*2) + 4, 1*(3*2) + 3, 1*(3*2) + 2 ]
-            # or
-            # [ 5,  3, 1 ||
-            #   10, 9, 8 ]
-            beam_voc_offset = tf.expand_dims(
-                tf.range(
-                    start=0,
-                    limit=(self.batch_size * self.beam_size
-                           * len(self.vocabulary)),
-                    delta=(self.beam_size * len(self.vocabulary))),
-                axis=1)
-            topk_indices_flat = tf.reshape(
-                topk_indices + beam_voc_offset, [-1])
-
-            # select logprobs of the best hyps (disregard lenghts)
-            next_beam_logprob_sum = tf.gather(hyp_probs_flat,
-                                              topk_indices_flat)
-
-            # Next, we compute the starting offsets of each batch with respect
-            # to the beam_size to flatten beam_id indices
-            # to gather correct beams from the respective batches.
-            #
-            # Similar to the previous offset computation however,
-            # now we have to recompute beam_ids with regard to their
-            # corresponding batch_id (again, the values are stargin at each
-            # batch, ||).
-            #
-            # e.g beam_ids (beam_size=5, batch_size=2).
-            # [ 3, 4, 1 ]
-            # [ 2, 0, 2 ]
-            #
-            # ...after reshaping should be:
-            # [ 0*(5) + 3, 0*(5) + 4, 0*(5) + 1 ||
-            #   1*(5) + 2, 1*(5) + 0, 1*(5) + 2 ]
-            # or
-            # [ 3, 4, 1 ||
-            #   7, 5, 7 ]
-            beam_offset = tf.expand_dims(
-                tf.range(
-                    start=0,
-                    limit=(self.batch_size * self.beam_size),
-                    delta=self.beam_size),
-                axis=1)
+            # batch offset for tf.gather_nd
+            batch_offset = tf.tile(
+                tf.expand_dims(tf.range(self.batch_size), 1),
+                [1, self.beam_size])
 
             next_word_ids = tf.mod(topk_indices, len(self.vocabulary))
             next_beam_ids = tf.div(topk_indices, len(self.vocabulary))
+            batch_beam_ids = tf.stack([batch_offset, next_beam_ids], axis=2)
 
-            next_word_ids_flat = tf.reshape(next_word_ids, [-1])
-            next_beam_ids_flat = tf.reshape(
-                next_beam_ids + beam_offset, [-1])
+            # gather the topk logprob_sums
+            next_beam_lengths = tf.gather_nd(
+                hyp_lengths,
+                batch_beam_ids)
+            next_beam_logprob_sum = (
+                topk_scores * self._length_penalty(next_beam_lengths))
 
-            next_finished = tf.gather(bs_state.finished, next_beam_ids_flat)
-            next_just_finished = tf.equal(next_word_ids_flat, END_TOKEN_INDEX)
+            # mark finished beams
+            next_finished = tf.gather_nd(
+                bs_state.finished,
+                batch_beam_ids)
+            next_just_finished = tf.equal(next_word_ids, END_TOKEN_INDEX)
             next_finished = tf.logical_or(next_finished, next_just_finished)
 
+            # we need to flatten the feedables for the parent_decoder
             next_feedables_dict = {
-                "input_symbol": next_word_ids_flat,
-                "finished": next_finished}
+                "input_symbol": tf.reshape(next_word_ids, [-1]),
+                "finished": tf.reshape(next_finished, [-1])}
             for key, val in dec_loop_state.feedables._asdict().items():
                 # Note that the parent decoder is working with "batches"
                 # of the size (batch*beam)
@@ -431,18 +367,17 @@ class BeamSearchDecoder(ModelPart):
                     continue
 
                 if isinstance(val, tf.Tensor):
-                    next_feedables_dict[key] = tf.gather(val,
-                                                         next_beam_ids_flat)
+                    next_feedables_dict[key] = self._gather_flat(
+                        val, batch_beam_ids)
                 elif isinstance(val, list):
                     if not all(isinstance(t, tf.Tensor) for t in val):
                         raise TypeError("Expected tf.Tensor among feedables")
 
                     next_feedables_dict[key] = [
-                        tf.gather(t, next_beam_ids_flat) for t in val]
+                        self._gather_flat(t, batch_beam_ids) for t in val]
                 else:
                     raise TypeError("Expected only tensors or list of tensors "
                                     "among feedables")
-            next_beam_lengths = tf.gather(hyp_lengths, next_beam_ids_flat)
 
             # During beam search decoding, we are not interested in recording
             # of the computation as done by the decoder. The record is stored
@@ -458,8 +393,9 @@ class BeamSearchDecoder(ModelPart):
 
             next_search_state = SearchState(
                 logprob_sum=next_beam_logprob_sum,
-                prev_logprobs=tf.nn.log_softmax(
-                    next_loop_state.feedables.prev_logits),
+                prev_logprobs=tf.reshape(
+                    tf.nn.log_softmax(next_loop_state.feedables.prev_logits),
+                    [self.batch_size, self.beam_size, len(self.vocabulary)]),
                 lengths=next_beam_lengths,
                 finished=next_finished)
 
@@ -479,5 +415,28 @@ class BeamSearchDecoder(ModelPart):
     def _length_penalty(self, lengths):
         """Apply lp term from eq. 14."""
 
-        return ((5. + tf.to_float(lengths)) ** self._length_normalization
-                / (5. + 1.) ** self._length_normalization)
+        return ((5. + tf.to_float(lengths)) / 6.) ** self._length_normalization
+
+    def _gather_flat(self, val, indices):
+        """Gather values from the flattened (shape=[batch * beam, ...]) input.
+
+        """
+        shape = [self.batch_size, self.beam_size] + get_shape_list(val)[1:]
+        val = tf.gather_nd(
+            tf.reshape(val, shape),
+            indices)
+        return tf.reshape(val, [-1] + shape[2:])
+
+    def _expand_to_beam(self, val):
+        orig_shape = get_shape_list(val)
+        orig_shape[0] *= self.beam_size
+        tile_shape = [1] * (len(orig_shape) + 1)
+        tile_shape[1] = self.beam_size
+
+        val = tf.tile(
+            tf.expand_dims(val, 1),
+            tile_shape)
+        val = tf.reshape(
+            val,
+            orig_shape)
+        return val

--- a/neuralmonkey/decoders/beam_search_decoder.py
+++ b/neuralmonkey/decoders/beam_search_decoder.py
@@ -206,8 +206,6 @@ class BeamSearchDecoder(ModelPart):
                 [self.batch_size, self.beam_size],
                 dtype=tf.bool))
 
-        self._decoder_state = dec_ls
-
         return BeamSearchLoopState(
             bs_state=self._search_state,
             bs_output=output,
@@ -247,6 +245,7 @@ class BeamSearchDecoder(ModelPart):
                 get_state_shape_invariants, next_bs_loop_state))
 
         dec_loop_state = final_state.decoder_loop_state
+        self._decoder_state = dec_loop_state
 
         # Drop the decode input_symbol we added during
         # the token_ids initialization

--- a/neuralmonkey/decoders/beam_search_decoder.py
+++ b/neuralmonkey/decoders/beam_search_decoder.py
@@ -39,8 +39,7 @@ from neuralmonkey.decorators import tensor
 
 # pylint: disable=invalid-name
 SearchState = NamedTuple("SearchState",
-                         [("input_beam_size", tf.Tensor),  # req. for reshaping
-                          ("logprob_sum", tf.Tensor),  # (batch*beam)
+                         [("logprob_sum", tf.Tensor),  # (batch*beam)
                           ("prev_logprobs", tf.Tensor),  # (batch*beam) x Vocab
                           ("lengths", tf.Tensor),  # (batch*beam)
                           ("finished", tf.Tensor)])  # (batch*beam)
@@ -94,6 +93,18 @@ class BeamSearchDecoder(ModelPart):
         self._beam_size = beam_size
         self._length_normalization = length_normalization
 
+        if self.parent_decoder.encoder_states is not None:
+            enc_states = self.parent_decoder.encoder_states
+            enc_states_shape = tf.shape(enc_states)
+            self.parent_decoder.encoder_states = tf.reshape(
+                tf.tile(enc_states, [1, self.beam_size, 1]),
+                [-1, enc_states_shape[1], enc_states.shape[2]])
+            enc_mask = self.parent_decoder.encoder_mask
+            enc_mask_shape = tf.shape(enc_mask)
+            self.parent_decoder.encoder_mask = tf.reshape(
+                tf.tile(enc_mask, [1, self.beam_size]),
+                [-1, enc_mask_shape[1]])
+
         # The parent_decoder is one step ahead. This is required for ensembling
         # support.
         # At the end of the Nth step we generate logits for ensembling
@@ -146,19 +157,32 @@ class BeamSearchDecoder(ModelPart):
 
         # We run the decoder once to get logits for ensembling
         dec_ls = self.parent_decoder.get_initial_loop_state()
+        feedables = dec_ls.feedables._replace(
+            input_symbol=tf.tile(
+                dec_ls.feedables.input_symbol,
+                [self.beam_size]),
+            finished=tf.tile(
+                dec_ls.feedables.finished,
+                [self.beam_size]))
+        dec_ls = dec_ls._replace(feedables=feedables)
+
         decoder_body = self.parent_decoder.get_body(False)
         dec_ls = decoder_body(*dec_ls)
 
         # We want to feed these values in ensembles
         self._search_state = SearchState(
-            input_beam_size=tf.placeholder_with_default(
-                input=1, shape=[], name="input_beam_size"),
-            logprob_sum=tf.placeholder_with_default(
-                input=[0.0], shape=[None], name="bs_logprob_sum"),
+            logprob_sum=tf.tile(
+                tf.constant([0.0] + [-1e9] * (self.beam_size - 1)),
+                [self.batch_size],
+                name="bs_logprob_sum"),
             prev_logprobs=tf.nn.log_softmax(dec_ls.feedables.prev_logits),
-            lengths=tf.placeholder_with_default(
-                input=[0], shape=[None], name="bs_lengths"),
-            finished=tf.zeros([self.batch_size], dtype=tf.bool))
+            lengths=tf.zeros(
+                [self.beam_size * self.batch_size],
+                dtype=tf.int32,
+                name="bs_lengths"),
+            finished=tf.zeros(
+                [self.beam_size * self.batch_size],
+                dtype=tf.bool))
 
         self._decoder_state = dec_ls.feedables
 
@@ -289,7 +313,7 @@ class BeamSearchDecoder(ModelPart):
 
             # reshape to batch x (beam*vocabulary) for topk
             scores_flat = tf.reshape(
-                scores, [-1, bs_state.input_beam_size * len(self.vocabulary)])
+                scores, [-1, self.beam_size * len(self.vocabulary)])
 
             # shape(both) = batch x beam
             topk_scores, topk_indices = tf.nn.top_k(
@@ -330,9 +354,9 @@ class BeamSearchDecoder(ModelPart):
             beam_voc_offset = tf.expand_dims(
                 tf.range(
                     start=0,
-                    limit=(self.batch_size * bs_state.input_beam_size
+                    limit=(self.batch_size * self.beam_size
                            * len(self.vocabulary)),
-                    delta=(bs_state.input_beam_size * len(self.vocabulary))),
+                    delta=(self.beam_size * len(self.vocabulary))),
                 axis=1)
             topk_indices_flat = tf.reshape(
                 topk_indices + beam_voc_offset, [-1])
@@ -363,8 +387,8 @@ class BeamSearchDecoder(ModelPart):
             beam_offset = tf.expand_dims(
                 tf.range(
                     start=0,
-                    limit=(self.batch_size * bs_state.input_beam_size),
-                    delta=bs_state.input_beam_size),
+                    limit=(self.batch_size * self.beam_size),
+                    delta=self.beam_size),
                 axis=1)
 
             next_word_ids = tf.mod(topk_indices, len(self.vocabulary))
@@ -415,7 +439,6 @@ class BeamSearchDecoder(ModelPart):
             next_loop_state = decoder_body(*dec_loop_state)  # type: ignore
 
             next_search_state = SearchState(
-                input_beam_size=self.beam_size,
                 logprob_sum=next_beam_logprob_sum,
                 prev_logprobs=tf.nn.log_softmax(
                     next_loop_state.feedables.prev_logits),

--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -392,6 +392,11 @@ class Decoder(AutoregressiveDecoder):
             a.initial_loop_state()
             for a in self.attentions if a is not None]
 
+        histories["decoder_outputs"] = tf.zeros(
+            shape=[0, self.batch_size, self.rnn_size],
+            dtype=tf.float32,
+            name="hist_decoder_outputs")
+
         # pylint: disable=not-callable
         rnn_feedables = RNNFeedables(**feedables)
         rnn_histories = RNNHistories(**histories)

--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -21,6 +21,7 @@ from neuralmonkey.decoders.encoder_projection import (
 from neuralmonkey.decoders.output_projection import (
     OutputProjectionSpec, OutputProjection, nonlinear_output)
 from neuralmonkey.decorators import tensor
+from neuralmonkey.tf_utils import append_tensor
 
 
 RNN_CELL_TYPES = {
@@ -349,21 +350,12 @@ class Decoder(AutoregressiveDecoder):
 
             new_histories = RNNHistories(
                 attention_histories=list(att_loop_states),
-                logits=tf.concat(
-                    [loop_state.histories.logits, tf.expand_dims(logits, 0)],
-                    axis=0),
-                decoder_outputs=tf.concat(
-                    [loop_state.histories.decoder_outputs,
-                     tf.expand_dims(cell_output, 0)],
-                    axis=0),
-                outputs=tf.concat(
-                    [loop_state.histories.outputs,
-                     tf.expand_dims(next_symbols, 0)],
-                    axis=0),
-                mask=tf.concat(
-                    [loop_state.histories.mask,
-                     tf.expand_dims(not_finished, 0)],
-                    axis=0))
+                logits=append_tensor(loop_state.histories.logits, logits),
+                decoder_outputs=append_tensor(
+                    loop_state.histories.decoder_outputs, cell_output),
+                outputs=append_tensor(
+                    loop_state.histories.outputs, next_symbols),
+                mask=append_tensor(loop_state.histories.mask, not_finished))
             # pylint: enable=not-callable
 
             new_loop_state = LoopState(

--- a/neuralmonkey/decoders/transformer.py
+++ b/neuralmonkey/decoders/transformer.py
@@ -115,7 +115,8 @@ class TransformerDecoder(AutoregressiveDecoder):
 
         self.encoder_states = get_attention_states(self.encoder)
         self.encoder_mask = get_attention_mask(self.encoder)
-        self.dimension = self.encoder_states.get_shape()[2].value
+        self.dimension = \
+            self.encoder_states.get_shape()[2].value  # type: ignore
 
         if self.embedding_size != self.dimension:
             raise ValueError("Model dimension and input embedding size"
@@ -311,9 +312,6 @@ class TransformerDecoder(AutoregressiveDecoder):
         histories["input_mask"] = tf.TensorArray(
             dtype=tf.float32, dynamic_size=True, size=0,
             clear_after_read=False, name="input_mask")
-
-        #histories["input_mask"] = input_mask.write(
-        #    0, tf.ones_like(self.go_symbols, dtype=tf.float32))
 
         # TransformerHistories is a type and should be callable
         # pylint: disable=not-callable

--- a/neuralmonkey/decoders/transformer.py
+++ b/neuralmonkey/decoders/transformer.py
@@ -8,9 +8,7 @@ import math
 import tensorflow as tf
 from typeguard import check_argument_types
 
-from neuralmonkey.attention.scaled_dot_product import (
-    #empty_multi_head_loop_state
-    attention)
+from neuralmonkey.attention.scaled_dot_product import attention
 from neuralmonkey.attention.base_attention import (
     Attendable, get_attention_states, get_attention_mask)
 from neuralmonkey.decorators import tensor
@@ -32,8 +30,9 @@ TransformerHistories = extend_namedtuple(
     "TransformerHistories",
     DecoderHistories,
     [("decoded_symbols", tf.Tensor),
-     #("self_attention_histories", List[Tuple]),
-     #("inter_attention_histories", List[Tuple]),
+     # TODO(all) handle these!
+     # ("self_attention_histories", List[Tuple]),
+     # ("inter_attention_histories", List[Tuple]),
      ("input_mask", tf.Tensor)])
 # pylint: enable=invalid-name
 
@@ -412,10 +411,10 @@ class TransformerDecoder(AutoregressiveDecoder):
                      tf.expand_dims(next_symbols, 0)],
                     axis=0),
                 # transformer-specific:
-                # TODO handle attention histories correctly
                 decoded_symbols=decoded_symbols,
-                #self_attention_histories=histories.self_attention_histories,
-                #inter_attention_histories=histories.inter_attention_histories,
+                # TODO(all) handle these!
+                # self_attention_histories=histories.self_attention_histories,
+                # inter_attention_histories analogicky
                 input_mask=input_mask)
             # pylint: enable=not-callable
 

--- a/neuralmonkey/decoders/transformer.py
+++ b/neuralmonkey/decoders/transformer.py
@@ -27,7 +27,7 @@ from neuralmonkey.tf_utils import layer_norm
 
 # pylint: disable=invalid-name
 TransformerHistories = extend_namedtuple(
-    "RNNHistories",
+    "TransformerHistories",
     DecoderHistories,
     [("decoded_symbols", tf.TensorArray),
      ("self_attention_histories", List[Tuple]),

--- a/neuralmonkey/decoders/transformer.py
+++ b/neuralmonkey/decoders/transformer.py
@@ -192,9 +192,6 @@ class TransformerDecoder(AutoregressiveDecoder):
     def encoder_attention_sublayer(self, queries: tf.Tensor) -> tf.Tensor:
         """Create the encoder-decoder attention sublayer."""
 
-        encoder_att_states = get_attention_states(self.encoder)
-        encoder_att_mask = get_attention_mask(self.encoder)
-
         # Layer normalization
         normalized_queries = layer_norm(queries)
 
@@ -202,9 +199,9 @@ class TransformerDecoder(AutoregressiveDecoder):
         # TODO handle histories
         encoder_context, _ = attention(
             queries=normalized_queries,
-            keys=encoder_att_states,
-            values=encoder_att_states,
-            keys_mask=encoder_att_mask,
+            keys=self.encoder_states,
+            values=self.encoder_states,
+            keys_mask=self.encoder_mask,
             num_heads=self.n_heads_enc,
             dropout_callback=lambda x: dropout(
                 x, self.attention_dropout_keep_prob, self.train_mode),
@@ -311,12 +308,12 @@ class TransformerDecoder(AutoregressiveDecoder):
             dtype=tf.int32, dynamic_size=True, size=0,
             clear_after_read=False, name="decoded_symbols")
 
-        input_mask = tf.TensorArray(
+        histories["input_mask"] = tf.TensorArray(
             dtype=tf.float32, dynamic_size=True, size=0,
             clear_after_read=False, name="input_mask")
 
-        histories["input_mask"] = input_mask.write(
-            0, tf.ones_like(self.go_symbols, dtype=tf.float32))
+        #histories["input_mask"] = input_mask.write(
+        #    0, tf.ones_like(self.go_symbols, dtype=tf.float32))
 
         # TransformerHistories is a type and should be callable
         # pylint: disable=not-callable
@@ -343,13 +340,16 @@ class TransformerDecoder(AutoregressiveDecoder):
             decoded_symbols_ta = histories.decoded_symbols.write(
                 step, feedables.input_symbol)
 
+            input_mask = histories.input_mask.write(
+                step, tf.to_float(tf.logical_not(feedables.finished)))
+
             # shape (time, batch)
             decoded_symbols = decoded_symbols_ta.stack()
             decoded_symbols.set_shape([None, None])
             decoded_symbols_in_batch = tf.transpose(decoded_symbols)
 
             # mask (time, batch)
-            mask = histories.input_mask.stack()
+            mask = input_mask.stack()
             mask.set_shape([None, None])
 
             with tf.variable_scope(self._variable_scope, reuse=tf.AUTO_REUSE):
@@ -407,8 +407,7 @@ class TransformerDecoder(AutoregressiveDecoder):
                 decoded_symbols=decoded_symbols_ta,
                 self_attention_histories=histories.self_attention_histories,
                 inter_attention_histories=histories.inter_attention_histories,
-                input_mask=histories.input_mask.write(
-                    step + 1, tf.to_float(not_finished)))
+                input_mask=input_mask)
             # pylint: enable=not-callable
 
             new_loop_state = LoopState(

--- a/neuralmonkey/decoders/transformer.py
+++ b/neuralmonkey/decoders/transformer.py
@@ -336,7 +336,6 @@ class TransformerDecoder(AutoregressiveDecoder):
             loop_state = LoopState(*args)
             histories = loop_state.histories
             feedables = loop_state.feedables
-            step = feedables.step
 
             # shape (time, batch)
             decoded_symbols = tf.concat(
@@ -392,7 +391,7 @@ class TransformerDecoder(AutoregressiveDecoder):
                 not_finished = tf.logical_not(has_finished)
 
             new_feedables = DecoderFeedables(
-                step=step + 1,
+                step=feedables.step + 1,
                 finished=has_finished,
                 input_symbol=next_symbols,
                 prev_logits=logits)
@@ -422,7 +421,7 @@ class TransformerDecoder(AutoregressiveDecoder):
 
             new_loop_state = LoopState(
                 histories=new_histories,
-                constants=[],
+                constants=loop_state.constants,
                 feedables=new_feedables)
 
             return new_loop_state

--- a/neuralmonkey/decoders/transformer.py
+++ b/neuralmonkey/decoders/transformer.py
@@ -116,8 +116,8 @@ class TransformerDecoder(AutoregressiveDecoder):
 
         self.encoder_states = get_attention_states(self.encoder)
         self.encoder_mask = get_attention_mask(self.encoder)
-        self.dimension = \
-            self.encoder_states.get_shape()[2].value  # type: ignore
+        self.dimension = (
+            self.encoder_states.get_shape()[2].value)  # type: ignore
 
         if self.embedding_size != self.dimension:
             raise ValueError("Model dimension and input embedding size"

--- a/neuralmonkey/runners/beamsearch_runner.py
+++ b/neuralmonkey/runners/beamsearch_runner.py
@@ -109,10 +109,7 @@ class BeamSearchExecutable(Executable):
         for result in results:
             bs_outputs = result["bs_outputs"]
 
-            input_beam_size = len(bs_outputs.last_search_state.prev_logprobs)
-            input_beam_size //= batch_size
             search_state = bs_outputs.last_search_state._replace(
-                input_beam_size=input_beam_size,
                 prev_logprobs=ens_logprobs)
 
             # in the next iteration, we want to generate one new symbol

--- a/neuralmonkey/runners/beamsearch_runner.py
+++ b/neuralmonkey/runners/beamsearch_runner.py
@@ -163,8 +163,10 @@ class BeamSearchExecutable(Executable):
 
     def _is_finished(self, results):
         # TODO: support for ensembles
-        feedables = results[0]["bs_outputs"].last_dec_loop_state.feedables
-        if all(feedables.finished):
+        #feedables = results[0]["bs_outputs"].last_dec_loop_state.feedables
+        finished = [res["bs_outputs"].last_dec_loop_state.feedables.finished for res in results]
+        #if all(feedables.finished):
+        if all(finished):
             return True
         if (self._decoder.max_output_len is not None
                 and self._step >= self._decoder.max_output_len):

--- a/neuralmonkey/runners/beamsearch_runner.py
+++ b/neuralmonkey/runners/beamsearch_runner.py
@@ -71,8 +71,7 @@ class BeamSearchExecutable(Executable):
                 prev_logprobs=ens_logprobs)
 
             dec_ls = bs_out.last_dec_loop_state
-            feedables = dec_ls.feedables._replace(
-                step=1)
+            feedables = dec_ls.feedables._replace(step=1)
             dec_ls = dec_ls._replace(feedables=feedables)
 
             fd = {

--- a/neuralmonkey/runners/beamsearch_runner.py
+++ b/neuralmonkey/runners/beamsearch_runner.py
@@ -164,7 +164,9 @@ class BeamSearchExecutable(Executable):
     def _is_finished(self, results):
         # TODO: support for ensembles
         #feedables = results[0]["bs_outputs"].last_dec_loop_state.feedables
-        finished = [res["bs_outputs"].last_dec_loop_state.feedables.finished for res in results]
+        finished = [
+            all(res["bs_outputs"].last_dec_loop_state.feedables.finished)
+            for res in results]
         #if all(feedables.finished):
         if all(finished):
             return True

--- a/neuralmonkey/runners/beamsearch_runner.py
+++ b/neuralmonkey/runners/beamsearch_runner.py
@@ -47,7 +47,6 @@ class BeamSearchExecutable(Executable):
                 {"bs_outputs": self._decoder.outputs},
                 self._next_feed)
 
-    # pylint: disable=too-many-locals,too-many-branches
     def collect_results(self, results: List[Dict]) -> None:
         # Recompute logits
         # Only necessary when ensembling models
@@ -84,7 +83,6 @@ class BeamSearchExecutable(Executable):
             self._next_feed.append(fd)
 
         return
-    # pylint: enable=too-many-locals,too-many-branches
 
     def prepare_results(self, output):
         bs_scores = [s[self._rank - 1] for s in output.scores]

--- a/neuralmonkey/runners/beamsearch_runner.py
+++ b/neuralmonkey/runners/beamsearch_runner.py
@@ -116,7 +116,6 @@ class BeamSearchExecutable(Executable):
         finished = [
             all(res["bs_outputs"].last_dec_loop_state.feedables.finished)
             for res in results]
-        #if all(feedables.finished):
         if all(finished):
             return True
         bs_outputs = results[0]["bs_outputs"]

--- a/neuralmonkey/runners/logits_runner.py
+++ b/neuralmonkey/runners/logits_runner.py
@@ -88,7 +88,7 @@ class LogitsRunner(BaseRunner[Classifier]):
         """Initialize the logits runner.
 
         Args:
-            output_series: Name of the series produces by the runner.
+            output_series: Name of the series produced by the runner.
             decoder: A decoder having logits.
             normalize: Flag whether the logits should be normalized with
                 softmax.

--- a/neuralmonkey/tf_manager.py
+++ b/neuralmonkey/tf_manager.py
@@ -278,6 +278,7 @@ class TensorFlowManager(object):
         for sess, file_name in zip(self.sessions, variable_files):
             log("Loading variables from {}".format(file_name))
             self.saver.restore(sess, file_name)
+            log("Variables loaded from {}".format(file_name))
 
     def restore_best_vars(self) -> None:
         # TODO warn when link does not exist

--- a/neuralmonkey/tf_utils.py
+++ b/neuralmonkey/tf_utils.py
@@ -243,3 +243,16 @@ def expand_to_beam(
     val = tf.reshape(val, orig_shape)
 
     return val
+
+
+def append_tensor(tensor: tf.Tensor, appendval: tf.Tensor) -> tf.Tensor:
+    """Append an ``N``-D Tensor to an ``(N+1)``-D Tensor.
+
+    Arguments:
+        tensor: The original Tensor
+        appendval: The Tensor to add
+
+    Returns:
+        An ``(N+1)``-D Tensor with ``appendval`` on the last position.
+    """
+    return tf.concat([tensor, tf.expand_dims(appendval, 0)], 0)

--- a/neuralmonkey/tf_utils.py
+++ b/neuralmonkey/tf_utils.py
@@ -50,6 +50,27 @@ def get_variable(name: str,
         initializer=get_initializer(name, initializer),
         **kwargs)
 
+def get_shape_list(x):
+    """Return list of dims, statically where possible.
+
+    Based on tensor2tensor.
+    """
+    x = tf.convert_to_tensor(x)
+
+    # If unknown rank, return dynamic shape
+    if x.get_shape().dims is None:
+        return tf.shape(x)
+
+    static = x.get_shape().as_list()
+    shape = tf.shape(x)
+
+    ret = []
+    for i in range(len(static)):
+        dim = static[i]
+        if dim is None:
+            dim = shape[i]
+        ret.append(dim)
+    return ret
 
 def tf_print(tensor: tf.Tensor,
              message: str = None,

--- a/neuralmonkey/tf_utils.py
+++ b/neuralmonkey/tf_utils.py
@@ -166,6 +166,7 @@ def layer_norm(x, epsilon=1e-6):
         norm_x = (x - mean) * tf.rsqrt(variance + epsilon)
         return norm_x * gamma + beta
 
+
 def expand_to_beam(val, i=0, beam_size=1):
     orig_shape = get_shape_list(val)
     if val.shape.ndims == 0:
@@ -173,7 +174,7 @@ def expand_to_beam(val, i=0, beam_size=1):
 
     orig_shape[i] *= beam_size
     tile_shape = [1] * (len(orig_shape) + 1)
-    tile_shape[i+1] = beam_size
+    tile_shape[i + 1] = beam_size
 
     val = tf.tile(
         tf.expand_dims(val, 1),

--- a/neuralmonkey/tf_utils.py
+++ b/neuralmonkey/tf_utils.py
@@ -219,32 +219,6 @@ def layer_norm(x: tf.Tensor, epsilon: float = 1e-6) -> tf.Tensor:
         return norm_x * gamma + beta
 
 
-def expand_to_beam(
-        val: tf.Tensor, i: int = 0, beam_size: int = 1) -> tf.Tensor:
-    """Copy a tensor along a new beam dimension.
-
-    Arguments:
-        val: The ``Tensor`` to expand.
-        i: The dimension along which to expand.
-        beam_size: The size of the beam.
-
-    Returns:
-        The expanded tensor.
-    """
-    orig_shape = get_shape_list(val)
-    if val.shape.ndims == 0:
-        return val
-
-    orig_shape[i] *= beam_size
-    tile_shape = [1] * (len(orig_shape) + 1)
-    tile_shape[i + 1] = beam_size
-
-    val = tf.tile(tf.expand_dims(val, 1), tile_shape)
-    val = tf.reshape(val, orig_shape)
-
-    return val
-
-
 def append_tensor(tensor: tf.Tensor, appendval: tf.Tensor) -> tf.Tensor:
     """Append an ``N``-D Tensor to an ``(N+1)``-D Tensor.
 

--- a/neuralmonkey/tf_utils.py
+++ b/neuralmonkey/tf_utils.py
@@ -65,8 +65,7 @@ def get_shape_list(x):
     shape = tf.shape(x)
 
     ret = []
-    for i in range(len(static)):
-        dim = static[i]
+    for i, dim in enumerate(static):
         if dim is None:
             dim = shape[i]
         ret.append(dim)

--- a/tests/beamsearch.ini
+++ b/tests/beamsearch.ini
@@ -25,11 +25,6 @@ num_sessions=1
 save_n_best=4
 
 [train_data]
-; This is a definition of the training data object. Dataset is not a standard
-; class, it treats the __init__ method's arguments as a dictionary, therefore
-; the data series names can be any string, prefixed with "s_". To specify the
-; output file for a series, use "s_" prefix and "_out" suffix, e.g.
-; "s_target_out"
 class=dataset.load_dataset_from_files
 s_source="tests/data/train.tc.en"
 s_target="tests/data/train.tc.de"
@@ -37,8 +32,6 @@ preprocessors=[("source", "source_chars", processors.helpers.preprocess_char_bas
 lazy=True
 
 [val_data]
-; Validation data, the languages are not necessary here, encoders and decoders
-; access the data series via the string identifiers defined here.
 class=dataset.load_dataset_from_files
 s_source="tests/data/val.tc.en"
 s_target="tests/data/val.tc.de"

--- a/tests/beamsearch.ini
+++ b/tests/beamsearch.ini
@@ -15,7 +15,7 @@ postprocess=None
 evaluation=[("target_beam.rank001", "target", evaluators.BLEU)]
 logging_period=20
 validation_period=60
-runners_batch_size=100
+runners_batch_size=5
 random_seed=1234
 
 [tf_manager]
@@ -48,30 +48,63 @@ preprocessors=[("source", "source_chars", processors.helpers.preprocess_char_bas
 class=vocabulary.from_wordlist
 path="tests/outputs/vocab/encoder_vocab.tsv"
 
-[encoder]
-class=encoders.recurrent.SentenceEncoder
-name="sentence_encoder"
-rnn_size=7
-max_input_len=10
-embedding_size=11
-dropout_keep_prob=0.5
+[inpseq]
+class=model.sequence.EmbeddedSequence
+name="input"
+embedding_size=6
+max_length=7
 data_id="source"
 vocabulary=<encoder_vocabulary>
+
+[encoder]
+class=encoders.transformer.TransformerEncoder
+name="transformer_encoder"
+input_sequence=<inpseq>
+ff_hidden_size=10
+depth=2
+n_heads=3
+dropout_keep_prob=0.9
 
 [decoder_vocabulary]
 class=vocabulary.from_wordlist
 path="tests/outputs/vocab/decoder_vocab.tsv"
 
 [decoder]
-class=decoders.decoder.Decoder
+class=decoders.transformer.TransformerDecoder
 name="decoder"
-encoders=[<encoder>]
-rnn_size=8
-embedding_size=9
+encoder=<encoder>
 dropout_keep_prob=0.5
 data_id="target"
-max_output_len=10
+max_output_len=3
 vocabulary=<decoder_vocabulary>
+embedding_size=6
+ff_hidden_size=10
+depth=2
+n_heads_self=3
+n_heads_enc=2
+
+[trainer]
+class=trainers.cross_entropy_trainer.CrossEntropyTrainer
+decoders=[<decoder>]
+optimizer=<lazyadam_g>
+
+[decayed_lr]
+class=functions.noam_decay
+learning_rate=0.2
+model_dimension=6
+warmup_steps=111
+
+[lazyadam_g]
+class=tf.contrib.opt.LazyAdamOptimizer
+beta1=0.9
+beta2=0.98
+epsilon=1.0e-9
+learning_rate=<decayed_lr>
+
+[runner]
+class=runners.GreedyRunner
+decoder=<decoder>
+output_series="target"
 
 [bs_decoder]
 class=decoders.beam_search_decoder.BeamSearchDecoder
@@ -80,13 +113,6 @@ parent_decoder=<decoder>
 length_normalization=0.6
 max_steps=10
 beam_size=3
-
-[trainer]
-; This block just fills the arguments of the trainer __init__ method.
-class=trainers.CrossEntropyTrainer
-decoders=[<decoder>]
-l2_weight=1.0e-8
-clip_norm=1.0
 
 [bs_runners]
 class=runners.beam_search_runner_range

--- a/tests/beamsearch.ini
+++ b/tests/beamsearch.ini
@@ -101,11 +101,6 @@ beta2=0.98
 epsilon=1.0e-9
 learning_rate=<decayed_lr>
 
-[runner]
-class=runners.GreedyRunner
-decoder=<decoder>
-output_series="target"
-
 [bs_decoder]
 class=decoders.beam_search_decoder.BeamSearchDecoder
 name="beam_search_decoder"

--- a/tests/beamsearch_ensembles.ini
+++ b/tests/beamsearch_ensembles.ini
@@ -15,7 +15,7 @@ postprocess=None
 evaluation=[("target_beam.rank001", "target", evaluators.BLEU)]
 logging_period=20
 validation_period=60
-runners_batch_size=1
+runners_batch_size=5
 random_seed=1234
 
 [tf_manager]
@@ -25,11 +25,6 @@ num_sessions=4
 save_n_best=4
 
 [train_data]
-; This is a definition of the training data object. Dataset is not a standard
-; class, it treats the __init__ method's arguments as a dictionary, therefore
-; the data series names can be any string, prefixed with "s_". To specify the
-; output file for a series, use "s_" prefix and "_out" suffix, e.g.
-; "s_target_out"
 class=dataset.load_dataset_from_files
 s_source="tests/data/train.tc.en"
 s_target="tests/data/train.tc.de"
@@ -37,8 +32,6 @@ preprocessors=[("source", "source_chars", processors.helpers.preprocess_char_bas
 lazy=True
 
 [val_data]
-; Validation data, the languages are not necessary here, encoders and decoders
-; access the data series via the string identifiers defined here.
 class=dataset.load_dataset_from_files
 s_source="tests/data/val.tc.en"
 s_target="tests/data/val.tc.de"
@@ -48,30 +41,58 @@ preprocessors=[("source", "source_chars", processors.helpers.preprocess_char_bas
 class=vocabulary.from_wordlist
 path="tests/outputs/vocab/encoder_vocab.tsv"
 
-[encoder]
-class=encoders.recurrent.SentenceEncoder
-name="sentence_encoder"
-rnn_size=7
-max_input_len=10
-embedding_size=11
-dropout_keep_prob=0.5
+[inpseq]
+class=model.sequence.EmbeddedSequence
+name="input"
+embedding_size=6
+max_length=7
 data_id="source"
 vocabulary=<encoder_vocabulary>
+
+[encoder]
+class=encoders.transformer.TransformerEncoder
+name="transformer_encoder"
+input_sequence=<inpseq>
+ff_hidden_size=10
+depth=2
+n_heads=3
+dropout_keep_prob=0.9
 
 [decoder_vocabulary]
 class=vocabulary.from_wordlist
 path="tests/outputs/vocab/decoder_vocab.tsv"
 
 [decoder]
-class=decoders.decoder.Decoder
+class=decoders.transformer.TransformerDecoder
 name="decoder"
-encoders=[<encoder>]
-rnn_size=8
-embedding_size=9
+encoder=<encoder>
 dropout_keep_prob=0.5
 data_id="target"
-max_output_len=10
+max_output_len=3
 vocabulary=<decoder_vocabulary>
+embedding_size=6
+ff_hidden_size=10
+depth=2
+n_heads_self=3
+n_heads_enc=2
+
+[trainer]
+class=trainers.cross_entropy_trainer.CrossEntropyTrainer
+decoders=[<decoder>]
+optimizer=<lazyadam_g>
+
+[decayed_lr]
+class=functions.noam_decay
+learning_rate=0.2
+model_dimension=6
+warmup_steps=111
+
+[lazyadam_g]
+class=tf.contrib.opt.LazyAdamOptimizer
+beta1=0.9
+beta2=0.98
+epsilon=1.0e-9
+learning_rate=<decayed_lr>
 
 [bs_decoder]
 class=decoders.beam_search_decoder.BeamSearchDecoder
@@ -80,13 +101,6 @@ parent_decoder=<decoder>
 length_normalization=0.6
 max_steps=10
 beam_size=3
-
-[trainer]
-; This block just fills the arguments of the trainer __init__ method.
-class=trainers.cross_entropy_trainer.CrossEntropyTrainer
-decoders=[<decoder>]
-l2_weight=1.0e-8
-clip_norm=1.0
 
 [bs_runners]
 class=runners.beam_search_runner_range

--- a/tests/flat-multiattention.ini
+++ b/tests/flat-multiattention.ini
@@ -154,6 +154,7 @@ name="beam_search_decoder"
 parent_decoder=<decoder_flat_share_sentinel>
 beam_size=2
 length_normalization=1.0
+max_steps=3
 
 [trainer]
 ; This block just fills the arguments of the trainer __init__ method.

--- a/tests/test_data_ensembles_all.ini
+++ b/tests/test_data_ensembles_all.ini
@@ -2,9 +2,7 @@
 
 [main]
 test_datasets=[<val_data>]
-;variables=["tests/outputs/beamsearch/variables.data.0", "tests/outputs/beamsearch/variables.data.1", "tests/outputs/beamsearch/variables.data.2", "tests/outputs/beamsearch/variables.data.3"]
-variables=["tests/outputs/beamsearch/variables.data.0", "tests/outputs/beamsearch/variables.data.0", "tests/outputs/beamsearch/variables.data.0", "tests/outputs/beamsearch/variables.data.0"]
-;variables=["tests/outputs/beamsearch/variables.data.0"]
+variables=["tests/outputs/beamsearch/variables.data.0", "tests/outputs/beamsearch/variables.data.1", "tests/outputs/beamsearch/variables.data.2", "tests/outputs/beamsearch/variables.data.3"]
 
 [val_data]
 class=dataset.load_dataset_from_files


### PR DESCRIPTION
Fixed beamsearch_decoder.py. Now it works with the attention models even when using runners_batch_size > 1.
The BeamSearchDecoder assumes that the parent_decoder has attributes 'encoder_states' and 'encoder_mask' which are created during parent_decoder initialization via get_attention* methods.