### PR TITLE
Use unittest discover instead of for loop

### DIFF
--- a/tests/unit-tests_run.sh
+++ b/tests/unit-tests_run.sh
@@ -3,6 +3,4 @@
 set -ex
 trap 'echo -e "\033[1;31mSome unit tests have failed!\033[0m"' ERR
 
-for file in $(cd neuralmonkey/tests && echo *.py); do
-    python3 -m neuralmonkey.tests.${file%.py}
-done
+python3 -m unittest discover -v


### PR DESCRIPTION
1. This is slightly faster
2. We can now use `test*.py` files anywhere in the package which is perhaps a better practice anyway.

I would either have a `test_MODULE.py` for each `MODULE` in the same direktorář as the module, or have a subdirectory `PACKAGE/tests` for each `PACKAGE` which would contain unit tests for modules in the package.