### PR TITLE
Namedtuples to classes

### DIFF
--- a/neuralmonkey/attention/base_attention.py
+++ b/neuralmonkey/attention/base_attention.py
@@ -37,17 +37,16 @@ this data to be available in the ``histories`` dictionary. The single and most
 used example of two *modes* are the *train* and *runtime* modes of the
 autoregressive decoder.
 """
-from typing import NamedTuple, Dict, Optional, Any, Tuple, Union
+from typing import Dict, Optional, Any, Tuple, Union
 
 import tensorflow as tf
 
 from neuralmonkey.model.stateful import TemporalStateful, SpatialStateful
 from neuralmonkey.model.model_part import ModelPart, InitializerSpecs
+from neuralmonkey.attention.namedtuples import AttentionLoopState
 
 # pylint: disable=invalid-name
 Attendable = Union[TemporalStateful, SpatialStateful]
-AttentionLoopState = NamedTuple(
-    "AttentionLoopState", [("contexts", tf.Tensor), ("weights", tf.Tensor)])
 # pylint: enable=invalid-name
 
 

--- a/neuralmonkey/attention/combination.py
+++ b/neuralmonkey/attention/combination.py
@@ -13,7 +13,7 @@ decoder not to attend to the, and extract information on its own hidden state
 (see paper `Knowing when to Look: Adaptive Attention via a Visual Sentinel for
 Image Captioning  <https://arxiv.org/pdf/1612.01887.pdf>`_).
 """
-from typing import Any, List, Tuple, NamedTuple
+from typing import Any, List, Tuple
 
 from typeguard import check_argument_types
 import tensorflow as tf
@@ -21,6 +21,7 @@ import tensorflow as tf
 from neuralmonkey.attention.base_attention import (
     BaseAttention, AttentionLoopState, empty_attention_loop_state,
     get_attention_states, get_attention_mask, Attendable)
+from neuralmonkey.attention.namedtuples import HierarchicalLoopState
 from neuralmonkey.checking import assert_shape
 from neuralmonkey.model.model_part import InitializerSpecs
 from neuralmonkey.tf_utils import get_variable
@@ -315,14 +316,6 @@ def _sentinel(state, prev_state, input_):
         assert_shape(sentinel_value, [-1, decoder_state_size])
 
         return sentinel_value
-
-
-# pylint: disable=invalid-name
-HierarchicalLoopState = NamedTuple(
-    "HierarchicalLoopState",
-    [("child_loop_states", List),
-     ("loop_state", AttentionLoopState)])
-# pylint: enable=invalid-name
 
 
 class HierarchicalMultiAttention(MultiAttention):

--- a/neuralmonkey/attention/namedtuples.py
+++ b/neuralmonkey/attention/namedtuples.py
@@ -2,10 +2,10 @@ from typing import NamedTuple, List
 import tensorflow as tf
 
 
-class AttentionLoopState(
-        NamedTuple("AttentionLoopState",
-                   [("contexts", tf.Tensor),
-                    ("weights", tf.Tensor)])):
+class AttentionLoopState(NamedTuple(
+        "AttentionLoopState",
+        [("contexts", tf.Tensor),
+         ("weights", tf.Tensor)])):
     """Basic loop state of an attention mechanism.
 
     Attributes:
@@ -17,10 +17,10 @@ class AttentionLoopState(
     """
 
 
-class HierarchicalLoopState(
-        NamedTuple("HierarchicalLoopState",
-                   [("child_loop_states", List),
-                    ("loop_state", AttentionLoopState)])):
+class HierarchicalLoopState(NamedTuple(
+        "HierarchicalLoopState",
+        [("child_loop_states", List),
+         ("loop_state", AttentionLoopState)])):
     """Loop state of the hierarchical attention mechanism.
 
     The input to the hierarchical attetnion is the output of a set of
@@ -35,10 +35,10 @@ class HierarchicalLoopState(
     """
 
 
-class MultiHeadLoopState(
-        NamedTuple("MultiHeadLoopState",
-                   [("contexts", tf.Tensor),
-                    ("head_weights", List[tf.Tensor])])):
+class MultiHeadLoopState(NamedTuple(
+        "MultiHeadLoopState",
+        [("contexts", tf.Tensor),
+         ("head_weights", List[tf.Tensor])])):
     """Loop state of a multi-head attention.
 
     Attributes:

--- a/neuralmonkey/attention/namedtuples.py
+++ b/neuralmonkey/attention/namedtuples.py
@@ -1,0 +1,51 @@
+from typing import NamedTuple, List
+import tensorflow as tf
+
+
+class AttentionLoopState(
+        NamedTuple("AttentionLoopState",
+                   [("contexts", tf.Tensor),
+                    ("weights", tf.Tensor)])):
+    """Basic loop state of an attention mechanism.
+
+    Attributes:
+        contexts: A tensor of shape ``(query_time, batch, context_dim)`` which
+            stores the context vectors for every decoder time step.
+        weights: A tensor of shape ``(query_time, batch, keys_len)`` which
+            stores the attention distribution over the keys given the query in
+            each decoder time step.
+    """
+
+
+class HierarchicalLoopState(
+        NamedTuple("HierarchicalLoopState",
+                   [("child_loop_states", List),
+                    ("loop_state", AttentionLoopState)])):
+    """Loop state of the hierarchical attention mechanism.
+
+    The input to the hierarchical attetnion is the output of a set of
+    underlying (child) attentions. To record the inner states of the underlying
+    attentions, we use the ``HierarchicalLoopState``, which holds information
+    about both the underlying attentions, and the top-level attention itself.
+
+    Attributes:
+        child_loop_states: A list of attention loop states of the underlying
+            attention mechanisms.
+        loop_state: The attention loop state of the top-level attention.
+    """
+
+
+class MultiHeadLoopState(
+        NamedTuple("MultiHeadLoopState",
+                   [("contexts", tf.Tensor),
+                    ("head_weights", List[tf.Tensor])])):
+    """Loop state of a multi-head attention.
+
+    Attributes:
+        contexts: A tensor of shape ``(query_time, batch, context_dim)`` which
+            stores the context vectors for every decoder time step.
+        head_weights: A tensor of shape ``(query_time, n_heads, batch,
+            keys_len)`` which stores the attention distribution over the keys
+            given the query in each decoder time step **for each attention
+            head**.
+    """

--- a/neuralmonkey/attention/scaled_dot_product.py
+++ b/neuralmonkey/attention/scaled_dot_product.py
@@ -7,7 +7,7 @@ dimensionality. This attention function has no trainable parameters.
 See arxiv.org/abs/1706.03762
 """
 import math
-from typing import Tuple, List, NamedTuple, Callable, Union
+from typing import Tuple, Callable, Union
 
 import tensorflow as tf
 from typeguard import check_argument_types
@@ -16,12 +16,7 @@ from neuralmonkey.nn.utils import dropout
 from neuralmonkey.model.model_part import InitializerSpecs
 from neuralmonkey.attention.base_attention import (
     BaseAttention, Attendable, get_attention_states, get_attention_mask)
-
-# pylint: disable=invalid-name
-MultiHeadLoopState = NamedTuple("MultiHeadLoopState",
-                                [("contexts", tf.Tensor),
-                                 ("head_weights", List[tf.Tensor])])
-# pylint: enable=invalid-name
+from neuralmonkey.attention.namedtuples import MultiHeadLoopState
 
 
 def split_for_heads(x: tf.Tensor, n_heads: int, head_dim: int) -> tf.Tensor:

--- a/neuralmonkey/decoders/beam_search_decoder.py
+++ b/neuralmonkey/decoders/beam_search_decoder.py
@@ -108,7 +108,7 @@ class BeamSearchLoopState(NamedTuple(
 
 
 class BeamSearchOutput(NamedTuple(
-        "SearchResults",
+        "BeamSearchOutput",
         [("last_search_step_output", SearchResults),
          ("last_dec_loop_state", NamedTuple),
          ("last_search_state", SearchState),

--- a/neuralmonkey/decoders/transformer.py
+++ b/neuralmonkey/decoders/transformer.py
@@ -2,7 +2,7 @@
 
 Described in Vaswani et al. (2017), arxiv.org/abs/1706.03762
 """
-from typing import Callable, Set, List, Tuple  # pylint: disable=unused-import
+from typing import Callable, NamedTuple
 import math
 
 import tensorflow as tf
@@ -13,8 +13,7 @@ from neuralmonkey.attention.base_attention import (
     Attendable, get_attention_states, get_attention_mask)
 from neuralmonkey.decorators import tensor
 from neuralmonkey.decoders.autoregressive import (
-    AutoregressiveDecoder, LoopState, extend_namedtuple, DecoderHistories,
-    DecoderFeedables)
+    AutoregressiveDecoder, LoopState, DecoderFeedables)
 from neuralmonkey.encoders.transformer import (
     TransformerLayer, position_signal)
 from neuralmonkey.model.sequence import EmbeddedSequence
@@ -24,17 +23,28 @@ from neuralmonkey.vocabulary import (
     Vocabulary, PAD_TOKEN_INDEX, END_TOKEN_INDEX)
 from neuralmonkey.tf_utils import append_tensor, layer_norm
 
-# pylint: disable=invalid-name
-# TODO: handle attention histories
-TransformerHistories = extend_namedtuple(
-    "TransformerHistories",
-    DecoderHistories,
-    [("decoded_symbols", tf.Tensor),
-     # TODO(all) handle these!
-     # ("self_attention_histories", List[Tuple]),
-     # ("inter_attention_histories", List[Tuple]),
-     ("input_mask", tf.Tensor)])
-# pylint: enable=invalid-name
+
+class TransformerHistories(NamedTuple(
+        "TransformerHistories", [
+            ("logits", tf.Tensor),
+            ("decoder_outputs", tf.Tensor),
+            ("outputs", tf.Tensor),
+            ("mask", tf.Tensor),
+            ("decoded_symbols", tf.Tensor),
+            ("input_mask", tf.Tensor)])):
+    # TODO include these:
+    # ("self_attention_histories", List[Tuple]),
+    # ("inter_attention_histories", List[Tuple]),
+    """The loop state histories for the transformer decoder.
+
+    Shares attributes with the ``DecoderHistories`` class. The special
+    attributes are listed below.
+
+    Attributes:
+        decoded_symbols: A tensor which stores the decoded symbols.
+        input_mask: A float tensor with zeros and ones which marks the valid
+            positions on the input.
+    """
 
 
 class TransformerDecoder(AutoregressiveDecoder):

--- a/neuralmonkey/encoders/imagenet_encoder.py
+++ b/neuralmonkey/encoders/imagenet_encoder.py
@@ -19,12 +19,11 @@ from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
 from neuralmonkey.model.stateful import SpatialStatefulWithOutput
 
 
-class ImageNetSpec(
-        NamedTuple(
-            "ImageNetSpec",
-            [("scope", Callable),
-             ("image_size", Tuple[int, int]),
-             ("apply_net", Callable)])):
+class ImageNetSpec(NamedTuple(
+        "ImageNetSpec",
+        [("scope", Callable),
+         ("image_size", Tuple[int, int]),
+         ("apply_net", Callable)])):
     """Specification of the Imagenet encoder.
 
     Do not use this object directly, instead, use one of the ``get_*``functions

--- a/neuralmonkey/encoders/imagenet_encoder.py
+++ b/neuralmonkey/encoders/imagenet_encoder.py
@@ -19,11 +19,23 @@ from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
 from neuralmonkey.model.stateful import SpatialStatefulWithOutput
 
 
-ImageNetSpec = NamedTuple(
-    "ImageNetSpec",
-    [("scope", Callable),
-     ("image_size", Tuple[int, int]),
-     ("apply_net", Callable)])
+class ImageNetSpec(
+        NamedTuple(
+            "ImageNetSpec",
+            [("scope", Callable),
+             ("image_size", Tuple[int, int]),
+             ("apply_net", Callable)])):
+    """Specification of the Imagenet encoder.
+
+    Do not use this object directly, instead, use one of the ``get_*``functions
+    in this module.
+
+    Attributes:
+        scope: The variable scope of the network to use.
+        image_size: A tuple of two integers giving the image width and height
+            in pixels.
+        apply_net: The function that receives an image and applies the network.
+    """
 
 
 # pylint: disable=import-error

--- a/neuralmonkey/encoders/raw_rnn_encoder.py
+++ b/neuralmonkey/encoders/raw_rnn_encoder.py
@@ -1,45 +1,18 @@
-from typing import Callable, List, Optional, Tuple, Union, NamedTuple
+from typing import List, Optional
 
 import numpy as np
 import tensorflow as tf
-from tensorflow.contrib.rnn import RNNCell
 from typeguard import check_argument_types
 
+# pylint: disable=protected-access
+from neuralmonkey.encoders.recurrent import (
+    RNNSpecTuple, _make_rnn_spec, _make_rnn_cell)
+# pylint: enable=protected-access
 from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
 from neuralmonkey.model.stateful import TemporalStatefulWithOutput
 from neuralmonkey.logging import log
-from neuralmonkey.nn.ortho_gru_cell import OrthoGRUCell
 from neuralmonkey.nn.utils import dropout
 from neuralmonkey.dataset import Dataset
-
-
-# pylint: disable=invalid-name
-RNNSpec = NamedTuple("RNNSpec", [("size", int),
-                                 ("direction", str),
-                                 ("cell_type", str)])
-
-RNNSpecTuple = Union[Tuple[int], Tuple[int, str], Tuple[int, str, str]]
-# pylint: enable=invalid-name
-
-
-def _make_rnn_spec(size: int,
-                   direction: str = "bidirectional",
-                   cell_type: str = "GRU") -> RNNSpec:
-    return RNNSpec(size, direction, cell_type)
-
-
-def _make_rnn_cell(spec: RNNSpec) -> Callable[[], RNNCell]:
-    """Return the graph template for creating RNN cells."""
-    if spec.cell_type == "GRU":
-        def cell():
-            return OrthoGRUCell(spec.size)
-    elif spec.cell_type == "LSTM":
-        def cell():
-            return tf.contrib.rnn.LSTMCell(spec.size)
-    else:
-        raise ValueError("Unknown RNN cell: {}".format(spec.cell_type))
-
-    return cell
 
 
 # pylint: disable=too-many-instance-attributes

--- a/neuralmonkey/encoders/raw_rnn_encoder.py
+++ b/neuralmonkey/encoders/raw_rnn_encoder.py
@@ -77,11 +77,12 @@ class RawRNNEncoder(ModelPart, TemporalStatefulWithOutput):
 
             for i, layer in enumerate(self._rnn_layers):
                 with tf.variable_scope("rnn_{}_{}".format(i, layer.direction)):
-                    cell = _make_rnn_cell(layer)
                     if layer.direction == "bidirectional":
+                        fw_cell = _make_rnn_cell(layer)
+                        bw_cell = _make_rnn_cell(layer)
                         outputs_tup, encoded_tup = (
                             tf.nn.bidirectional_dynamic_rnn(
-                                cell(), cell(), states, self._input_lengths,
+                                fw_cell, bw_cell, states, self._input_lengths,
                                 dtype=tf.float32))
 
                         if states_reversed:
@@ -97,8 +98,9 @@ class RawRNNEncoder(ModelPart, TemporalStatefulWithOutput):
                         if states_reversed != should_be_reversed:
                             reverse_states()
 
+                        cell = _make_rnn_cell(layer)
                         states, encoded = tf.nn.dynamic_rnn(
-                            cell(), states,
+                            cell, states,
                             sequence_length=self._input_lengths,
                             dtype=tf.float32)
                     else:

--- a/neuralmonkey/encoders/recurrent.py
+++ b/neuralmonkey/encoders/recurrent.py
@@ -27,11 +27,11 @@ RNNCellTuple = Tuple[tf.nn.rnn_cell.RNNCell, tf.nn.rnn_cell.RNNCell]
 # pylint: enable=invalid-name
 
 
-class RNNSpec(
-        NamedTuple("RNNSpec",
-                   [("size", int),
-                    ("direction", str),
-                    ("cell_type", str)])):
+class RNNSpec(NamedTuple(
+        "RNNSpec",
+        [("size", int),
+         ("direction", str),
+         ("cell_type", str)])):
     """Recurrent neural network specifications.
 
     Attributes:

--- a/neuralmonkey/encoders/recurrent.py
+++ b/neuralmonkey/encoders/recurrent.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List, NamedTuple, Union, Callable, cast, Set
+from typing import Tuple, List, Union, Callable, cast, Set, NamedTuple
 
 import tensorflow as tf
 from typeguard import check_argument_types
@@ -21,16 +21,26 @@ RNN_CELL_TYPES = {
 
 RNN_DIRECTIONS = ["forward", "backward", "bidirectional"]
 
-
 # pylint: disable=invalid-name
-RNNCellTuple = Tuple[tf.nn.rnn_cell.RNNCell, tf.nn.rnn_cell.RNNCell]
-
-RNNSpec = NamedTuple("RNNSpec", [("size", int),
-                                 ("direction", str),
-                                 ("cell_type", str)])
-
 RNNSpecTuple = Union[Tuple[int], Tuple[int, str], Tuple[int, str, str]]
+RNNCellTuple = Tuple[tf.nn.rnn_cell.RNNCell, tf.nn.rnn_cell.RNNCell]
 # pylint: enable=invalid-name
+
+
+class RNNSpec(
+        NamedTuple("RNNSpec",
+                   [("size", int),
+                    ("direction", str),
+                    ("cell_type", str)])):
+    """Recurrent neural network specifications.
+
+    Attributes:
+        size: The state size.
+        direction: The RNN processing direction. One of ``forward``,
+            ``backward``, and ``bidirectional``.
+        cell_type: The recurrent cell type to use. Refer to
+            ``encoders.recurrent.RNN_CELL_TYPES`` for possible values.
+    """
 
 
 def _make_rnn_spec(size: int,

--- a/neuralmonkey/readers/audio_reader.py
+++ b/neuralmonkey/readers/audio_reader.py
@@ -6,12 +6,16 @@ import subprocess
 import sys
 
 import numpy as np
-
 from scipy.io import wavfile
 
 
-# pylint: disable=invalid-name
-Audio = NamedTuple("Audio", [("rate", int), ("data", np.ndarray)])
+class Audio(NamedTuple("Audio", [("rate", int), ("data", np.ndarray)])):
+    """A raw audio object with its rate as metadata.
+
+    Attribute:
+        rate: The sample rate of the audio.
+        data: The raw audio data.
+    """
 
 
 def audio_reader(prefix: str = "",

--- a/neuralmonkey/runners/base_runner.py
+++ b/neuralmonkey/runners/base_runner.py
@@ -8,15 +8,29 @@ from neuralmonkey.model.model_part import ModelPart
 # pylint: disable=invalid-name
 FeedDict = Dict[tf.Tensor, Union[int, float, np.ndarray]]
 NextExecute = Tuple[Set[ModelPart], Union[Dict, List], List[FeedDict]]
-ExecutionResult = NamedTuple("ExecutionResult",
-                             [("outputs", List[Any]),
-                              ("losses", List[float]),
-                              ("scalar_summaries", tf.Summary),
-                              ("histogram_summaries", tf.Summary),
-                              ("image_summaries", tf.Summary)])
-
 MP = TypeVar("MP", bound=ModelPart)
 # pylint: enable=invalid-name
+
+
+class ExecutionResult(NamedTuple(
+        "ExecutionResult",
+        [("outputs", List[Any]),
+         ("losses", List[float]),
+         ("scalar_summaries", tf.Summary),
+         ("histogram_summaries", tf.Summary),
+         ("image_summaries", tf.Summary)])):
+    """A data structure that represents a result of a graph execution.
+
+    The goal of each runner is to populate this structure and set it as its
+    ``self.result``.
+
+    Attributes:
+        outputs: A batch of outputs of the runner.
+        losses: A (possibly empty) list of loss values computed during the run.
+        scalar_summaries: A TensorFlow summary object with scalar values.
+        histogram_summaries: A TensorFlow summary object with histograms.
+        image_summaries: A TensorFlow summary object with images.
+    """
 
 
 class Executable(object):

--- a/neuralmonkey/trainers/generic_trainer.py
+++ b/neuralmonkey/trainers/generic_trainer.py
@@ -10,14 +10,30 @@ from neuralmonkey.runners.base_runner import (
 # pylint: disable=invalid-name
 Gradients = List[Tuple[tf.Tensor, tf.Variable]]
 ObjectiveWeight = Union[tf.Tensor, float, None]
-Objective = NamedTuple("Objective",
-                       [("name", str),
-                        ("decoder", ModelPart),
-                        ("loss", tf.Tensor),
-                        ("gradients", Optional[Gradients]),
-                        ("weight", ObjectiveWeight)])
+# pylint: enable=invalid-name
 
 BIAS_REGEX = re.compile(r"[Bb]ias")
+
+
+class Objective(NamedTuple(
+        "Objective",
+        [("name", str),
+         ("decoder", ModelPart),
+         ("loss", tf.Tensor),
+         ("gradients", Optional[Gradients]),
+         ("weight", ObjectiveWeight)])):
+    """The training objective.
+
+    Attributes:
+        name: The name for the objective. Used in TensorBoard.
+        decoder: The decoder which generates the value to optimize.
+        loss: The loss tensor fetched by the trainer.
+        gradients: Manually specified gradients. Useful for reinforcement
+            learning.
+        weight: The weight of this objective. The loss will be multiplied by
+            this so the gradients can be controled in case of multiple
+            objectives.
+    """
 
 
 # pylint: disable=too-few-public-methods,too-many-locals,too-many-arguments


### PR DESCRIPTION
closes #721 

Inheritance of namedtuples in python is not possible so some of the fields had to be copied. It can be done dynamically (as it was prior to this PR) but the class hierarchy is lost anyway. Moreover typechecking of objects that inherit from NamedTuple works only with static definitions of the types of the elements of the tuple. 

This PR introduces some code-copying, but the real value is in the docstrings that were added to the
custom named tuple objects so I think it is worth it.