### PR TITLE
Fix computation of perplexity

### DIFF
--- a/neuralmonkey/evaluators/perplexity.py
+++ b/neuralmonkey/evaluators/perplexity.py
@@ -1,15 +1,24 @@
 # pylint: disable=too-few-public-methods, no-self-use, unused-argument
 from typing import List
 
-import numpy as np
-
 from neuralmonkey.evaluators.evaluator import Evaluator
 
 
 class PerplexityEvaluator(Evaluator[float]):
-    """Just 2 ** average the numeric output of a runner."""
+    """Just 2 ** average the numeric output of a runner.
+
+    Masked position get xent of 0. The sum of crosentropies is divided by the
+    number of non-zero numbers.
+    """
 
     def score_batch(self,
-                    hypotheses: List[float],
-                    references: List[float]) -> float:
-        return 2 ** np.mean(hypotheses)
+                    hypotheses: List[List[float]],
+                    references: List[List[float]]) -> float:
+
+        sum_of_all = sum(
+            sum(xent for xent in hyp_xent) for hyp_xent in hypotheses)
+        count_of_all = sum(
+            sum(float(xent != 0.0) for xent in hyp_xent)
+            for hyp_xent in hypotheses)
+
+        return 2 ** (sum_of_all / count_of_all)


### PR DESCRIPTION
There were two issues with the perplexity evaluator:

* it crashed during validation because the list of hypotheses consisted of batches of different length and numpy was not able to convert it to `np.array` and `np.mean` crashed
* it did not take into account masking and included padded position with xent of 0.0 into the mean