### PR TITLE
Three wmt18-related changes in one

### DIFF
--- a/neuralmonkey/experiment.py
+++ b/neuralmonkey/experiment.py
@@ -194,7 +194,16 @@ class Experiment:
             self.build_model()
 
         if variable_files is None:
-            variable_files = [self.get_path("variables.data")]
+            if os.path.exists(self.get_path("variables.data.avg-0.index")):
+                variable_files = [self.get_path("variables.data.avg-0")]
+            elif os.path.exists(self.get_path("variables.data.avg.index")):
+                variable_files = [self.get_path("variables.data.avg")]
+            else:
+                best_var_file = self.get_path("variables.data.best")
+                with open(best_var_file, "r") as f_best:
+                    var_path = f_best.read().rstrip()
+                variable_files = [self.get_path(var_path)]
+
             log("Default variable file '{}' will be used for loading "
                 "variables.".format(variable_files[0]))
 

--- a/neuralmonkey/trainers/generic_trainer.py
+++ b/neuralmonkey/trainers/generic_trainer.py
@@ -97,6 +97,11 @@ class GenericTrainer:
             tf.summary.scalar("train_l2", l2_value,
                               collections=["summary_train"])
 
+            # log all objectives
+            for obj in objectives:
+                tf.summary.scalar(
+                    obj.name, obj.loss, collections=["summary_train"])
+
             # if the objective does not have its own gradients,
             # just use TF to do the derivative
             update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS)

--- a/scripts/imagenet_features.py
+++ b/scripts/imagenet_features.py
@@ -38,12 +38,18 @@ def main():
                         "repository")
     parser.add_argument("--model-checkpoint", type=str, required=True,
                         help="Path to the ImageNet model checkpoint.")
-    parser.add_argument("--conv-map", type=str, required=True,
+    parser.add_argument("--conv-map", type=str, required=False, default=None,
                         help="Name of the convolutional map that is.")
+    parser.add_argument("--vector", type=str, required=False, default=None,
+                        help="Name of the feed-forward layer.")
     parser.add_argument("--images", type=str,
                         help="File with paths to images or stdin by default.")
     parser.add_argument("--batch-size", type=int, default=128)
     args = parser.parse_args()
+
+    if args.conv_map is None == args.vector is None:
+        raise ValueError(
+            "You must provide either convolutional map or feed-forward layer.")
 
     if not os.path.exists(args.input_prefix):
         raise ValueError("Directory {} does not exist.".format(
@@ -67,7 +73,7 @@ def main():
     imagenet = ImageNet(
         name="imagenet", data_id="images", network_type=args.net,
         slim_models_path=args.slim_models, load_checkpoint=args.model_checkpoint,
-        spatial_layer=args.conv_map)
+        spatial_layer=args.conv_map, encoded_layer=args.vector)
 
     log("Creating TensorFlow session.")
     session = tf.Session()
@@ -87,7 +93,9 @@ def main():
     def process_images():
         dataset = Dataset("dataset", {"images": np.array(images)}, {})
         feed_dict = imagenet.feed_dict(dataset)
-        feature_maps = session.run(imagenet.spatial_states, feed_dict=feed_dict)
+
+        fetch = imagenet.encoded if args.vector else imagenet.spatial_states
+        feature_maps = session.run(fetch, feed_dict=feed_dict)
 
         for features, rel_path in zip(feature_maps, image_paths):
             npz_path = os.path.join(args.output_prefix, rel_path + ".npz")


### PR DESCRIPTION
1. All objectives are logged to tensorboard. This may generate duplicate tables in TB, but it's handy if you have more objectives.
2. imagenet features script has been updated
3. default loading priority has been changed to:
```
1. variables.data.avg-0
2. variables.data.avg
3. $(cat variables.data.best)
```

@jlibovicky should comment on why there are two flavours of the averaged file so we could reconsider this.

Note that loading from `variables.data` in case of a single checkpoint is more or less guaranteed because the file name should appear in the `*.best` file.