### PR TITLE
Model refactor

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -345,7 +345,7 @@ max-branches=12
 max-statements=50
 
 # Maximum number of parents for a class (see R0901).
-max-parents=9
+max-parents=10
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=12

--- a/.pylintrc
+++ b/.pylintrc
@@ -345,7 +345,7 @@ max-branches=12
 max-statements=50
 
 # Maximum number of parents for a class (see R0901).
-max-parents=7
+max-parents=9
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=12

--- a/neuralmonkey/attention/base_attention.py
+++ b/neuralmonkey/attention/base_attention.py
@@ -41,9 +41,10 @@ from typing import Dict, Optional, Any, Tuple, Union
 
 import tensorflow as tf
 
-from neuralmonkey.model.stateful import TemporalStateful, SpatialStateful
-from neuralmonkey.model.model_part import ModelPart, InitializerSpecs
 from neuralmonkey.attention.namedtuples import AttentionLoopState
+from neuralmonkey.model.model_part import ModelPart
+from neuralmonkey.model.parameterized import InitializerSpecs
+from neuralmonkey.model.stateful import TemporalStateful, SpatialStateful
 
 # pylint: disable=invalid-name
 Attendable = Union[TemporalStateful, SpatialStateful]

--- a/neuralmonkey/attention/combination.py
+++ b/neuralmonkey/attention/combination.py
@@ -23,7 +23,8 @@ from neuralmonkey.attention.base_attention import (
     get_attention_states, get_attention_mask, Attendable)
 from neuralmonkey.attention.namedtuples import HierarchicalLoopState
 from neuralmonkey.checking import assert_shape
-from neuralmonkey.model.model_part import InitializerSpecs, ModelPart
+from neuralmonkey.model.model_part import ModelPart
+from neuralmonkey.model.parameterized import InitializerSpecs
 from neuralmonkey.tf_utils import get_variable
 
 

--- a/neuralmonkey/attention/coverage.py
+++ b/neuralmonkey/attention/coverage.py
@@ -10,7 +10,8 @@ from typeguard import check_argument_types
 
 from neuralmonkey.attention.base_attention import Attendable
 from neuralmonkey.attention.feed_forward import Attention
-from neuralmonkey.model.model_part import InitializerSpecs, ModelPart
+from neuralmonkey.model.model_part import ModelPart
+from neuralmonkey.model.parameterized import InitializerSpecs
 
 
 class CoverageAttention(Attention):

--- a/neuralmonkey/attention/feed_forward.py
+++ b/neuralmonkey/attention/feed_forward.py
@@ -13,9 +13,10 @@ from neuralmonkey.attention.base_attention import (
     BaseAttention, AttentionLoopState, empty_attention_loop_state,
     get_attention_states, get_attention_mask, Attendable)
 from neuralmonkey.decorators import tensor
-from neuralmonkey.nn.utils import dropout
 from neuralmonkey.logging import log
-from neuralmonkey.model.model_part import InitializerSpecs, ModelPart
+from neuralmonkey.model.model_part import ModelPart
+from neuralmonkey.model.parameterized import InitializerSpecs
+from neuralmonkey.nn.utils import dropout
 from neuralmonkey.tf_utils import get_variable
 
 

--- a/neuralmonkey/attention/scaled_dot_product.py
+++ b/neuralmonkey/attention/scaled_dot_product.py
@@ -13,7 +13,8 @@ import tensorflow as tf
 from typeguard import check_argument_types
 
 from neuralmonkey.nn.utils import dropout
-from neuralmonkey.model.model_part import InitializerSpecs, ModelPart
+from neuralmonkey.model.model_part import ModelPart
+from neuralmonkey.model.parameterized import InitializerSpecs
 from neuralmonkey.attention.base_attention import (
     BaseAttention, Attendable, get_attention_states, get_attention_mask)
 from neuralmonkey.attention.namedtuples import MultiHeadLoopState

--- a/neuralmonkey/attention/stateful_context.py
+++ b/neuralmonkey/attention/stateful_context.py
@@ -7,7 +7,8 @@ from neuralmonkey.attention.base_attention import (
     BaseAttention, AttentionLoopState, empty_attention_loop_state)
 from neuralmonkey.model.stateful import Stateful
 from neuralmonkey.decorators import tensor
-from neuralmonkey.model.model_part import InitializerSpecs, ModelPart
+from neuralmonkey.model.model_part import ModelPart
+from neuralmonkey.model.parameterized import InitializerSpecs
 
 
 class StatefulContext(BaseAttention):

--- a/neuralmonkey/checking.py
+++ b/neuralmonkey/checking.py
@@ -24,7 +24,7 @@ def check_dataset_and_coders(dataset: Dataset,
 
     data_list = []
     for runner in runners:
-        for c in runner.all_coders:
+        for c in runner.feedables:
             if hasattr(c, "data_id"):
                 data_list.append((getattr(c, "data_id"), c))
             elif hasattr(c, "data_ids"):

--- a/neuralmonkey/checking.py
+++ b/neuralmonkey/checking.py
@@ -53,7 +53,7 @@ def check_dataset_and_coders(dataset: Dataset,
             missing.append((coder, serie))
 
     if missing:
-        formated = ["{} ({}, {}.{})" .format(serie, cod.name,
+        formated = ["{} ({}, {}.{})" .format(serie, str(cod),
                                              cod.__class__.__module__,
                                              cod.__class__.__name__)
                     for cod, serie in missing]

--- a/neuralmonkey/decoders/autoregressive.py
+++ b/neuralmonkey/decoders/autoregressive.py
@@ -12,7 +12,9 @@ import tensorflow as tf
 
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.decorators import tensor
-from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
+from neuralmonkey.model.feedable import FeedDict
+from neuralmonkey.model.parameterized import InitializerSpecs
+from neuralmonkey.model.model_part import ModelPart
 from neuralmonkey.logging import log, warn
 from neuralmonkey.model.sequence import EmbeddedSequence
 from neuralmonkey.nn.utils import dropout

--- a/neuralmonkey/decoders/classifier.py
+++ b/neuralmonkey/decoders/classifier.py
@@ -5,7 +5,9 @@ from typeguard import check_argument_types
 
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.vocabulary import Vocabulary
-from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
+from neuralmonkey.model.feedable import FeedDict
+from neuralmonkey.model.parameterized import InitializerSpecs
+from neuralmonkey.model.model_part import ModelPart
 from neuralmonkey.model.stateful import Stateful
 from neuralmonkey.nn.mlp import MultilayerPerceptron
 from neuralmonkey.decorators import tensor

--- a/neuralmonkey/decoders/ctc_decoder.py
+++ b/neuralmonkey/decoders/ctc_decoder.py
@@ -7,7 +7,9 @@ from typeguard import check_argument_types
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.decorators import tensor
 from neuralmonkey.logging import log
-from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
+from neuralmonkey.model.feedable import FeedDict
+from neuralmonkey.model.parameterized import InitializerSpecs
+from neuralmonkey.model.model_part import ModelPart
 from neuralmonkey.model.stateful import TemporalStateful
 from neuralmonkey.tf_utils import get_variable
 from neuralmonkey.vocabulary import Vocabulary, END_TOKEN

--- a/neuralmonkey/decoders/decoder.py
+++ b/neuralmonkey/decoders/decoder.py
@@ -10,7 +10,8 @@ from neuralmonkey.vocabulary import (
     Vocabulary, END_TOKEN_INDEX, PAD_TOKEN_INDEX)
 from neuralmonkey.model.sequence import EmbeddedSequence
 from neuralmonkey.model.stateful import Stateful
-from neuralmonkey.model.model_part import ModelPart, InitializerSpecs
+from neuralmonkey.model.parameterized import InitializerSpecs
+from neuralmonkey.model.model_part import ModelPart
 from neuralmonkey.logging import log
 from neuralmonkey.nn.ortho_gru_cell import OrthoGRUCell, NematusGRUCell
 from neuralmonkey.nn.utils import dropout

--- a/neuralmonkey/decoders/sequence_labeler.py
+++ b/neuralmonkey/decoders/sequence_labeler.py
@@ -4,7 +4,9 @@ import tensorflow as tf
 from typeguard import check_argument_types
 
 from neuralmonkey.dataset import Dataset
-from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
+from neuralmonkey.model.feedable import FeedDict
+from neuralmonkey.model.parameterized import InitializerSpecs
+from neuralmonkey.model.model_part import ModelPart
 from neuralmonkey.encoders.recurrent import RecurrentEncoder
 from neuralmonkey.encoders.facebook_conv import SentenceEncoder
 from neuralmonkey.vocabulary import Vocabulary

--- a/neuralmonkey/decoders/sequence_regressor.py
+++ b/neuralmonkey/decoders/sequence_regressor.py
@@ -5,7 +5,9 @@ from typeguard import check_argument_types
 
 from neuralmonkey.nn.projection import multilayer_projection
 from neuralmonkey.dataset import Dataset
-from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
+from neuralmonkey.model.feedable import FeedDict
+from neuralmonkey.model.parameterized import InitializerSpecs
+from neuralmonkey.model.model_part import ModelPart
 from neuralmonkey.model.stateful import Stateful
 from neuralmonkey.decorators import tensor
 

--- a/neuralmonkey/decoders/transformer.py
+++ b/neuralmonkey/decoders/transformer.py
@@ -20,9 +20,10 @@ from neuralmonkey.decoders.autoregressive import (
     AutoregressiveDecoder, LoopState, DecoderFeedables)
 from neuralmonkey.encoders.transformer import (
     TransformerLayer, position_signal)
-from neuralmonkey.model.sequence import EmbeddedSequence
 from neuralmonkey.logging import log, warn
-from neuralmonkey.model.model_part import ModelPart, InitializerSpecs
+from neuralmonkey.model.sequence import EmbeddedSequence
+from neuralmonkey.model.parameterized import InitializerSpecs
+from neuralmonkey.model.model_part import ModelPart
 from neuralmonkey.nn.utils import dropout
 from neuralmonkey.vocabulary import (
     Vocabulary, PAD_TOKEN_INDEX, END_TOKEN_INDEX)

--- a/neuralmonkey/decoders/word_alignment_decoder.py
+++ b/neuralmonkey/decoders/word_alignment_decoder.py
@@ -8,7 +8,9 @@ from neuralmonkey.dataset import Dataset
 from neuralmonkey.encoders.recurrent import RecurrentEncoder
 from neuralmonkey.decoders.decoder import Decoder
 from neuralmonkey.logging import warn
-from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
+from neuralmonkey.model.feedable import FeedDict
+from neuralmonkey.model.parameterized import InitializerSpecs
+from neuralmonkey.model.model_part import ModelPart
 from neuralmonkey.model.sequence import Sequence
 from neuralmonkey.decorators import tensor
 

--- a/neuralmonkey/encoders/attentive.py
+++ b/neuralmonkey/encoders/attentive.py
@@ -1,5 +1,3 @@
-from typing import Set, cast
-
 import tensorflow as tf
 from typeguard import check_argument_types
 
@@ -102,13 +100,3 @@ class AttentiveEncoder(ModelPart, TemporalStatefulWithOutput):
                                      name="output_projection")
 
         return output
-
-    def get_dependencies(self) -> Set[ModelPart]:
-        deps = ModelPart.get_dependencies(self)
-
-        # feed only if needed
-        if isinstance(self.input_sequence, ModelPart):
-            feedable = cast(ModelPart, self.input_sequence)
-            deps |= feedable.get_dependencies()
-
-        return deps

--- a/neuralmonkey/encoders/attentive.py
+++ b/neuralmonkey/encoders/attentive.py
@@ -2,7 +2,8 @@ import tensorflow as tf
 from typeguard import check_argument_types
 
 from neuralmonkey.model.stateful import TemporalStatefulWithOutput
-from neuralmonkey.model.model_part import ModelPart, InitializerSpecs
+from neuralmonkey.model.parameterized import InitializerSpecs
+from neuralmonkey.model.model_part import ModelPart
 from neuralmonkey.nn.utils import dropout
 from neuralmonkey.decorators import tensor
 from neuralmonkey.attention.base_attention import (

--- a/neuralmonkey/encoders/cnn_encoder.py
+++ b/neuralmonkey/encoders/cnn_encoder.py
@@ -350,5 +350,5 @@ class CNNTemporalView(ModelPart, TemporalStatefulWithOutput):
         return tf.to_float(tf.greater(summed, 0))
 
     @property
-    def _singleton_dependencies(self) -> List[str]:
-        return super()._singleton_dependencies + ["_cnn"]
+    def singleton_dependencies(self) -> List[str]:
+        return super().singleton_dependencies + ["_cnn"]

--- a/neuralmonkey/encoders/cnn_encoder.py
+++ b/neuralmonkey/encoders/cnn_encoder.py
@@ -1,6 +1,6 @@
 """CNN for image processing."""
 
-from typing import cast, Callable, List, Tuple, Set, Union
+from typing import cast, Callable, List, Tuple, Union
 from typeguard import check_argument_types
 
 import numpy as np
@@ -8,8 +8,7 @@ import tensorflow as tf
 
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.decorators import tensor
-from neuralmonkey.model.model_part import (
-    ModelPart, GenericModelPart, FeedDict, InitializerSpecs)
+from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
 from neuralmonkey.model.stateful import (SpatialStatefulWithOutput,
                                          TemporalStatefulWithOutput)
 from neuralmonkey.nn.projection import multilayer_projection
@@ -350,6 +349,6 @@ class CNNTemporalView(ModelPart, TemporalStatefulWithOutput):
         summed = tf.reduce_sum(mask, axis=1)
         return tf.to_float(tf.greater(summed, 0))
 
-    def get_dependencies(self) -> Set[GenericModelPart]:
-        """Collect recusively all encoders and decoders."""
-        return self._cnn.get_dependencies().union([self])
+    @property
+    def _singleton_dependencies(self) -> List[str]:
+        return super()._singleton_dependencies + ["_cnn"]

--- a/neuralmonkey/encoders/cnn_encoder.py
+++ b/neuralmonkey/encoders/cnn_encoder.py
@@ -8,7 +8,8 @@ import tensorflow as tf
 
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.decorators import tensor
-from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
+from neuralmonkey.model.model_part import (
+    ModelPart, GenericModelPart, FeedDict, InitializerSpecs)
 from neuralmonkey.model.stateful import (SpatialStatefulWithOutput,
                                          TemporalStatefulWithOutput)
 from neuralmonkey.nn.projection import multilayer_projection
@@ -349,6 +350,6 @@ class CNNTemporalView(ModelPart, TemporalStatefulWithOutput):
         summed = tf.reduce_sum(mask, axis=1)
         return tf.to_float(tf.greater(summed, 0))
 
-    def get_dependencies(self) -> Set["ModelPart"]:
+    def get_dependencies(self) -> Set[GenericModelPart]:
         """Collect recusively all encoders and decoders."""
         return self._cnn.get_dependencies().union([self])

--- a/neuralmonkey/encoders/cnn_encoder.py
+++ b/neuralmonkey/encoders/cnn_encoder.py
@@ -352,5 +352,5 @@ class CNNTemporalView(ModelPart, TemporalStatefulWithOutput):
         return tf.to_float(tf.greater(summed, 0))
 
     @property
-    def singleton_dependencies(self) -> List[str]:
-        return super().singleton_dependencies + ["_cnn"]
+    def dependencies(self) -> List[str]:
+        return super().dependencies + ["_cnn"]

--- a/neuralmonkey/encoders/cnn_encoder.py
+++ b/neuralmonkey/encoders/cnn_encoder.py
@@ -8,7 +8,9 @@ import tensorflow as tf
 
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.decorators import tensor
-from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
+from neuralmonkey.model.feedable import FeedDict
+from neuralmonkey.model.parameterized import InitializerSpecs
+from neuralmonkey.model.model_part import ModelPart
 from neuralmonkey.model.stateful import (SpatialStatefulWithOutput,
                                          TemporalStatefulWithOutput)
 from neuralmonkey.nn.projection import multilayer_projection

--- a/neuralmonkey/encoders/facebook_conv.py
+++ b/neuralmonkey/encoders/facebook_conv.py
@@ -7,12 +7,13 @@ import tensorflow as tf
 import numpy as np
 from typeguard import check_argument_types
 
-from neuralmonkey.model.model_part import ModelPart, InitializerSpecs
-from neuralmonkey.logging import log
 from neuralmonkey.decorators import tensor
-from neuralmonkey.nn.projection import glu
+from neuralmonkey.logging import log
+from neuralmonkey.model.model_part import ModelPart
+from neuralmonkey.model.parameterized import InitializerSpecs
 from neuralmonkey.model.sequence import EmbeddedSequence
 from neuralmonkey.model.stateful import TemporalStatefulWithOutput
+from neuralmonkey.nn.projection import glu
 from neuralmonkey.tf_utils import get_variable
 
 

--- a/neuralmonkey/encoders/imagenet_encoder.py
+++ b/neuralmonkey/encoders/imagenet_encoder.py
@@ -15,7 +15,9 @@ import tensorflow.contrib.slim.nets
 
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.decorators import tensor
-from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
+from neuralmonkey.model.feedable import FeedDict
+from neuralmonkey.model.model_part import ModelPart
+from neuralmonkey.model.parameterized import InitializerSpecs
 from neuralmonkey.model.stateful import SpatialStatefulWithOutput
 
 

--- a/neuralmonkey/encoders/numpy_stateful_filler.py
+++ b/neuralmonkey/encoders/numpy_stateful_filler.py
@@ -5,7 +5,9 @@ import tensorflow as tf
 
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.decorators import tensor
-from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
+from neuralmonkey.model.feedable import FeedDict
+from neuralmonkey.model.parameterized import InitializerSpecs
+from neuralmonkey.model.model_part import ModelPart
 from neuralmonkey.model.stateful import Stateful, SpatialStatefulWithOutput
 
 

--- a/neuralmonkey/encoders/pooling.py
+++ b/neuralmonkey/encoders/pooling.py
@@ -1,5 +1,3 @@
-from typing import Set, cast
-
 import tensorflow as tf
 from typeguard import check_argument_types
 
@@ -9,6 +7,7 @@ from neuralmonkey.decorators import tensor
 
 
 # pylint: disable=abstract-method
+# Pylint bug: https://github.com/PyCQA/pylint/issues/179
 class SequencePooling(ModelPart, Stateful):
     """An abstract pooling layer over a sequence."""
 
@@ -31,16 +30,6 @@ class SequencePooling(ModelPart, Stateful):
                 self.input_sequence.temporal_mask, -1)
             self._masked_input = (
                 self.input_sequence.temporal_states * self._input_mask)
-
-    def get_dependencies(self) -> Set[ModelPart]:
-        deps = ModelPart.get_dependencies(self)
-
-        # feed only if needed
-        if isinstance(self.input_sequence, ModelPart):
-            feedable = cast(ModelPart, self.input_sequence)
-            deps |= feedable.get_dependencies()
-
-        return deps
 # pylint: enable=abstract-method
 
 

--- a/neuralmonkey/encoders/pooling.py
+++ b/neuralmonkey/encoders/pooling.py
@@ -2,7 +2,8 @@ import tensorflow as tf
 from typeguard import check_argument_types
 
 from neuralmonkey.model.stateful import Stateful, TemporalStateful
-from neuralmonkey.model.model_part import ModelPart, InitializerSpecs
+from neuralmonkey.model.parameterized import InitializerSpecs
+from neuralmonkey.model.model_part import ModelPart
 from neuralmonkey.decorators import tensor
 
 

--- a/neuralmonkey/encoders/raw_rnn_encoder.py
+++ b/neuralmonkey/encoders/raw_rnn_encoder.py
@@ -8,7 +8,9 @@ from typeguard import check_argument_types
 from neuralmonkey.encoders.recurrent import (
     RNNSpecTuple, _make_rnn_spec, _make_rnn_cell)
 # pylint: enable=protected-access
-from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
+from neuralmonkey.model.feedable import FeedDict
+from neuralmonkey.model.parameterized import InitializerSpecs
+from neuralmonkey.model.model_part import ModelPart
 from neuralmonkey.model.stateful import TemporalStatefulWithOutput
 from neuralmonkey.logging import log
 from neuralmonkey.nn.utils import dropout

--- a/neuralmonkey/encoders/recurrent.py
+++ b/neuralmonkey/encoders/recurrent.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List, Union, Callable, cast, Set, NamedTuple
+from typing import Tuple, List, Union, Callable, NamedTuple
 
 import tensorflow as tf
 from typeguard import check_argument_types
@@ -193,16 +193,6 @@ class RecurrentEncoder(ModelPart, TemporalStatefulWithOutput):
         # pylint: disable=unsubscriptable-object
         return self.rnn[1]
         # pylint: enable=unsubscriptable-object
-
-    def get_dependencies(self) -> Set[ModelPart]:
-        """Collect recusively all encoders and decoders."""
-        deps = ModelPart.get_dependencies(self)
-
-        # feed only if needed
-        if isinstance(self.input_sequence, ModelPart):
-            feedable = cast(ModelPart, self.input_sequence)
-            deps = deps.union(feedable.get_dependencies())
-        return deps
 
 
 class SentenceEncoder(RecurrentEncoder):

--- a/neuralmonkey/encoders/recurrent.py
+++ b/neuralmonkey/encoders/recurrent.py
@@ -5,7 +5,8 @@ from typeguard import check_argument_types
 
 from neuralmonkey.model.stateful import (
     TemporalStatefulWithOutput, TemporalStateful)
-from neuralmonkey.model.model_part import ModelPart, InitializerSpecs
+from neuralmonkey.model.parameterized import InitializerSpecs
+from neuralmonkey.model.model_part import ModelPart
 from neuralmonkey.logging import warn
 from neuralmonkey.nn.ortho_gru_cell import OrthoGRUCell, NematusGRUCell
 from neuralmonkey.nn.utils import dropout

--- a/neuralmonkey/encoders/sentence_cnn_encoder.py
+++ b/neuralmonkey/encoders/sentence_cnn_encoder.py
@@ -6,7 +6,8 @@ import tensorflow as tf
 from typeguard import check_argument_types
 
 from neuralmonkey.encoders.recurrent import RNNCellTuple
-from neuralmonkey.model.model_part import ModelPart, InitializerSpecs
+from neuralmonkey.model.parameterized import InitializerSpecs
+from neuralmonkey.model.model_part import ModelPart
 from neuralmonkey.model.sequence import Sequence
 from neuralmonkey.model.stateful import TemporalStatefulWithOutput
 from neuralmonkey.nn.noisy_gru_cell import NoisyGRUCell

--- a/neuralmonkey/encoders/sequence_cnn_encoder.py
+++ b/neuralmonkey/encoders/sequence_cnn_encoder.py
@@ -7,7 +7,9 @@ import tensorflow as tf
 
 from neuralmonkey.dataset import Dataset
 from neuralmonkey.decorators import tensor
-from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
+from neuralmonkey.model.feedable import FeedDict
+from neuralmonkey.model.parameterized import InitializerSpecs
+from neuralmonkey.model.model_part import ModelPart
 from neuralmonkey.model.stateful import Stateful
 from neuralmonkey.nn.utils import dropout
 from neuralmonkey.vocabulary import Vocabulary

--- a/neuralmonkey/encoders/transformer.py
+++ b/neuralmonkey/encoders/transformer.py
@@ -2,9 +2,7 @@
 
 Described in Vaswani et al. (2017), arxiv.org/abs/1706.03762
 """
-# pylint: disable=unused-import
-from typing import Set, Optional, List
-# pylint: enable=unused-import
+from typing import List
 
 import math
 import tensorflow as tf
@@ -15,8 +13,7 @@ from neuralmonkey.attention.base_attention import (
 from neuralmonkey.decorators import tensor
 from neuralmonkey.attention.scaled_dot_product import attention
 from neuralmonkey.logging import log
-from neuralmonkey.model.model_part import (
-    ModelPart, InitializerSpecs, GenericModelPart)
+from neuralmonkey.model.model_part import ModelPart, InitializerSpecs
 from neuralmonkey.model.stateful import (TemporalStateful,
                                          TemporalStatefulWithOutput)
 from neuralmonkey.nn.utils import dropout
@@ -321,11 +318,10 @@ class TransformerEncoder(ModelPart, TemporalStatefulWithOutput):
     def temporal_mask(self) -> tf.Tensor:
         return self.input_sequence.temporal_mask
 
-    def get_dependencies(self) -> Set[GenericModelPart]:
-        """Collect recusively all inputs."""
-        to_return = super().get_dependencies()
+    @property
+    def _singleton_dependencies(self) -> List[str]:
+        deps = super()._singleton_dependencies
 
         if self.input_for_cross_attention is not None:
-            to_return |= self.input_for_cross_attention.get_dependencies()
-
-        return to_return
+            return deps + ["input_for_cross_attention"]
+        return deps

--- a/neuralmonkey/encoders/transformer.py
+++ b/neuralmonkey/encoders/transformer.py
@@ -319,8 +319,8 @@ class TransformerEncoder(ModelPart, TemporalStatefulWithOutput):
         return self.input_sequence.temporal_mask
 
     @property
-    def _singleton_dependencies(self) -> List[str]:
-        deps = super()._singleton_dependencies
+    def singleton_dependencies(self) -> List[str]:
+        deps = super().singleton_dependencies
 
         if self.input_for_cross_attention is not None:
             return deps + ["input_for_cross_attention"]

--- a/neuralmonkey/encoders/transformer.py
+++ b/neuralmonkey/encoders/transformer.py
@@ -15,7 +15,8 @@ from neuralmonkey.attention.base_attention import (
 from neuralmonkey.decorators import tensor
 from neuralmonkey.attention.scaled_dot_product import attention
 from neuralmonkey.logging import log
-from neuralmonkey.model.model_part import ModelPart, InitializerSpecs
+from neuralmonkey.model.model_part import (
+    ModelPart, InitializerSpecs, GenericModelPart)
 from neuralmonkey.model.stateful import (TemporalStateful,
                                          TemporalStatefulWithOutput)
 from neuralmonkey.nn.utils import dropout
@@ -320,13 +321,11 @@ class TransformerEncoder(ModelPart, TemporalStatefulWithOutput):
     def temporal_mask(self) -> tf.Tensor:
         return self.input_sequence.temporal_mask
 
-    def get_dependencies(self) -> Set[ModelPart]:
+    def get_dependencies(self) -> Set[GenericModelPart]:
         """Collect recusively all inputs."""
-        to_return = ModelPart.get_dependencies(self)
+        to_return = super().get_dependencies()
 
-        if (self.input_for_cross_attention is not None
-                and isinstance(self.input_for_cross_attention, ModelPart)):
-            to_return = to_return.union(
-                self.input_for_cross_attention.get_dependencies())
+        if self.input_for_cross_attention is not None:
+            to_return |= self.input_for_cross_attention.get_dependencies()
 
         return to_return

--- a/neuralmonkey/encoders/transformer.py
+++ b/neuralmonkey/encoders/transformer.py
@@ -13,7 +13,8 @@ from neuralmonkey.attention.base_attention import (
 from neuralmonkey.decorators import tensor
 from neuralmonkey.attention.scaled_dot_product import attention
 from neuralmonkey.logging import log
-from neuralmonkey.model.model_part import ModelPart, InitializerSpecs
+from neuralmonkey.model.parameterized import InitializerSpecs
+from neuralmonkey.model.model_part import ModelPart
 from neuralmonkey.model.stateful import (TemporalStateful,
                                          TemporalStatefulWithOutput)
 from neuralmonkey.nn.utils import dropout

--- a/neuralmonkey/encoders/transformer.py
+++ b/neuralmonkey/encoders/transformer.py
@@ -320,8 +320,8 @@ class TransformerEncoder(ModelPart, TemporalStatefulWithOutput):
         return self.input_sequence.temporal_mask
 
     @property
-    def singleton_dependencies(self) -> List[str]:
-        deps = super().singleton_dependencies
+    def dependencies(self) -> List[str]:
+        deps = super().dependencies
 
         if self.input_for_cross_attention is not None:
             return deps + ["input_for_cross_attention"]

--- a/neuralmonkey/learning_utils.py
+++ b/neuralmonkey/learning_utils.py
@@ -15,6 +15,7 @@ from termcolor import colored
 from typeguard import check_argument_types
 
 from neuralmonkey.logging import log, log_print, warn, notice
+from neuralmonkey.model.parameterized import Parameterized
 from neuralmonkey.dataset import Dataset, BatchingScheme
 from neuralmonkey.tf_manager import TensorFlowManager
 from neuralmonkey.runners.base_runner import (
@@ -300,8 +301,9 @@ def training_loop(tf_manager: TensorFlowManager,
                                     *[rnr.all_coders
                                       for rnr in rnrs])
                                 for coder in all_coders:
-                                    for session in tf_manager.sessions:
-                                        coder.save(session)
+                                    if isinstance(coder, Parameterized):
+                                        for session in tf_manager.sessions:
+                                            coder.save(session)
                             else:
                                 best_score_str = "{:.4g}".format(
                                     tf_manager.best_score)

--- a/neuralmonkey/learning_utils.py
+++ b/neuralmonkey/learning_utils.py
@@ -15,7 +15,6 @@ from termcolor import colored
 from typeguard import check_argument_types
 
 from neuralmonkey.logging import log, log_print, warn, notice
-from neuralmonkey.model.parameterized import Parameterized
 from neuralmonkey.dataset import Dataset, BatchingScheme
 from neuralmonkey.tf_manager import TensorFlowManager
 from neuralmonkey.runners.base_runner import (
@@ -297,13 +296,12 @@ def training_loop(tf_manager: TensorFlowManager,
                                 rnrs = runners + trainers  # type: ignore
                                 # TODO: refactor trainers/runners so that they
                                 # have the same API predecessor
-                                all_coders = set.union(
-                                    *[rnr.all_coders
+                                parameterizeds = set.union(
+                                    *[rnr.parameterizeds
                                       for rnr in rnrs])
-                                for coder in all_coders:
-                                    if isinstance(coder, Parameterized):
-                                        for session in tf_manager.sessions:
-                                            coder.save(session)
+                                for coder in parameterizeds:
+                                    for session in tf_manager.sessions:
+                                        coder.save(session)
                             else:
                                 best_score_str = "{:.4g}".format(
                                     tf_manager.best_score)

--- a/neuralmonkey/model/feedable.py
+++ b/neuralmonkey/model/feedable.py
@@ -13,12 +13,34 @@ FeedDict = Dict[tf.Tensor, Any]
 # pylint: disable=too-few-public-methods
 # TODO add some public methods
 class Feedable(metaclass=ABCMeta):
+    """Base class for feedable model parts.
+
+    In TensorFlow, data is provided to the model using placeholders. Neural
+    Monkey abstraction objects, such as encoders or decoders, can be members of
+    this class in order to be able to receive data inputs from the framework.
+
+    All feedable objects have a `feed_dict` method, which gets the current
+    dataset and returns a `FeedDict` dictionary which assigns values to
+    symbolic placeholders.
+
+    Additionally, each Feedable object has two placeholders which are fed
+    automatically in this super class - `batch_size` and `train_mode`.
+    """
 
     def __init__(self) -> None:
         self.train_mode = tf.placeholder(tf.bool, [], "train_mode")
         self.batch_size = tf.placeholder(tf.int32, [], "batch_size")
 
     def feed_dict(self, dataset: Dataset, train: bool = True) -> FeedDict:
+        """Return a feed dictionary for the given feedable object.
+
+        Arguments:
+            dataset: A dataset instance from which to get the data.
+            train: Boolean indicating whether the model runs in training mode.
+
+        Returns:
+            A `FeedDict` dictionary object.
+        """
         fd = {}  # type: FeedDict
         fd[self.train_mode] = train
         fd[self.batch_size] = len(dataset)

--- a/neuralmonkey/model/feedable.py
+++ b/neuralmonkey/model/feedable.py
@@ -1,0 +1,25 @@
+from abc import ABCMeta
+from typing import Any, Dict
+
+import tensorflow as tf
+
+from neuralmonkey.dataset import Dataset
+
+# pylint: disable=invalid-name
+FeedDict = Dict[tf.Tensor, Any]
+# pylint: enable=invalid-name
+
+
+# pylint: disable=too-few-public-methods
+# TODO add some public methods
+class Feedable(metaclass=ABCMeta):
+
+    def __init__(self) -> None:
+        self.train_mode = tf.placeholder(tf.bool, [], "train_mode")
+        self.batch_size = tf.placeholder(tf.int32, [], "batch_size")
+
+    def feed_dict(self, dataset: Dataset, train: bool = True) -> FeedDict:
+        fd = {}  # type: FeedDict
+        fd[self.train_mode] = train
+        fd[self.batch_size] = len(dataset)
+        return fd

--- a/neuralmonkey/model/gradient_blocking.py
+++ b/neuralmonkey/model/gradient_blocking.py
@@ -1,9 +1,8 @@
 """Module that blocks gradient propagation to model parts."""
-from typing import Set
+from typing import List
 import tensorflow as tf
 from typeguard import check_argument_types
 
-from neuralmonkey.model.model_part import GenericModelPart
 from neuralmonkey.model.stateful import (
     Stateful, TemporalStateful, SpatialStateful)
 
@@ -18,8 +17,9 @@ class StatefulView(Stateful):
     def output(self) -> tf.Tensor:
         return self._output
 
-    def get_dependencies(self) -> Set[GenericModelPart]:
-        return self._blocked_object.get_dependencies()
+    @property
+    def _singleton_dependencies(self) -> List[str]:
+        return super()._singleton_dependencies + ["_blocked_object"]
 
 
 class TemporalStatefulView(TemporalStateful):
@@ -36,8 +36,9 @@ class TemporalStatefulView(TemporalStateful):
     def temporal_mask(self) -> tf.Tensor:
         return self._blocked_object.temporal_mask
 
-    def get_dependencies(self) -> Set[GenericModelPart]:
-        return self._blocked_object.get_dependencies()
+    @property
+    def _singleton_dependencies(self) -> List[str]:
+        return super()._singleton_dependencies + ["_blocked_object"]
 
 
 class SpatialStatefulView(SpatialStateful):
@@ -54,5 +55,6 @@ class SpatialStatefulView(SpatialStateful):
     def spatial_mask(self) -> tf.Tensor:
         return self._blocked_object.spatial_mask
 
-    def get_dependencies(self) -> Set[GenericModelPart]:
-        return self._blocked_object.get_dependencies()
+    @property
+    def _singleton_dependencies(self) -> List[str]:
+        return super()._singleton_dependencies + ["_blocked_object"]

--- a/neuralmonkey/model/gradient_blocking.py
+++ b/neuralmonkey/model/gradient_blocking.py
@@ -8,6 +8,8 @@ from neuralmonkey.model.stateful import (
 
 
 class StatefulView(Stateful):
+    """Provides a gradient-blocking view of a `Stateful` object."""
+
     def __init__(self, blocked_object: Stateful) -> None:
         check_argument_types()
         self._blocked_object = blocked_object
@@ -18,11 +20,13 @@ class StatefulView(Stateful):
         return self._output
 
     @property
-    def _singleton_dependencies(self) -> List[str]:
-        return super()._singleton_dependencies + ["_blocked_object"]
+    def singleton_dependencies(self) -> List[str]:
+        return super().singleton_dependencies + ["_blocked_object"]
 
 
 class TemporalStatefulView(TemporalStateful):
+    """Provides a gradient-blocking view of a `TemporalStateful` object."""
+
     def __init__(self, blocked_object: TemporalStateful) -> None:
         check_argument_types()
         self._blocked_object = blocked_object
@@ -37,11 +41,13 @@ class TemporalStatefulView(TemporalStateful):
         return self._blocked_object.temporal_mask
 
     @property
-    def _singleton_dependencies(self) -> List[str]:
-        return super()._singleton_dependencies + ["_blocked_object"]
+    def singleton_dependencies(self) -> List[str]:
+        return super().singleton_dependencies + ["_blocked_object"]
 
 
 class SpatialStatefulView(SpatialStateful):
+    """Provides a gradient-blocking view of a `SpatialStateful` object."""
+
     def __init__(self, blocked_object: SpatialStateful) -> None:
         check_argument_types()
         self._blocked_object = blocked_object
@@ -56,5 +62,5 @@ class SpatialStatefulView(SpatialStateful):
         return self._blocked_object.spatial_mask
 
     @property
-    def _singleton_dependencies(self) -> List[str]:
-        return super()._singleton_dependencies + ["_blocked_object"]
+    def singleton_dependencies(self) -> List[str]:
+        return super().singleton_dependencies + ["_blocked_object"]

--- a/neuralmonkey/model/gradient_blocking.py
+++ b/neuralmonkey/model/gradient_blocking.py
@@ -20,8 +20,8 @@ class StatefulView(Stateful):
         return self._output
 
     @property
-    def singleton_dependencies(self) -> List[str]:
-        return super().singleton_dependencies + ["_blocked_object"]
+    def dependencies(self) -> List[str]:
+        return super().dependencies + ["_blocked_object"]
 
 
 class TemporalStatefulView(TemporalStateful):
@@ -41,8 +41,8 @@ class TemporalStatefulView(TemporalStateful):
         return self._blocked_object.temporal_mask
 
     @property
-    def singleton_dependencies(self) -> List[str]:
-        return super().singleton_dependencies + ["_blocked_object"]
+    def dependencies(self) -> List[str]:
+        return super().dependencies + ["_blocked_object"]
 
 
 class SpatialStatefulView(SpatialStateful):
@@ -62,5 +62,5 @@ class SpatialStatefulView(SpatialStateful):
         return self._blocked_object.spatial_mask
 
     @property
-    def singleton_dependencies(self) -> List[str]:
-        return super().singleton_dependencies + ["_blocked_object"]
+    def dependencies(self) -> List[str]:
+        return super().dependencies + ["_blocked_object"]

--- a/neuralmonkey/model/model_part.py
+++ b/neuralmonkey/model/model_part.py
@@ -10,16 +10,34 @@ from neuralmonkey.model.feedable import Feedable, FeedDict
 # pylint: enable=unused-import
 
 
-# pylint: disable=too-few-public-methods
-# TODO add some public methods or think of something else
 class GenericModelPart(metaclass=ABCMeta):
+    """Base class for Neural Monkey model parts.
+
+    Neural Monkey dynamically decides which model parts are in use when using a
+    specific trainer or a runner. Each trainer/runner holds a reference to a
+    top-level model part, which is then responsible for collecting references
+    to all `Parameterized` and `Feedable` objects that contribute to the
+    computation of its Tensors. This behavior is implemented using the
+    `get_dependencies` method, which is called recursively on all instances of
+    `GenericModelPart` class that are references from within a model part.
+
+    Apart from the `get_dependencies` method, this class also provides two
+    properties: `list_dependencies` and `singleton_dependencies` which store
+    the names of the Python class attributes that are regarded as potential
+    dependents of the `GenericModelPart` object. These dependents are
+    automatically checked for type and when they are instances of the
+    `GenericModelPart` class, results of their `get_dependencies` are united
+    and returned as dependencies of the current object.
+    """
 
     @property
-    def _list_dependencies(self) -> List[str]:
+    def list_dependencies(self) -> List[str]:
+        """Return a list of attributes regarded as lists of dependents."""
         return ["attentions", "encoders"]
 
     @property
-    def _singleton_dependencies(self) -> List[str]:
+    def singleton_dependencies(self) -> List[str]:
+        """Return a list of attributes regarded as dependents."""
         return ["encoder", "parent_decoder", "input_sequence"]
 
     def __get_deps_from_list(
@@ -49,7 +67,20 @@ class GenericModelPart(metaclass=ABCMeta):
                 parameterizeds |= params
 
     def get_dependencies(self) -> Tuple[Set[Feedable], Set[Parameterized]]:
-        """Collect recusively all encoders and decoders."""
+        """Collect all dependents of this object recursively.
+
+        The dependents are collected using the `list_dependencies` and
+        `singleton_dependencies` properties. Each stores a potential dependent
+        object. If the object exsits and is an instance of `GenericModelPart`,
+        dependents are collected recursively by calling its `get_dependencies`
+        method.
+
+        If the object itself is instance of `Feedable` or `Parameterized`
+        class, it is added among the respective sets returned.
+
+        Returns:
+            A `Tuple` of `Set`s of `Feedable` and `Parameterized` objects.
+        """
         feedables = set()  # type: Set[Feedable]
         parameterizeds = set()  # type: Set[Parameterized]
 
@@ -58,18 +89,21 @@ class GenericModelPart(metaclass=ABCMeta):
         if isinstance(self, Parameterized):
             parameterizeds |= {self}
 
-        for attr in self._list_dependencies:
+        for attr in self.list_dependencies:
             self.__get_deps_from_list(attr, feedables, parameterizeds)
 
-        for attr in self._singleton_dependencies:
+        for attr in self.singleton_dependencies:
             self.__get_deps(attr, feedables, parameterizeds)
 
         return feedables, parameterizeds
-# pylint: enable=too-few-public-methods
 
 
 class ModelPart(Parameterized, GenericModelPart, Feedable):
-    """Base class of all parametric feedable model parts."""
+    """Base class of all parametric feedable model parts.
+
+    Serves as a syntactic sugar for labeling `Feedable`, `Parameterized`, and
+    `GenericModelPart` objects.
+    """
 
     def __init__(self,
                  name: str,

--- a/neuralmonkey/model/model_part.py
+++ b/neuralmonkey/model/model_part.py
@@ -1,22 +1,15 @@
 """Basic functionality of all model parts."""
+from typing import Set
 
-from abc import ABCMeta
-from contextlib import contextmanager
-from typing import Any, Callable, Dict, List, Set, Tuple
-
-import tensorflow as tf
-
-from neuralmonkey.dataset import Dataset
-from neuralmonkey.logging import log
-from neuralmonkey import tf_utils
-
-# pylint: disable=invalid-name
-FeedDict = Dict[tf.Tensor, Any]
-InitializerSpecs = List[Tuple[str, Callable]]
-# pylint: disable=invalid-name
+# pylint: disable=unused-import
+# TODO feed dict and initializer specs are imported for convenience
+# TODO this is because the codebase import these things from this module
+from neuralmonkey.model.parameterized import Parameterized, InitializerSpecs
+from neuralmonkey.model.feedable import Feedable, FeedDict
+# pylint: enable=unused-import
 
 
-class ModelPart(metaclass=ABCMeta):
+class ModelPart(Parameterized, Feedable):
     """Base class of all model parts."""
 
     def __init__(self,
@@ -25,61 +18,10 @@ class ModelPart(metaclass=ABCMeta):
                  save_checkpoint: str = None,
                  load_checkpoint: str = None,
                  initializers: InitializerSpecs = None) -> None:
-        self._name = name
-        self._save_checkpoint = save_checkpoint
-        self._load_checkpoint = load_checkpoint
-
-        self._saver = None  # type: tf.train.Saver
-        self._reuse = reuse is not None
-
-        if reuse is not None:
-            # pylint: disable=unidiomatic-typecheck
-            # Here we need an exact match of types
-            if type(self) != type(reuse):
-                raise TypeError("Can only reuse parameters of ModelPart "
-                                "objects within the same sub-class.")
-            # pylint: enable=unidiomatic-typecheck
-
-            if initializers is not None:
-                raise ValueError("Cannot use initializers in model part '{}' "
-                                 "that reuses variables from '{}'."
-                                 .format(name, reuse.name))
-
-            # pylint: disable=protected-access
-            self._variable_scope = reuse._variable_scope  # type: ignore
-            # pylint: enable=protected-access
-        else:
-            with tf.variable_scope(name) as scope:
-                self._variable_scope = scope
-                if initializers is not None:
-                    tf_utils.update_initializers(
-                        (scope.name + "/" + name, initializer)
-                        for name, initializer in initializers)
-
+        Parameterized.__init__(self, name, reuse, save_checkpoint,
+                               load_checkpoint, initializers)
         with self.use_scope():
-            self.train_mode = tf.placeholder(tf.bool, [], "train_mode")
-            self.batch_size = tf.placeholder(tf.int32, [], "batch_size")
-
-    @property
-    def name(self) -> str:
-        """Get the name of the model part and its variable scope."""
-        return self._name
-
-    @contextmanager
-    def use_scope(self):
-        """Return a context manager.
-
-        Return a context manager that (re)opens the model part's variable
-        and name scope.
-        """
-        # If we are already reusing, reuse regardless of self._reuse.
-        reuse = self._variable_scope.reuse or self._reuse
-
-        with tf.variable_scope(self._variable_scope, reuse=reuse):
-            # tf.variable_scope always creates a NEW name scope for ops, but
-            # we want to use the original one:
-            with tf.name_scope(self._variable_scope.original_name_scope):
-                yield
+            Feedable.__init__(self)
 
     def get_dependencies(self) -> Set["ModelPart"]:
         """Collect recusively all encoders and decoders."""
@@ -113,35 +55,3 @@ class ModelPart(metaclass=ABCMeta):
                 to_return = to_return.union(dec.get_dependencies())
 
         return to_return
-
-    def feed_dict(self, dataset: Dataset, train: bool) -> FeedDict:
-        fd = {}  # type: FeedDict
-        fd[self.train_mode] = train
-        fd[self.batch_size] = len(dataset)
-        return fd
-
-    def _init_saver(self) -> None:
-        if not self._saver:
-            parts_variables = tf.get_collection(
-                tf.GraphKeys.GLOBAL_VARIABLES, scope=self._variable_scope.name)
-
-            with self.use_scope():
-                self._saver = tf.train.Saver(var_list=parts_variables)
-
-    def save(self, session: tf.Session) -> None:
-        """Save model part to a checkpoint file."""
-        if self._save_checkpoint:
-            self._init_saver()
-            self._saver.save(session, self._save_checkpoint)
-
-            log("Variables of '{}' saved to '{}'".format(
-                self.name, self._save_checkpoint))
-
-    def load(self, session: tf.Session) -> None:
-        """Load model part from a checkpoint file."""
-        if self._load_checkpoint:
-            self._init_saver()
-            self._saver.restore(session, self._load_checkpoint)
-
-            log("Variables of '{}' loaded from '{}'".format(
-                self.name, self._load_checkpoint))

--- a/neuralmonkey/model/model_part.py
+++ b/neuralmonkey/model/model_part.py
@@ -1,6 +1,6 @@
 """Basic functionality of all model parts."""
 from abc import ABCMeta
-from typing import MutableSet, Set, List, Tuple
+from typing import MutableSet, Set, List, Tuple, Iterable
 
 from neuralmonkey.model.parameterized import Parameterized, InitializerSpecs
 from neuralmonkey.model.feedable import Feedable
@@ -17,37 +17,20 @@ class GenericModelPart(metaclass=ABCMeta):
     `get_dependencies` method, which is called recursively on all instances of
     `GenericModelPart` class that are references from within a model part.
 
-    Apart from the `get_dependencies` method, this class also provides two
-    properties: `list_dependencies` and `singleton_dependencies` which store
-    the names of the Python class attributes that are regarded as potential
-    dependents of the `GenericModelPart` object. These dependents are
-    automatically checked for type and when they are instances of the
-    `GenericModelPart` class, results of their `get_dependencies` are united
-    and returned as dependencies of the current object.
+    Apart from the `get_dependencies` method, this class also provides the
+    `dependencies` property which store the names of the Python class
+    attributes that are regarded as potential dependents of the
+    `GenericModelPart` object. These dependents are automatically checked for
+    type and when they are instances of the `GenericModelPart` class, results
+    of their `get_dependencies` are united and returned as dependencies of the
+    current object.
     """
 
     @property
-    def list_dependencies(self) -> List[str]:
-        """Return a list of attributes regarded as lists of dependents."""
-        return ["attentions", "encoders"]
-
-    @property
-    def singleton_dependencies(self) -> List[str]:
-        """Return a list of attributes regarded as dependents."""
-        return ["encoder", "parent_decoder", "input_sequence"]
-
-    def __get_deps_from_list(
-            self,
-            attr: str,
-            feedables: MutableSet[Feedable],
-            parameterizeds: MutableSet[Parameterized]) -> None:
-
-        if hasattr(self, attr):
-            for enc in getattr(self, attr):
-                if isinstance(enc, GenericModelPart):
-                    feeds, params = enc.get_dependencies()
-                    feedables |= feeds
-                    parameterizeds |= params
+    def dependencies(self) -> List[str]:
+        """Return a list of attribute names regarded as dependents."""
+        return ["encoder", "parent_decoder", "input_sequence", "attentions",
+                "encoders"]
 
     def __get_deps(
             self,
@@ -55,27 +38,36 @@ class GenericModelPart(metaclass=ABCMeta):
             feedables: MutableSet[Feedable],
             parameterizeds: MutableSet[Parameterized]) -> None:
 
-        if hasattr(self, attr):
-            enc = getattr(self, attr)
-            if isinstance(enc, GenericModelPart):
-                feeds, params = enc.get_dependencies()
-                feedables |= feeds
-                parameterizeds |= params
+        attr_val = getattr(self, attr, None)
+
+        if attr_val is None:
+            return
+
+        deps = []  # type: List[GenericModelPart]
+        if isinstance(attr_val, GenericModelPart):
+            deps = [attr_val]
+        elif isinstance(attr_val, Iterable):
+            deps = [a for a in attr_val if isinstance(a, GenericModelPart)]
+
+        for dep in deps:
+            feeds, params = dep.get_dependencies()
+            feedables |= feeds
+            parameterizeds |= params
 
     def get_dependencies(self) -> Tuple[Set[Feedable], Set[Parameterized]]:
         """Collect all dependents of this object recursively.
 
-        The dependents are collected using the `list_dependencies` and
-        `singleton_dependencies` properties. Each stores a potential dependent
-        object. If the object exsits and is an instance of `GenericModelPart`,
-        dependents are collected recursively by calling its `get_dependencies`
-        method.
+        The dependents are collected using the `dependencies` property. Each
+        stores a potential dependent object. If the object exsits and is an
+        instance of `GenericModelPart`, dependents are collected recursively by
+        calling its `get_dependencies` method.
 
         If the object itself is instance of `Feedable` or `Parameterized`
         class, it is added among the respective sets returned.
 
         Returns:
             A `Tuple` of `Set`s of `Feedable` and `Parameterized` objects.
+
         """
         feedables = set()  # type: Set[Feedable]
         parameterizeds = set()  # type: Set[Parameterized]
@@ -85,10 +77,7 @@ class GenericModelPart(metaclass=ABCMeta):
         if isinstance(self, Parameterized):
             parameterizeds |= {self}
 
-        for attr in self.list_dependencies:
-            self.__get_deps_from_list(attr, feedables, parameterizeds)
-
-        for attr in self.singleton_dependencies:
+        for attr in self.dependencies:
             self.__get_deps(attr, feedables, parameterizeds)
 
         return feedables, parameterizeds

--- a/neuralmonkey/model/model_part.py
+++ b/neuralmonkey/model/model_part.py
@@ -2,12 +2,8 @@
 from abc import ABCMeta
 from typing import MutableSet, Set, List, Tuple
 
-# pylint: disable=unused-import
-# TODO feed dict and initializer specs are imported for convenience
-# TODO this is because the codebase import these things from this module
 from neuralmonkey.model.parameterized import Parameterized, InitializerSpecs
-from neuralmonkey.model.feedable import Feedable, FeedDict
-# pylint: enable=unused-import
+from neuralmonkey.model.feedable import Feedable
 
 
 class GenericModelPart(metaclass=ABCMeta):

--- a/neuralmonkey/model/parameterized.py
+++ b/neuralmonkey/model/parameterized.py
@@ -13,6 +13,14 @@ InitializerSpecs = List[Tuple[str, Callable]]
 
 
 class Parameterized(metaclass=ABCMeta):
+    """Base class for parameterized model parts.
+
+    This class is an abstraction for all model parts which use TensorFlow
+    variables. Shared properties and characteristics of all these objects
+    are the capability of loading and saving the variables, re-using variables
+    from a different `Parameterized` object, and managing variable scopes,
+    including overriding the default initializer settings for the variables.
+    """
 
     def __init__(self,
                  name: str,
@@ -20,7 +28,19 @@ class Parameterized(metaclass=ABCMeta):
                  save_checkpoint: str = None,
                  load_checkpoint: str = None,
                  initializers: InitializerSpecs = None) -> None:
+        """Construct a new parameterized object.
 
+        Arguments:
+            name: The name for the model part. Will be used in the variable
+                and name scopes.
+            reuse: Optional parameterized part with which to share parameters.
+            save_checkpoint: Optional path to a checkpoint file which will
+                store the parameters of this object.
+            load_checkpoint: Optional path to a checkpoint file from which to
+                load initial variables for this object.
+            initializers: An `InitializerSpecs` instance with specification
+                of the initializers.
+        """
         self._name = name
         self._save_checkpoint = save_checkpoint
         self._load_checkpoint = load_checkpoint

--- a/neuralmonkey/model/parameterized.py
+++ b/neuralmonkey/model/parameterized.py
@@ -1,0 +1,99 @@
+from abc import ABCMeta
+from contextlib import contextmanager
+from typing import List, Tuple, Callable, Iterator
+
+import tensorflow as tf
+
+from neuralmonkey.tf_utils import update_initializers
+from neuralmonkey.logging import log
+
+# pylint: enable=invalid-name
+InitializerSpecs = List[Tuple[str, Callable]]
+# pylint: disable=invalid-name
+
+
+class Parameterized(metaclass=ABCMeta):
+
+    def __init__(self,
+                 name: str,
+                 reuse: "Parameterized" = None,
+                 save_checkpoint: str = None,
+                 load_checkpoint: str = None,
+                 initializers: InitializerSpecs = None) -> None:
+
+        self._name = name
+        self._save_checkpoint = save_checkpoint
+        self._load_checkpoint = load_checkpoint
+
+        self._saver = None  # type: tf.train.Saver
+        self._reuse = reuse is not None
+
+        if reuse is not None:
+            # pylint: disable=unidiomatic-typecheck
+            # Here we need an exact match of types
+            if type(self) != type(reuse):
+                raise TypeError("Can only reuse parameters of ModelPart "
+                                "objects within the same sub-class.")
+            # pylint: enable=unidiomatic-typecheck
+
+            if initializers is not None:
+                raise ValueError("Cannot use initializers in model part '{}' "
+                                 "that reuses variables from '{}'."
+                                 .format(name, reuse.name))
+
+            # pylint: disable=protected-access
+            self._variable_scope = reuse._variable_scope  # type: ignore
+            # pylint: enable=protected-access
+        else:
+            with tf.variable_scope(name) as scope:
+                self._variable_scope = scope
+                if initializers is not None:
+                    update_initializers((scope.name + "/" + name, initializer)
+                                        for name, initializer in initializers)
+
+    @property
+    def name(self) -> str:
+        """Get the name of the parameterized object and its variable scope."""
+        return self._name
+
+    @contextmanager
+    def use_scope(self) -> Iterator[None]:
+        """Return the object variable scope context manager.
+
+        Return the context manager that (re)opens variable and name scopes of
+        the parameterized object..
+        """
+        # If we are already reusing, reuse regardless of self._reuse.
+        reuse = self._variable_scope.reuse or self._reuse
+
+        with tf.variable_scope(self._variable_scope, reuse=reuse):
+            # tf.variable_scope always creates a NEW name scope for ops, but
+            # we want to use the original one:
+            with tf.name_scope(self._variable_scope.original_name_scope):
+                yield
+
+    def _init_saver(self) -> None:
+        if not self._saver:
+            parts_variables = tf.get_collection(
+                tf.GraphKeys.GLOBAL_VARIABLES, scope=self._variable_scope.name)
+
+            with self.use_scope():
+                self._saver = tf.train.Saver(var_list=parts_variables)
+
+    def save(self, session: tf.Session) -> None:
+        """Save model part to a checkpoint file."""
+        if self._save_checkpoint:
+            self._init_saver()
+            self._saver.save(session, self._save_checkpoint)
+
+            log("Variables of '{}' saved to '{}'".format(
+                self.name, self._save_checkpoint))
+
+    def load(self, session: tf.Session) -> None:
+        """Load model part from a checkpoint file."""
+        if self._load_checkpoint:
+            self._init_saver()
+            self._saver.restore(session, self._load_checkpoint)
+
+            log("Variables of '{}' loaded from '{}'".format(
+                self.name, self._load_checkpoint))

--- a/neuralmonkey/model/parameterized.py
+++ b/neuralmonkey/model/parameterized.py
@@ -56,6 +56,10 @@ class Parameterized(metaclass=ABCMeta):
         """Get the name of the parameterized object and its variable scope."""
         return self._name
 
+    def __str__(self) -> str:
+        """Return the name of the object."""
+        return self.name
+
     @contextmanager
     def use_scope(self) -> Iterator[None]:
         """Return the object variable scope context manager.

--- a/neuralmonkey/model/parameterized.py
+++ b/neuralmonkey/model/parameterized.py
@@ -5,7 +5,7 @@ from typing import List, Tuple, Callable, Iterator
 import tensorflow as tf
 
 from neuralmonkey.tf_utils import update_initializers
-from neuralmonkey.logging import log
+from neuralmonkey.logging import log, warn
 
 # pylint: enable=invalid-name
 InitializerSpecs = List[Tuple[str, Callable]]
@@ -52,8 +52,8 @@ class Parameterized(metaclass=ABCMeta):
             # pylint: disable=unidiomatic-typecheck
             # Here we need an exact match of types
             if type(self) != type(reuse):
-                raise TypeError("Can only reuse parameters of ModelPart "
-                                "objects within the same sub-class.")
+                warn("Warning: sharing parameters between model parts of "
+                     "different types.")
             # pylint: enable=unidiomatic-typecheck
 
             if initializers is not None:

--- a/neuralmonkey/model/sequence.py
+++ b/neuralmonkey/model/sequence.py
@@ -7,7 +7,9 @@ import tensorflow as tf
 from tensorflow.contrib.tensorboard.plugins import projector
 from typeguard import check_argument_types
 
-from neuralmonkey.model.model_part import ModelPart, FeedDict, InitializerSpecs
+from neuralmonkey.model.feedable import FeedDict
+from neuralmonkey.model.model_part import ModelPart
+from neuralmonkey.model.parameterized import InitializerSpecs
 from neuralmonkey.model.stateful import TemporalStateful
 from neuralmonkey.vocabulary import Vocabulary
 from neuralmonkey.decorators import tensor

--- a/neuralmonkey/model/sequence_split.py
+++ b/neuralmonkey/model/sequence_split.py
@@ -5,7 +5,7 @@ from typeguard import check_argument_types
 
 from neuralmonkey.decorators import tensor
 from neuralmonkey.dataset import Dataset
-from neuralmonkey.model.model_part import ModelPart, FeedDict
+from neuralmonkey.model.model_part import ModelPart, FeedDict, GenericModelPart
 from neuralmonkey.model.stateful import TemporalStateful
 
 
@@ -74,11 +74,8 @@ class SequenceSplitter(TemporalStateful, ModelPart):
     def feed_dict(self, dataset: Dataset, train: bool = True) -> FeedDict:
         return ModelPart.feed_dict(self, dataset, train)
 
-    def get_dependencies(self) -> Set[ModelPart]:
-        deps = set([self])  # type: Set[ModelPart]
-        if isinstance(self.parent, ModelPart):
-            deps = deps.union(self.parent.get_dependencies())
-        return deps
+    def get_dependencies(self) -> Set[GenericModelPart]:
+        return self.parent.get_dependencies().union([self])
 
 
 def split_by_factor(

--- a/neuralmonkey/model/sequence_split.py
+++ b/neuralmonkey/model/sequence_split.py
@@ -1,11 +1,11 @@
 """Split temporal states such that the sequence is n-times longer."""
-from typing import Callable, Set
+from typing import Callable, List
 import tensorflow as tf
 from typeguard import check_argument_types
 
 from neuralmonkey.decorators import tensor
 from neuralmonkey.dataset import Dataset
-from neuralmonkey.model.model_part import ModelPart, FeedDict, GenericModelPart
+from neuralmonkey.model.model_part import ModelPart, FeedDict
 from neuralmonkey.model.stateful import TemporalStateful
 
 
@@ -20,7 +20,7 @@ class SequenceSplitter(TemporalStateful, ModelPart):
             factor: int,
             projection_size: int = None,
             projection_activation: Activation = None) -> None:
-        """Initialize SetenceSplitter.
+        """Initialize SentenceSplitter.
 
         Args:
             parent: TemporalStateful whose states will be split.
@@ -74,8 +74,9 @@ class SequenceSplitter(TemporalStateful, ModelPart):
     def feed_dict(self, dataset: Dataset, train: bool = True) -> FeedDict:
         return ModelPart.feed_dict(self, dataset, train)
 
-    def get_dependencies(self) -> Set[GenericModelPart]:
-        return self.parent.get_dependencies().union([self])
+    @property
+    def _singleton_dependencies(self) -> List[str]:
+        return super()._singleton_dependencies + ["parent"]
 
 
 def split_by_factor(

--- a/neuralmonkey/model/sequence_split.py
+++ b/neuralmonkey/model/sequence_split.py
@@ -75,8 +75,8 @@ class SequenceSplitter(TemporalStateful, ModelPart):
         return ModelPart.feed_dict(self, dataset, train)
 
     @property
-    def _singleton_dependencies(self) -> List[str]:
-        return super()._singleton_dependencies + ["parent"]
+    def singleton_dependencies(self) -> List[str]:
+        return super().singleton_dependencies + ["parent"]
 
 
 def split_by_factor(

--- a/neuralmonkey/model/sequence_split.py
+++ b/neuralmonkey/model/sequence_split.py
@@ -71,7 +71,7 @@ class SequenceSplitter(TemporalStateful, ModelPart):
         return tf.squeeze(
             split_by_factor(double_mask, self.batch_size, self.factor), axis=2)
 
-    def feed_dict(self, dataset: Dataset, train: bool) -> FeedDict:
+    def feed_dict(self, dataset: Dataset, train: bool = True) -> FeedDict:
         return ModelPart.feed_dict(self, dataset, train)
 
     def get_dependencies(self) -> Set[ModelPart]:

--- a/neuralmonkey/model/sequence_split.py
+++ b/neuralmonkey/model/sequence_split.py
@@ -5,7 +5,8 @@ from typeguard import check_argument_types
 
 from neuralmonkey.decorators import tensor
 from neuralmonkey.dataset import Dataset
-from neuralmonkey.model.model_part import ModelPart, FeedDict
+from neuralmonkey.model.feedable import FeedDict
+from neuralmonkey.model.model_part import ModelPart
 from neuralmonkey.model.stateful import TemporalStateful
 
 

--- a/neuralmonkey/model/sequence_split.py
+++ b/neuralmonkey/model/sequence_split.py
@@ -76,8 +76,8 @@ class SequenceSplitter(TemporalStateful, ModelPart):
         return ModelPart.feed_dict(self, dataset, train)
 
     @property
-    def singleton_dependencies(self) -> List[str]:
-        return super().singleton_dependencies + ["parent"]
+    def dependencies(self) -> List[str]:
+        return super().dependencies + ["parent"]
 
 
 def split_by_factor(

--- a/neuralmonkey/model/stateful.py
+++ b/neuralmonkey/model/stateful.py
@@ -12,13 +12,14 @@ There are also classes that inherit from both stateful and temporal or spatial
 stateful (e.g. `TemporalStatefulWithOutput`) that can be used for model parts
 that satisfy more requirements (e.g. recurrent encoder).
 """
-from abc import ABCMeta, abstractproperty
+from abc import abstractproperty
 import tensorflow as tf
+from neuralmonkey.model.model_part import GenericModelPart
 
 
 # pylint: disable=too-few-public-methods
 # pydocstyle: disable=
-class Stateful(metaclass=ABCMeta):
+class Stateful(GenericModelPart):
     @abstractproperty
     def output(self) -> tf.Tensor:
         """Return the object output.
@@ -30,7 +31,7 @@ class Stateful(metaclass=ABCMeta):
 # pylint: enable=too-few-public-methods
 
 
-class TemporalStateful(metaclass=ABCMeta):
+class TemporalStateful(GenericModelPart):
     @abstractproperty
     def temporal_states(self) -> tf.Tensor:
         """Return object states in time.
@@ -66,7 +67,7 @@ class TemporalStateful(metaclass=ABCMeta):
         return self.temporal_states.get_shape()[-1].value
 
 
-class SpatialStateful(metaclass=ABCMeta):
+class SpatialStateful(GenericModelPart):
     @property
     def spatial_states(self) -> tf.Tensor:
         """Return object states in space.

--- a/neuralmonkey/runners/base_runner.py
+++ b/neuralmonkey/runners/base_runner.py
@@ -4,11 +4,11 @@ import numpy as np
 import tensorflow as tf
 
 from neuralmonkey.logging import notice
-from neuralmonkey.model.model_part import ModelPart
+from neuralmonkey.model.model_part import GenericModelPart
 # pylint: disable=invalid-name
 FeedDict = Dict[tf.Tensor, Union[int, float, np.ndarray]]
-NextExecute = Tuple[Set[ModelPart], Union[Dict, List], List[FeedDict]]
-MP = TypeVar("MP", bound=ModelPart)
+NextExecute = Tuple[Set[GenericModelPart], Union[Dict, List], List[FeedDict]]
+MP = TypeVar("MP", bound=GenericModelPart)
 # pylint: enable=invalid-name
 
 
@@ -51,7 +51,7 @@ class BaseRunner(Generic[MP]):
 
         if not hasattr(decoder, "data_id"):
             notice("Top-level decoder {} does not have the 'data_id' attribute"
-                   .format(decoder.name))
+                   .format(decoder))
 
     def get_executable(self,
                        compute_losses: bool,

--- a/neuralmonkey/runners/beamsearch_runner.py
+++ b/neuralmonkey/runners/beamsearch_runner.py
@@ -4,7 +4,7 @@ import scipy
 import numpy as np
 from typeguard import check_argument_types
 
-from neuralmonkey.model.model_part import ModelPart
+from neuralmonkey.model.model_part import GenericModelPart
 from neuralmonkey.decoders.beam_search_decoder import BeamSearchDecoder
 from neuralmonkey.runners.base_runner import (
     BaseRunner, Executable, ExecutionResult, NextExecute)
@@ -17,7 +17,7 @@ from neuralmonkey.vocabulary import END_TOKEN_INDEX
 class BeamSearchExecutable(Executable):
     def __init__(self,
                  rank: int,
-                 all_coders: Set[ModelPart],
+                 all_coders: Set[GenericModelPart],
                  num_sessions: int,
                  decoder: BeamSearchDecoder,
                  postprocess: Optional[Callable]) -> None:

--- a/neuralmonkey/runners/ctc_debug_runner.py
+++ b/neuralmonkey/runners/ctc_debug_runner.py
@@ -5,7 +5,7 @@ from typeguard import check_argument_types
 
 from neuralmonkey.runners.base_runner import (
     BaseRunner, Executable, FeedDict, ExecutionResult, NextExecute)
-from neuralmonkey.model.model_part import ModelPart
+from neuralmonkey.model.model_part import GenericModelPart
 from neuralmonkey.vocabulary import Vocabulary
 from neuralmonkey.decoders.ctc_decoder import CTCDecoder
 
@@ -13,7 +13,7 @@ from neuralmonkey.decoders.ctc_decoder import CTCDecoder
 class CTCDebugExecutable(Executable):
 
     def __init__(self,
-                 all_coders: Set[ModelPart],
+                 all_coders: Set[GenericModelPart],
                  fetches: FeedDict,
                  vocabulary: Vocabulary) -> None:
         self._all_coders = all_coders

--- a/neuralmonkey/runners/label_runner.py
+++ b/neuralmonkey/runners/label_runner.py
@@ -3,7 +3,7 @@ import numpy as np
 from typeguard import check_argument_types
 
 from neuralmonkey.logging import log
-from neuralmonkey.model.model_part import ModelPart
+from neuralmonkey.model.model_part import GenericModelPart
 from neuralmonkey.vocabulary import Vocabulary, END_TOKEN_INDEX
 from neuralmonkey.runners.base_runner import (
     BaseRunner, Executable, FeedDict, ExecutionResult, NextExecute)
@@ -17,7 +17,7 @@ Postprocessor = Callable[[List[List[str]]], List[List[str]]]
 class LabelRunExecutable(Executable):
 
     def __init__(self,
-                 all_coders: Set[ModelPart],
+                 all_coders: Set[GenericModelPart],
                  fetches: FeedDict,
                  vocabulary: Vocabulary,
                  postprocess: Optional[Postprocessor]) -> None:

--- a/neuralmonkey/runners/logits_runner.py
+++ b/neuralmonkey/runners/logits_runner.py
@@ -9,14 +9,14 @@ import tensorflow as tf
 from neuralmonkey.decoders.classifier import Classifier
 from neuralmonkey.runners.base_runner import (
     BaseRunner, Executable, FeedDict, ExecutionResult, NextExecute)
-from neuralmonkey.model.model_part import ModelPart
+from neuralmonkey.model.model_part import GenericModelPart
 from neuralmonkey.vocabulary import Vocabulary
 
 
 class LogitsExecutable(Executable):
 
     def __init__(self,
-                 all_coders: Set[ModelPart],
+                 all_coders: Set[GenericModelPart],
                  fetches: FeedDict,
                  vocabulary: Vocabulary,
                  normalize: bool,

--- a/neuralmonkey/runners/perplexity_runner.py
+++ b/neuralmonkey/runners/perplexity_runner.py
@@ -7,7 +7,7 @@ from typeguard import check_argument_types
 import tensorflow as tf
 import numpy as np
 
-from neuralmonkey.model.model_part import ModelPart
+from neuralmonkey.model.model_part import GenericModelPart
 from neuralmonkey.decoders.autoregressive import AutoregressiveDecoder
 from neuralmonkey.runners.base_runner import (
     BaseRunner, Executable, ExecutionResult, NextExecute)
@@ -15,7 +15,7 @@ from neuralmonkey.runners.base_runner import (
 
 class PerplexityExecutable(Executable):
     def __init__(self,
-                 all_coders: Set[ModelPart],
+                 all_coders: Set[GenericModelPart],
                  xent_op: tf.Tensor) -> None:
         self._all_coders = all_coders
         self._xent_op = xent_op

--- a/neuralmonkey/runners/perplexity_runner.py
+++ b/neuralmonkey/runners/perplexity_runner.py
@@ -7,7 +7,7 @@ from typeguard import check_argument_types
 import tensorflow as tf
 import numpy as np
 
-from neuralmonkey.model.model_part import GenericModelPart
+from neuralmonkey.model.feedable import Feedable
 from neuralmonkey.decoders.autoregressive import AutoregressiveDecoder
 from neuralmonkey.runners.base_runner import (
     BaseRunner, Executable, ExecutionResult, NextExecute)
@@ -15,21 +15,21 @@ from neuralmonkey.runners.base_runner import (
 
 class PerplexityExecutable(Executable):
     def __init__(self,
-                 all_coders: Set[GenericModelPart],
+                 feedables: Set[Feedable],
                  xent_op: tf.Tensor) -> None:
-        self._all_coders = all_coders
+        self._feedables = feedables
         self._xent_op = xent_op
 
-        self.result = None  # type: Optional[ExecutionResult]
+        self._result = None  # type: Optional[ExecutionResult]
 
     def next_to_execute(self) -> NextExecute:
         """Get the feedables and tensors to run."""
-        return self._all_coders, {"xents": self._xent_op}, []
+        return self._feedables, {"xents": self._xent_op}, []
 
     def collect_results(self, results: List[Dict]) -> None:
         perplexities = np.mean([2 ** res["xents"] for res in results], axis=0)
         xent = float(np.mean([res["xents"] for res in results]))
-        self.result = ExecutionResult(
+        self._result = ExecutionResult(
             outputs=perplexities.tolist(),
             losses=[xent],
             scalar_summaries=None,
@@ -52,7 +52,7 @@ class PerplexityRunner(BaseRunner[AutoregressiveDecoder]):
                        compute_losses: bool,
                        summaries: bool,
                        num_sessions: int) -> PerplexityExecutable:
-        return PerplexityExecutable(self.all_coders, self._decoder_xent)
+        return PerplexityExecutable(self.feedables, self._decoder_xent)
     # pylint: enable=unused-argument
 
     @property

--- a/neuralmonkey/runners/plain_runner.py
+++ b/neuralmonkey/runners/plain_runner.py
@@ -7,7 +7,7 @@ from neuralmonkey.decoders.autoregressive import AutoregressiveDecoder
 from neuralmonkey.decoders.ctc_decoder import CTCDecoder
 from neuralmonkey.decoders.classifier import Classifier
 from neuralmonkey.decoders.sequence_labeler import SequenceLabeler
-from neuralmonkey.model.model_part import ModelPart
+from neuralmonkey.model.model_part import GenericModelPart
 from neuralmonkey.runners.base_runner import (
     BaseRunner, Executable, FeedDict, ExecutionResult, NextExecute)
 from neuralmonkey.vocabulary import Vocabulary
@@ -22,7 +22,7 @@ Postprocessor = Callable[[List[List[str]]], List[List[str]]]
 class PlainExecutable(Executable):
 
     def __init__(self,
-                 all_coders: Set[ModelPart],
+                 all_coders: Set[GenericModelPart],
                  fetches: FeedDict,
                  num_sessions: int,
                  vocabulary: Vocabulary,

--- a/neuralmonkey/runners/regression_runner.py
+++ b/neuralmonkey/runners/regression_runner.py
@@ -5,7 +5,7 @@ import tensorflow as tf
 from typeguard import check_argument_types
 
 from neuralmonkey.decoders.sequence_regressor import SequenceRegressor
-from neuralmonkey.model.model_part import ModelPart
+from neuralmonkey.model.model_part import GenericModelPart
 from neuralmonkey.runners.base_runner import (
     BaseRunner, Executable, ExecutionResult, NextExecute)
 
@@ -17,7 +17,7 @@ Postprocessor = Callable[[List[float]], List[float]]
 class RegressionRunExecutable(Executable):
 
     def __init__(self,
-                 all_coders: Set[ModelPart],
+                 all_coders: Set[GenericModelPart],
                  fetches: Dict[str, tf.Tensor],
                  postprocess: Optional[Postprocessor]) -> None:
         self._all_coders = all_coders

--- a/neuralmonkey/runners/runner.py
+++ b/neuralmonkey/runners/runner.py
@@ -6,7 +6,7 @@ from typeguard import check_argument_types
 
 from neuralmonkey.runners.base_runner import (
     BaseRunner, Executable, FeedDict, ExecutionResult, NextExecute)
-from neuralmonkey.model.model_part import ModelPart
+from neuralmonkey.model.model_part import GenericModelPart
 from neuralmonkey.vocabulary import Vocabulary
 from neuralmonkey.decoders.autoregressive import AutoregressiveDecoder
 from neuralmonkey.decoders.classifier import Classifier
@@ -20,7 +20,7 @@ Postprocessor = Callable[[List[List[str]]], List[List[str]]]
 class GreedyRunExecutable(Executable):
 
     def __init__(self,
-                 all_coders: Set[ModelPart],
+                 all_coders: Set[GenericModelPart],
                  fetches: FeedDict,
                  vocabulary: Vocabulary,
                  postprocess: Optional[Postprocessor]) -> None:

--- a/neuralmonkey/runners/tensor_runner.py
+++ b/neuralmonkey/runners/tensor_runner.py
@@ -5,6 +5,7 @@ import tensorflow as tf
 from typeguard import check_argument_types
 
 from neuralmonkey.logging import log, warn
+from neuralmonkey.model.feedable import Feedable
 from neuralmonkey.model.model_part import GenericModelPart
 from neuralmonkey.runners.base_runner import (
     BaseRunner, Executable, ExecutionResult, NextExecute, FeedDict)
@@ -14,21 +15,21 @@ from neuralmonkey.experiment import Experiment
 class TensorExecutable(Executable):
 
     def __init__(self,
-                 all_coders: Set[GenericModelPart],
+                 feedables: Set[Feedable],
                  fetches: FeedDict,
                  batch_dims: Dict[str, int],
                  select_session: Optional[int],
                  single_tensor: bool) -> None:
-        self._all_coders = all_coders
+        self._feedables = feedables
         self._fetches = fetches
         self._batch_dims = batch_dims
         self._select_session = select_session
         self._single_tensor = single_tensor
 
-        self.result = None  # type: Optional[ExecutionResult]
+        self._result = None  # type: Optional[ExecutionResult]
 
     def next_to_execute(self) -> NextExecute:
-        return self._all_coders, self._fetches, []
+        return self._feedables, self._fetches, []
 
     def collect_results(self, results: List[Dict]) -> None:
         if len(results) > 1 and self._select_session is None:
@@ -46,7 +47,7 @@ class TensorExecutable(Executable):
         else:
             batched = self._fetch_values_from_session(results[0])
 
-        self.result = ExecutionResult(
+        self._result = ExecutionResult(
             outputs=batched,
             losses=[],
             scalar_summaries=None,
@@ -176,7 +177,7 @@ class TensorRunner(BaseRunner[GenericModelPart]):
             self._batch_ids[tensor.name] = bid
 
         return TensorExecutable(
-            self.all_coders, self._fetches, self._batch_ids,
+            self.feedables, self._fetches, self._batch_ids,
             self._select_session, self._single_tensor)
     # pylint: enable=unused-argument
 

--- a/neuralmonkey/runners/word_alignment_runner.py
+++ b/neuralmonkey/runners/word_alignment_runner.py
@@ -8,7 +8,7 @@ from typeguard import check_argument_types
 
 from neuralmonkey.attention.base_attention import BaseAttention
 from neuralmonkey.decoders.decoder import Decoder
-from neuralmonkey.model.model_part import GenericModelPart
+from neuralmonkey.model.feedable import Feedable
 from neuralmonkey.runners.base_runner import (
     BaseRunner, Executable, FeedDict, ExecutionResult, NextExecute)
 
@@ -16,19 +16,19 @@ from neuralmonkey.runners.base_runner import (
 class WordAlignmentRunnerExecutable(Executable):
 
     def __init__(self,
-                 all_coders: Set[GenericModelPart],
+                 feedables: Set[Feedable],
                  fetches: FeedDict) -> None:
-        self._all_coders = all_coders
+        self._feedables = feedables
         self._fetches = fetches
 
-        self.result = None  # type: Optional[ExecutionResult]
+        self._result = None  # type: Optional[ExecutionResult]
 
     def next_to_execute(self) -> NextExecute:
         """Get the feedables and tensors to run."""
-        return self._all_coders, self._fetches, []
+        return self._feedables, self._fetches, []
 
     def collect_results(self, results: List[Dict]) -> None:
-        self.result = ExecutionResult(
+        self._result = ExecutionResult(
             outputs=results[0]["alignment"],
             losses=[],
             scalar_summaries=None,
@@ -60,7 +60,7 @@ class WordAlignmentRunner(BaseRunner[BaseAttention]):
         alignment = tf.transpose(att_histories, perm=[1, 2, 0])
         fetches = {"alignment": alignment}
 
-        return WordAlignmentRunnerExecutable(self.all_coders, fetches)
+        return WordAlignmentRunnerExecutable(self.feedables, fetches)
     # pylint: enable=unused-argument
 
     @property

--- a/neuralmonkey/runners/word_alignment_runner.py
+++ b/neuralmonkey/runners/word_alignment_runner.py
@@ -8,7 +8,7 @@ from typeguard import check_argument_types
 
 from neuralmonkey.attention.base_attention import BaseAttention
 from neuralmonkey.decoders.decoder import Decoder
-from neuralmonkey.model.model_part import ModelPart
+from neuralmonkey.model.model_part import GenericModelPart
 from neuralmonkey.runners.base_runner import (
     BaseRunner, Executable, FeedDict, ExecutionResult, NextExecute)
 
@@ -16,7 +16,7 @@ from neuralmonkey.runners.base_runner import (
 class WordAlignmentRunnerExecutable(Executable):
 
     def __init__(self,
-                 all_coders: Set[ModelPart],
+                 all_coders: Set[GenericModelPart],
                  fetches: FeedDict) -> None:
         self._all_coders = all_coders
         self._fetches = fetches

--- a/neuralmonkey/trainers/delayed_update_trainer.py
+++ b/neuralmonkey/trainers/delayed_update_trainer.py
@@ -184,7 +184,7 @@ class DelayedTrainExecutable(Executable):
     def __init__(self, trainer: DelayedUpdateTrainer, summaries: bool) -> None:
         self.trainer = trainer
         self.summaries = summaries
-        self.result = None  # type: Optional[ExecutionResult]
+        self._result = None  # type: Optional[ExecutionResult]
 
         self.state = 0
         self.res_hist_sums = None
@@ -197,7 +197,7 @@ class DelayedTrainExecutable(Executable):
             fetches = {"accumulators": self.trainer.accumulate_ops,
                        "counter": self.trainer.cumulator_counter,
                        "losses": self.trainer.objective_values}
-            coders = self.trainer.all_coders
+            coders = self.trainer.feedables
 
         elif self.state == 1:  # UPDATING
             fetches = {
@@ -207,7 +207,7 @@ class DelayedTrainExecutable(Executable):
             if self.summaries:
                 fetches.update(self.trainer.summaries)
 
-            coders = self.trainer.all_coders
+            coders = self.trainer.feedables
 
         else:  # RESETTING
             fetches = {"resets": self.trainer.reset_ops}
@@ -237,7 +237,7 @@ class DelayedTrainExecutable(Executable):
             return
 
         assert self.res_losses is not None
-        self.result = ExecutionResult(
+        self._result = ExecutionResult(
             [], losses=self.res_losses,
             scalar_summaries=self.res_scal_sums,
             histogram_summaries=self.res_hist_sums,

--- a/neuralmonkey/trainers/multitask_trainer.py
+++ b/neuralmonkey/trainers/multitask_trainer.py
@@ -1,7 +1,9 @@
-from typing import List
+from typing import List, Set
 
 from typeguard import check_argument_types
 
+from neuralmonkey.model.feedable import Feedable
+from neuralmonkey.model.parameterized import Parameterized
 from neuralmonkey.runners.base_runner import Executable
 from neuralmonkey.trainers.generic_trainer import GenericTrainer
 
@@ -23,7 +25,13 @@ class MultitaskTrainer:
         self.trainer_idx = 0
 
         self.var_list = list(set.union(*[set(t.var_list) for t in trainers]))
-        self.all_coders = set.union(*[t.all_coders for t in self.trainers])
+
+        self.feedables = set()  # type: Set[Feedable]
+        self.parameterizeds = set()  # type: Set[Parameterized]
+
+        for trainer in self.trainers:
+            self.feedables |= trainer.feedables
+            self.parameterizeds |= trainer.parameterizeds
 
     def get_executable(
             self, compute_losses: bool = True, summaries: bool = True,

--- a/neuralmonkey/trainers/test_multitask_trainer.py
+++ b/neuralmonkey/trainers/test_multitask_trainer.py
@@ -51,7 +51,9 @@ class TestMultitaskTrainer(unittest.TestCase):
         trainer = MultitaskTrainer(
             [self.trainer1, self.trainer2, self.trainer1])
 
-        self.assertSetEqual(trainer.all_coders, {self.mpart, self.mpart_2})
+        self.assertSetEqual(trainer.feedables, {self.mpart, self.mpart_2})
+        self.assertSetEqual(trainer.parameterizeds, {self.mpart, self.mpart_2})
+
         self.assertSetEqual(
             set(trainer.var_list), {self.mpart.var, self.mpart_2.var})
 

--- a/tests/bpe.ini
+++ b/tests/bpe.ini
@@ -72,8 +72,12 @@ conv_features=10
 encoder_layers=2
 input_sequence=<encoder_input>
 
-[encoder_frozen]
-class=model.gradient_blocking.TemporalStatefulWithOutputView
+[encoder_output_frozen]
+class=model.gradient_blocking.StatefulView
+blocked_object=<encoder>
+
+[encoder_states_frozen]
+class=model.gradient_blocking.TemporalStatefulView
 blocked_object=<encoder>
 
 [attention]

--- a/tests/tests_run.sh
+++ b/tests/tests_run.sh
@@ -8,7 +8,7 @@ export PYTHONFAULTHANDLER=1
 bin/neuralmonkey-train tests/vocab.ini
 bin/neuralmonkey-train tests/bahdanau.ini
 NEURALMONKEY_STRICT= bin/neuralmonkey-train tests/bpe.ini
-bin/neuralmonkey-train tests/bpe.ini -s 'decoder.encoders=[<encoder_frozen>]' -s 'main.initial_variables=["tests/outputs/bpe/variables.data"]'
+bin/neuralmonkey-train tests/bpe.ini -s 'decoder.encoders=[<encoder_output_frozen>]' -s 'attention.encoder=<encoder_states_frozen>' -s 'main.initial_variables=["tests/outputs/bpe/variables.data"]'
 #bin/neuralmonkey-train tests/alignment.ini
 bin/neuralmonkey-train tests/post-edit.ini
 bin/neuralmonkey-train tests/factored.ini


### PR DESCRIPTION
Read the commit messages.

ModelPart is now a syntactic sugar class for these three abstract classes:
`Parameterized` - manages variables, name scopes, loading and saving
`Feedable` - has feed_dict, batch_size, and train_mode (in the future, may also contain some logic for creating placeholders or handling data in tf.dataset)
`GenericModelPart` - the get_dependencies function is now here and all the classes that handle something in the graph before runners and/or trainers are descendants of this class

as a bonus, this PR fixes the dependenies gradient blocking objects and provides a way of how to do 
it e.g. for adversarial gradient layers introduced in #771 