### PR TITLE
Changes that allow MT with CTC

### DIFF
--- a/neuralmonkey/model/sequence_split.py
+++ b/neuralmonkey/model/sequence_split.py
@@ -1,0 +1,80 @@
+"""Split temporal states such that the sequence is n-times longer."""
+from typing import Callable, Set
+import tensorflow as tf
+from typeguard import check_argument_types
+
+from neuralmonkey.decorators import tensor
+from neuralmonkey.dataset import Dataset
+from neuralmonkey.model.model_part import ModelPart, FeedDict
+from neuralmonkey.model.stateful import TemporalStateful
+
+
+class SequenceSplitter(TemporalStateful, ModelPart):
+    def __init__(
+            self,
+            parent: TemporalStateful,
+            factor: int,
+            projection_size: int = None,
+            projection_activation: Callable = None) -> None:
+        """Initialize SetenceSplitter.
+
+        Args:
+            parent: TemporalStateful whose states will be split.
+            factor: Factor by which the states will be split - the  resulting
+                sequence will be longer by this factor.
+        """
+        check_argument_types()
+
+        ModelPart.__init__(
+            self, name="sequence_split",
+            save_checkpoint=None, load_checkpoint=None, initializers=None)
+        self.parent = parent
+        self.factor = factor
+        self.projection_size = projection_size
+        self.activation = projection_activation
+
+        state_dim = parent.temporal_states.get_shape()[2].value
+        if state_dim % factor != 0 and projection_size is None:
+            raise ValueError((
+                "Dimension of the parent temporal stateful ({}) must be "
+                "dividable by the given factor ({}).").format(
+                    state_dim, factor))
+
+        if projection_size is not None and projection_size % factor != 0:
+            raise ValueError((
+                "Dimension of projection ({}) must be "
+                "dividable by the given factor ({}).").format(
+                    projection_size, factor))
+
+    @tensor
+    def temporal_states(self) -> tf.Tensor:
+        states = self.parent.temporal_states
+        if self.projection_size:
+            states = tf.layers.dense(
+                states, self.projection_size, activation=self.activation)
+
+        return split_by_factor(states, self.factor)
+
+    @tensor
+    def temporal_mask(self) -> tf.Tensor:
+        double_mask = tf.stack(
+            self.factor * [tf.expand_dims(self.parent.temporal_mask, 2)],
+            axis=2)
+        return tf.squeeze(split_by_factor(double_mask, self.factor), axis=2)
+
+    def feed_dict(self, dataset: Dataset, train: bool) -> FeedDict:
+        return {}
+
+    def get_dependencies(self) -> Set[ModelPart]:
+        to_return = set([self])
+        to_return = to_return.union(self.parent.get_dependencies())
+        return to_return
+
+
+def split_by_factor(tensor_3d: tf.Tensor, factor: int) -> tf.Tensor:
+    orig_shape = tf.shape(tensor_3d)
+    batch_size = orig_shape[0]
+    max_time = orig_shape[1]
+    state_dim = tensor_3d.get_shape()[2].value
+    return tf.reshape(
+        tensor_3d, [batch_size, max_time * factor, state_dim // factor])

--- a/neuralmonkey/model/sequence_split.py
+++ b/neuralmonkey/model/sequence_split.py
@@ -9,31 +9,39 @@ from neuralmonkey.model.model_part import ModelPart, FeedDict
 from neuralmonkey.model.stateful import TemporalStateful
 
 
+Activation = Callable[[tf.Tensor], tf.Tensor]
+
+
 class SequenceSplitter(TemporalStateful, ModelPart):
     def __init__(
             self,
+            name: str,
             parent: TemporalStateful,
             factor: int,
             projection_size: int = None,
-            projection_activation: Callable = None) -> None:
+            projection_activation: Activation = None) -> None:
         """Initialize SetenceSplitter.
 
         Args:
             parent: TemporalStateful whose states will be split.
             factor: Factor by which the states will be split - the  resulting
                 sequence will be longer by this factor.
+            projection_size: If not None, specifies dimensionality of a
+                projection before state splitting.
+            projection_activation: Non-linearity function for the optional
+                projection.
         """
         check_argument_types()
 
         ModelPart.__init__(
-            self, name="sequence_split",
-            save_checkpoint=None, load_checkpoint=None, initializers=None)
+            self, name=name, save_checkpoint=None, load_checkpoint=None,
+            initializers=None)
         self.parent = parent
         self.factor = factor
         self.projection_size = projection_size
         self.activation = projection_activation
 
-        state_dim = parent.temporal_states.get_shape()[2].value
+        state_dim = parent.dimension
         if state_dim % factor != 0 and projection_size is None:
             raise ValueError((
                 "Dimension of the parent temporal stateful ({}) must be "
@@ -53,28 +61,29 @@ class SequenceSplitter(TemporalStateful, ModelPart):
             states = tf.layers.dense(
                 states, self.projection_size, activation=self.activation)
 
-        return split_by_factor(states, self.factor)
+        return split_by_factor(states, self.batch_size, self.factor)
 
     @tensor
     def temporal_mask(self) -> tf.Tensor:
         double_mask = tf.stack(
             self.factor * [tf.expand_dims(self.parent.temporal_mask, 2)],
             axis=2)
-        return tf.squeeze(split_by_factor(double_mask, self.factor), axis=2)
+        return tf.squeeze(
+            split_by_factor(double_mask, self.batch_size, self.factor), axis=2)
 
     def feed_dict(self, dataset: Dataset, train: bool) -> FeedDict:
-        return {}
+        return ModelPart.feed_dict(self, dataset, train)
 
     def get_dependencies(self) -> Set[ModelPart]:
-        to_return = set([self])
-        to_return = to_return.union(self.parent.get_dependencies())
-        return to_return
+        deps = set([self])  # type: Set[ModelPart]
+        if isinstance(self.parent, ModelPart):
+            deps = deps.union(self.parent.get_dependencies())
+        return deps
 
 
-def split_by_factor(tensor_3d: tf.Tensor, factor: int) -> tf.Tensor:
-    orig_shape = tf.shape(tensor_3d)
-    batch_size = orig_shape[0]
-    max_time = orig_shape[1]
+def split_by_factor(
+        tensor_3d: tf.Tensor, batch_size: tf.Tensor, factor: int) -> tf.Tensor:
+    max_time = tf.shape(tensor_3d)[1]
     state_dim = tensor_3d.get_shape()[2].value
     return tf.reshape(
         tensor_3d, [batch_size, max_time * factor, state_dim // factor])

--- a/neuralmonkey/runners/ctc_debug_runner.py
+++ b/neuralmonkey/runners/ctc_debug_runner.py
@@ -1,0 +1,79 @@
+from typing import Dict, List, Set
+
+import numpy as np
+from typeguard import check_argument_types
+
+from neuralmonkey.runners.base_runner import (
+    BaseRunner, Executable, FeedDict, ExecutionResult, NextExecute)
+from neuralmonkey.model.model_part import ModelPart
+from neuralmonkey.vocabulary import Vocabulary
+from neuralmonkey.decoders.ctc_decoder import CTCDecoder
+
+
+class CTCDebugExecutable(Executable):
+
+    def __init__(self,
+                 all_coders: Set[ModelPart],
+                 fetches: FeedDict,
+                 vocabulary: Vocabulary) -> None:
+        self._all_coders = all_coders
+        self._fetches = fetches
+        self._vocabulary = vocabulary
+
+        self.result = None  # type: ExecutionResult
+
+    def next_to_execute(self) -> NextExecute:
+        """Get the feedables and tensors to run."""
+        return self._all_coders, self._fetches, None
+
+    def collect_results(self, results: List[Dict]) -> None:
+        if len(results) != 1:
+            raise RuntimeError("CTCDebug runner does not support ensembling.")
+
+        logits = results[0]["logits"]
+        argmaxes = np.argmax(logits, axis=2).T
+
+        decoded_batch = []
+        for indices in argmaxes:
+            decoded_instance = []
+            for index in indices:
+                if index == len(self._vocabulary):
+                    symbol = "<BLANK>"
+                else:
+                    symbol = self._vocabulary.index_to_word[index]
+                decoded_instance.append(symbol)
+            decoded_batch.append(decoded_instance)
+
+        self.result = ExecutionResult(
+            outputs=decoded_batch,
+            losses=[],
+            scalar_summaries=None,
+            histogram_summaries=None,
+            image_summaries=None)
+
+
+class CTCDebugRunner(BaseRunner[CTCDecoder]):
+    "A runner that print out raw CTC output including the blank symbols."
+
+    def __init__(self,
+                 output_series: str,
+                 decoder: CTCDecoder) -> None:
+        check_argument_types()
+        BaseRunner[CTCDecoder].__init__(self, output_series, decoder)
+
+    # pylint: disable=unused-argument
+    def get_executable(self,
+                       compute_losses: bool,
+                       summaries: bool,
+                       num_sessions: int) -> CTCDebugExecutable:
+        fetches = {"logits": self._decoder.logits}
+
+        return CTCDebugExecutable(
+            self.all_coders,
+            fetches,
+            self._decoder.vocabulary)
+    # pylint: enable=unused-argument
+
+    @property
+    def loss_names(self) -> List[str]:
+        return []

--- a/neuralmonkey/runners/ctc_debug_runner.py
+++ b/neuralmonkey/runners/ctc_debug_runner.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Set
+from typing import Dict, List, Set, Optional
 
 import numpy as np
 from typeguard import check_argument_types
@@ -20,11 +20,11 @@ class CTCDebugExecutable(Executable):
         self._fetches = fetches
         self._vocabulary = vocabulary
 
-        self.result = None  # type: ExecutionResult
+        self.result = None  # type: Optional[ExecutionResult]
 
     def next_to_execute(self) -> NextExecute:
         """Get the feedables and tensors to run."""
-        return self._all_coders, self._fetches, None
+        return self._all_coders, self._fetches, []
 
     def collect_results(self, results: List[Dict]) -> None:
         if len(results) != 1:
@@ -53,7 +53,7 @@ class CTCDebugExecutable(Executable):
 
 
 class CTCDebugRunner(BaseRunner[CTCDecoder]):
-    "A runner that print out raw CTC output including the blank symbols."
+    """A runner that print out raw CTC output including the blank symbols."""
 
     def __init__(self,
                  output_series: str,


### PR DESCRIPTION
This PR contains required for replicating paper "End-to-End Non-Autoregressive Neural Machine Translation with Connectionist Temporal Classification" that will appear at EMNLP 2018. Changes include:

* updating CTC decoder, such that it uses `@tensor` annotations and has maximum sentence length
* a model part that projects and split temporal states
* a runner that allows debugging of CTC outputs by showing where the `<BLANK>` symbols are