### PR TITLE
Parse floats of type 1e-3 correctly

### DIFF
--- a/neuralmonkey/config/parsing.py
+++ b/neuralmonkey/config/parsing.py
@@ -14,7 +14,7 @@ from neuralmonkey.logging import log
 LINE_NUM = re.compile(r"^(.*) ([0-9]+)$")
 
 INTEGER = re.compile(r"^-?[0-9]+$")
-FLOAT = re.compile(r"^-?[0-9]*\.[0-9]*(e[+-]?[0-9]+)?$")
+FLOAT = re.compile(r"^-?[0-9]*\.[0-9]*(e[+-]?[0-9]+)?$|^-?[0-9]+e[+-]?[0-9]+$")
 LIST = re.compile(r"\[([^]]*)\]")
 TUPLE = re.compile(r"\(([^)]+)\)")
 STRING = re.compile(r'^"(.*)"$')

--- a/tests/bpe.ini
+++ b/tests/bpe.ini
@@ -105,7 +105,7 @@ optimizer=<adadelta>
 [adadelta]
 class=tf.train.AdadeltaOptimizer
 name="adadelta"
-learning_rate=1.0e-4
+learning_rate=1e-4
 epsilon=1.0e-6
 rho=0.95
 


### PR DESCRIPTION
I basically extended the regex without modifying the existing one. This
is because that would have been only possible by using a lookahead to
avoid that ints are also parsed as floats. And lookaheads are hard to
read.