### PR TITLE
make vocabulary generation from data deterministic

### DIFF
--- a/neuralmonkey/vocabulary.py
+++ b/neuralmonkey/vocabulary.py
@@ -413,7 +413,8 @@ class Vocabulary(collections.Sized):
                              "word_counts to use for vocabulary truncate")
 
         # sort by frequency
-        words_by_freq = sorted(list(self.word_count.keys()),
+        # sorting words first makes vocabulary generation deterministic
+        words_by_freq = sorted(list(sorted(self.word_count.keys())),
                                key=lambda w: self.word_count[w])
 
         # keep the least frequent words which are not special symbols


### PR DESCRIPTION
The use of `vocabulary.from_dataset` is currently not deterministic and can make models useless if their vocabulary was not saved.

Example: Run `bin/neuralmonkey-train tests/vocab.ini` three times to generate vocabulary files `encoder_vocab1.tsv`, `encoder_vocab2.tsv`, `encoder_vocab3.tsv`. Then compare vocabularies:

    diff encoder_vocab2.tsv encoder_vocab1.tsv
    17a18 
    > into  30 
    57d57 
    < from  30

    diff encoder_vocab2.tsv encoder_vocab3.tsv
    43a44
    > women 30
    57d57
    < from  30

Words with equal frequencies are treated in random order for determining the cutoff position, this is simply fixed by sorting them before.