### PR TITLE
BERT: data preparation script, tests

### DIFF
--- a/neuralmonkey/decoders/sequence_labeler.py
+++ b/neuralmonkey/decoders/sequence_labeler.py
@@ -85,8 +85,8 @@ class SequenceLabeler(ModelPart):
 
     @tensor
     def output_mask(self) -> tf.Tensor:
-        return tf.where(
-            self.train_mode, self.train_mask, self.input_mask)
+        return tf.cond(
+            self.train_mode, lambda: self.train_mask, lambda: self.input_mask)
 
     @tensor
     def concatenated_inputs(self) -> tf.Tensor:

--- a/neuralmonkey/decoders/sequence_labeler.py
+++ b/neuralmonkey/decoders/sequence_labeler.py
@@ -84,11 +84,6 @@ class SequenceLabeler(ModelPart):
         return sentence_mask(self.train_targets)
 
     @tensor
-    def output_mask(self) -> tf.Tensor:
-        return tf.cond(
-            self.train_mode, lambda: self.train_mask, lambda: self.input_mask)
-
-    @tensor
     def concatenated_inputs(self) -> tf.Tensor:
         # Validate shapes first
         with tf.control_dependencies([self.input_mask]):

--- a/neuralmonkey/decoders/sequence_labeler.py
+++ b/neuralmonkey/decoders/sequence_labeler.py
@@ -130,8 +130,8 @@ class SequenceLabeler(ModelPart):
     def cost(self) -> tf.Tensor:
         # Cross entropy mean over all words in the batch
         # (could also be done as a mean over sentences)
-        return ((tf.reduce_sum(self.train_xents) + 1)
-                / (tf.reduce_sum(self.train_mask) + 1))
+        return (tf.reduce_sum(self.train_xents)
+                / (tf.reduce_sum(self.train_mask) + 1e-9))
 
     @property
     def train_loss(self) -> tf.Tensor:

--- a/neuralmonkey/decoders/sequence_labeler.py
+++ b/neuralmonkey/decoders/sequence_labeler.py
@@ -83,6 +83,13 @@ class SequenceLabeler(ModelPart):
     def train_mask(self) -> tf.Tensor:
         return sentence_mask(self.train_targets)
 
+    # TODO(tf-dataset) Uncomment this method after tf-dataset is done
+    # @tensor
+    # def output_mask(self) -> tf.Tensor:
+    #     return tf.cond(
+    #         self.train_mode, lambda: self.train_mask,
+    #         lambda: self.input_mask)
+
     @tensor
     def concatenated_inputs(self) -> tf.Tensor:
         # Validate shapes first

--- a/neuralmonkey/evaluators/perplexity.py
+++ b/neuralmonkey/evaluators/perplexity.py
@@ -21,4 +21,6 @@ class PerplexityEvaluator(Evaluator[float]):
             sum(float(xent != 0.0) for xent in hyp_xent)
             for hyp_xent in hypotheses)
 
+        if count_of_all == 0:
+            return float("nan")
         return 2 ** (sum_of_all / count_of_all)

--- a/neuralmonkey/runners/label_runner.py
+++ b/neuralmonkey/runners/label_runner.py
@@ -23,19 +23,19 @@ class LabelRunner(BaseRunner[SequenceLabeler]):
         def collect_results(self, results: List[Dict]) -> None:
             loss = results[0].get("loss", 0.)
             summed_logprobs = results[0]["label_logprobs"]
-            output_mask = results[0]["output_mask"]
+            input_mask = results[0]["input_mask"]
 
             for sess_result in results[1:]:
                 loss += sess_result.get("loss", 0.)
                 summed_logprobs = np.logaddexp(summed_logprobs,
                                                sess_result["label_logprobs"])
-                assert output_mask == sess_result["output_mask"]
+                assert input_mask == sess_result["input_mask"]
 
             argmaxes = np.argmax(summed_logprobs, axis=2)
 
             # We change all masked tokens to END_TOKEN
             argmaxes -= END_TOKEN_INDEX
-            argmaxes *= output_mask.astype(int)
+            argmaxes *= input_mask.astype(int)
             argmaxes += END_TOKEN_INDEX
 
             # transpose argmaxes because vectors_to_sentences is time-major
@@ -60,7 +60,7 @@ class LabelRunner(BaseRunner[SequenceLabeler]):
     def fetches(self) -> Dict[str, tf.Tensor]:
         return {
             "label_logprobs": self.decoder.logprobs,
-            "output_mask": self.decoder.output_mask,
+            "input_mask": self.decoder.input_mask,
             "loss": self.decoder.cost}
 
     @property

--- a/scripts/preprocess_bert.py
+++ b/scripts/preprocess_bert.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Creates training data for the BERT network training
+(noisified + masked gold predictions) using the input corpus.
+
+The masked Gold predictions use Neural Monkey's PAD_TOKEN to indicate
+tokens that should not be classified during training.
+
+We only leave `coverage` percent of symbols for classification. These
+symbols are left unchanged on input with a probability of `1 - mask_prob`.
+If they are being changed, they are replaced by the `mask_token` with a
+probability of `1 - replace_prob` and by a random vocabulary token otherwise.
+"""
+
+import argparse
+import os
+
+import numpy as np
+
+from neuralmonkey.logging import log as _log
+from neuralmonkey.vocabulary import (
+    Vocabulary, PAD_TOKEN, UNK_TOKEN, from_wordlist)
+
+
+def log(message: str, color: str = "blue") -> None:
+    _log(message, color)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input_file", type=str, default="/dev/stdin")
+    parser.add_argument("--vocabulary", type=str, required=True)
+    parser.add_argument("--output_prefix", type=str, default=None)
+    parser.add_argument("--mask_token", type=str, default=UNK_TOKEN,
+                        help="token used to mask the tokens")
+    parser.add_argument("--coverage", type=float, default=0.15,
+                        help=("percentage of tokens that should be left "
+                              "for classification during training"))
+    parser.add_argument("--mask_prob", type=float, default=0.8,
+                        help=("probability of the classified token being "
+                             "replaced by a different token on input"))
+    parser.add_argument("--replace_prob", type=float, default=0.1,
+                        help=("probability of the classified token being "
+                              "replaced by a random token instead of "
+                              "mask_token"))
+    parser.add_argument("--vocab_contains_header", type=bool, default=True)
+    parser.add_argument("--vocab_contains_frequencies",
+                        type=bool, default=True)
+    args = parser.parse_args()
+
+    assert (args.coverage <= 1 and args.coverage >= 0)
+    assert (args.mask_prob <= 1 and args.mask_prob >= 0)
+    assert (args.replace_prob <= 1 and args.replace_prob >= 0)
+
+    log("Loading vocabulary.")
+    vocabulary = from_wordlist(
+        args.vocabulary,
+        contains_header=args.vocab_contains_header,
+        contains_frequencies=args.vocab_contains_frequencies)
+
+    mask_prob = args.mask_prob
+    replace_prob = args.replace_prob
+    keep_prob = 1 - mask_prob - replace_prob
+    sample_probs = (keep_prob, mask_prob, replace_prob)
+
+    output_prefix = args.output_prefix
+    if output_prefix is None:
+        output_prefix = args.input_file
+    out_f_noise = "{}.noisy".format(output_prefix)
+    out_f_mask = "{}.mask".format(output_prefix)
+
+    out_noise_h = open(out_f_noise, "w", encoding="utf-8")
+    out_mask_h = open(out_f_mask, "w", encoding="utf-8")
+    log("Processing data.")
+    with open(args.input_file, "r", encoding="utf-8") as input_h:
+        # TODO: performance optimizations
+        for line in input_h:
+            line = line.strip().split(" ")
+            num_samples = int(args.coverage * len(line))
+            sampled_indices = np.random.choice(len(line), num_samples, False)
+
+            output_noisy = list(line)
+            output_masked = [PAD_TOKEN] * len(line)
+            for i in sampled_indices:
+                random_token = np.random.choice(vocabulary.index_to_word[4:])
+                new_token = np.random.choice(
+                    [line[i], args.mask_token, random_token], p=sample_probs)
+                output_noisy[i] = new_token
+                output_masked[i] = line[i]
+            out_noise_h.write(str(" ".join(output_noisy)) + "\n")
+            out_mask_h.write(str(" ".join(output_masked)) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/bert.ini
+++ b/tests/bert.ini
@@ -1,0 +1,103 @@
+[main]
+name="BERT LM"
+output="tests/outputs/bert"
+tf_manager=<tf_manager>
+
+train_dataset=<train_data>
+val_dataset=<val_data>
+test_datasets=[<val_data>]
+
+runners=[<runner>]
+trainer=<trainer>
+evaluation=[("xent", "source_masked", <perplexity>), ("source", "source_masked", evaluators.Accuracy)]
+
+batch_size=10
+epochs=2
+
+validation_period="10s"
+logging_period="2s"
+overwrite_output_dir=True
+
+
+[batching_scheme]
+class=dataset.BatchingScheme
+bucket_batch_sizes=[30, 25, 12, 8, 6, 5]
+bucket_boundaries=[5, 10, 15, 20, 25]
+
+[tf_manager]
+class=tf_manager.TensorFlowManager
+num_sessions=1
+num_threads=4
+
+[accuracy]
+class=evaluators.AccuracyEvaluator
+mask_symbol="<pad>"
+
+[perplexity]
+class=evaluators.PerplexityEvaluator
+name="perplexity"
+
+
+[train_data]
+class=dataset.load
+batching=<batching_scheme>
+# source_masked masks all tokens that weren't ``noisified''
+series=["source_noisy", "source_masked"]
+data=["tests/data/bert/train.pcedt.forms.noisy", "tests/data/bert/train.pcedt.forms.mask"]
+
+[val_data]
+class=dataset.load
+series=["source_noisy", "source_masked"]
+data=["tests/data/bert/val.pcedt.forms", "tests/data/bert/val.pcedt.forms"]
+batching=<batching_scheme>
+
+[vocabulary]
+class=vocabulary.from_wordlist
+path="tests/data/factored_decoder_vocab.tsv"
+
+[sequence]
+class=model.sequence.EmbeddedSequence
+vocabulary=<vocabulary>
+data_id="source_noisy"
+embedding_size=6
+scale_embeddings_by_depth=True
+max_length=20
+
+[encoder]
+class=encoders.transformer.TransformerEncoder
+name="encoder_bert"
+input_sequence=<sequence>
+ff_hidden_size=10
+depth=2
+n_heads=3
+dropout_keep_prob=0.9
+
+[labeler]
+class=decoders.sequence_labeler.EmbeddingsLabeler
+name="labeler_bert"
+encoders=[<encoder>]
+embedded_sequence=<sequence>
+data_id="source_masked"
+max_output_len=20
+dropout_keep_prob=0.5
+
+[trainer]
+class=trainers.delayed_update_trainer.DelayedUpdateTrainer
+batches_per_update=5
+l2_weight=1.0e-8
+clip_norm=1.0
+objectives=[<obj>]
+
+[obj]
+class=trainers.cross_entropy_trainer.CostObjective
+decoder=<labeler>
+
+[runner]
+class=runners.LabelRunner
+decoder=<labeler>
+output_series="source"
+
+[runner_xent]
+class=runners.XentRunner
+decoder=<labeler>
+output_series="xent"

--- a/tests/bert.ini
+++ b/tests/bert.ini
@@ -7,9 +7,9 @@ train_dataset=<train_data>
 val_dataset=<val_data>
 test_datasets=[<val_data>]
 
-runners=[<runner>]
+runners=[<runner_xent>, <runner>]
 trainer=<trainer>
-evaluation=[("xent", "source_masked", <perplexity>), ("source", "source_masked", evaluators.Accuracy)]
+evaluation=[("xent", "source_masked", <perplexity>), ("source", "source_masked", <accuracy>)]
 
 batch_size=10
 epochs=2

--- a/tests/data/bert/train.pcedt.forms.mask
+++ b/tests/data/bert/train.pcedt.forms.mask
@@ -1,0 +1,500 @@
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> nevýkonný ředitel <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> společnosti <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> byl <pad> <pad> <pad> tohoto <pad> <pad> <pad> .
+<pad> uvedli <pad> že <pad> azbestu <pad> <pad> <pad> <pad> <pad> <pad> <pad> Kent <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> azbestové <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> neobvykle <pad> <pad> že i <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> se <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> společnosti <pad> <pad> <pad> <pad> <pad> <pad> <pad> Kent <pad> <pad> <pad> <pad> <pad> <pad> <pad> cigaret <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> než <pad> <pad> <pad> <pad> výsledky <pad> <pad> <pad> <pad> <pad> New England <pad> <pad> <pad> <pad> <pad> <pad> <pad> který <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> Tohle <pad> <pad> <pad> <pad>
+<pad> o <pad> <pad> <pad> <pad> <pad> <pad> <pad> tom <pad> <pad> <pad> <pad> <pad> mít <pad> <pad> <pad> <pad>
+<pad> <pad> našich <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> dělníky <pad> <pad> <pad> <pad> <pad> <pad> <pad> kuřácích <pad> <pad> <pad> .
+<pad> <pad> <pad> použitelné informace <pad> <pad> <pad> <pad> <pad> uživatelé <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> institutu <pad> <pad> <pad> <pad>
+<pad> . <pad> <pad> <pad> <pad> <pad> <pad> <pad> pro <pad> <pad> <pad> z <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> azbest <pad> <pad> <pad> <pad> <pad> <pad> <pad> " <pad> <pad> množstvích <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> jiným <pad> filtru <pad>
+Společnost <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> cigaret <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> více <pad> <pad> očekávaného <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> související <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> mnohem <pad> <pad> <pad> <pad> očekávalo .
+" <pad> <pad> <pad> pro <pad> <pad> <pad> <pad> <pad> související <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> mezi <pad> <pad> <pad> <pad> <pad> Grontonu v <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> všeho <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> smlouvu na <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> , <pad> <pad> pravděpodobně <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> ve většině <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> mála průmyslových <pad> <pad> <pad> <pad> <pad> <pad> normy <pad> <pad> <pad> <pad> <pad> jako <pad> <pad> <pad> <pad> <pad> <pad> jako <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> vlákna <pad> <pad> <pad> tělo <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> ochranu <pad> <pad> <pad> <pad> <pad> všech <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> mimo <pad> téměř <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Kent <pad> 160 <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> obzvlášť <pad> <pad>
+<pad> <pad> postupu <pad> <pad> <pad> <pad> vysypali <pad> <pad> <pad> <pad> <pad> <pad> velkého <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> promíchali <pad>
+<pad> <pad> " <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> nad <pad> továrny <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> Není <pad> <pad> <pad> se <pad> <pad> <pad> <pad> a <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> řekl <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> události odehrály <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> pracovní <pad> <pad>
+<pad> jeden <pad> <pad> <pad> <pad> <pad> <pad> <pad> další <pad> <pad> sazeb <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> sedmidenní <pad> <pad> 400 <pad> <pad> <pad> společností <pad> <pad> <pad> <pad> <pad> <pad> <pad> zlomek <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+Složené <pad> <pad> <pad> <pad> <pad> budou <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> splatnost <pad> <pad> <pad> <pad> <pad> <pad> <pad> na <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> ' <pad> <pad> <pad> <pad> <pad> <pad>
+Delší <pad> jsou <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> považovány za <pad> zvyšujících <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+Průměrná <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> silnější <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> dosáhla <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> říká <pad> <pad> <pad> <pad> <pad> předtím <pad> <pad> spadnou <pad> <pad> <pad> vyskočit <pad> <pad> <pad> <pad> <pad> <pad> úrokových <pad> <pad>
+<pad> výnosy <pad> šestiměsíčních <pad> <pad> obligací <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> hotovosti <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> posledního <pad> <pad> <pad> miliardy <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> porážejí <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> splatnosti <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Dollar <pad> <pad> <pad> <pad> <pad> <pad> <pad> 9.37 <pad> <pad> <pad> <pad> <pad> <pad> 9.45 <pad> <pad> <pad> týdnu <pad>
+<pad> <pad> <pad> do <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> výnosy vyhání <pad> <pad>
+<pad> sedmidenní <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> 8.12 <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> na <pad> <pad> <pad> <pad> třicetidenní <pad> <pad> <pad> <pad> <pad> <pad> na <pad> <pad> <pad> <pad>
+<pad> . <pad> <pad> Bolduc <pad> <pad> <pad> <pad> . <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> bývalého <pad> <pad> W <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> sedmi <pad> v <pad> <pad> <pad> <pad> <pad>
+<pad> Pacific <pad> <pad> <pad> . <pad> <pad> <pad> <pad> <pad> její <pad> <pad> <pad> <pad> <pad> <pad> <pad> za <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> povolení <pad> <pad> <pad> <pad> transakce <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> uvedla <pad> <pad> <pad> <pad> <pad> & <pad> <pad> <pad> <pad> <pad> <pad> <pad> Operations <pad> <pad> <pad> . <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> státní <pad> <pad> <pad> <pad> <pad> <pad> strojního <pad> <pad>
+<pad> Bailey <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> systémy <pad>
+<pad> <pad> <pad> <pad> a <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> vláda <pad> <pad> <pad> <pad> <pad> papírů <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> Kongres <pad> <pad> <pad> <pad> <pad> <pad> žádné <pad> <pad> <pad>
+Vládní <pad> <pad> <pad> <pad> <pad> <pad> <pad> z <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> je <pad> <pad> <pad> <pad> <pad> <pad> z <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> ale jednání <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> financí <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> listopadu , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> Vitulli <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> prodejní a <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> služby <pad> <pad> <pad> <pad> společnosti <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Corp <pad>
+<pad> <pad> <pad> vedoucím <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> do <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Raton či <pad> <pad> <pad>
+<pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> podzimní zasedání <pad> <pad> <pad> <pad> <pad> <pad> <pad> městě <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> rockové <pad> <pad> <pad> jako <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> 125 <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> a že <pad> to <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> je <pad> <pad> <pad> Maytag <pad> <pad> <pad> <pad> známými <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> předkrmu <pad> <pad> <pad> pracovníci <pad> <pad> <pad> starostovi <pad> <pad> <pad> <pad> <pad> <pad> <pad> strávili <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> jejich manželek <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> provozem <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> hosty <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> se <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> běžným <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , posádky <pad> <pad> <pad> oficiálního <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+Po <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> a <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> nejsou žádní <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> jednoho <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> v <pad> <pad> <pad> <pad> aby <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> a <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> Roof je <pad> <pad> <pad> z <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> polevou <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> pracovníci <pad> <pad> vestoje .
+Víc <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> červených koberců <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> se <pad> <pad> <pad> <pad> <pad> Boca <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> zaznamenala <pad> <pad> <pad> říjnu <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> ekonomickou <pad> <pad>
+Předběžné <pad> <pad> <pad> <pad> <pad> ukázaly v <pad> <pad> <pad> <pad> bilance <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> se <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> 0.7 <pad> <pad> oproti <pad> <pad> <pad> <pad> <pad> se <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> roku <pad> <pad> <pad> <pad> zastavil <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> vývoz <pad> <pad> <pad> <pad> <pad> <pad> cílem <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> letos <pad> <pad> <pad> přebytky <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> ledna <pad> <pad> <pad> <pad> <pad> <pad> <pad> roku <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> dolarů <pad>
+<pad> <pad> <pad> <pad> <pad> nárůstu <pad> <pad> <pad> <pad>
+<pad> Newsweek <pad> <pad> <pad> <pad> <pad> <pad> <pad> konkurenčním <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> pobídkový <pad> <pad> inzerenty <pad>
+Nový <pad> inzerce <pad> <pad> <pad> jednotky <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+Plány <pad> <pad> poskytují inzerentům <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , se <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Time <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Zuckermana <pad>
+<pad> <pad> <pad> časopisu <pad> <pad> <pad> <pad> , <pad> <pad> <pad> se <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> bude <pad> <pad> <pad> <pad>
+<pad> Time <pad> <pad> <pad> snížil <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> aniž by <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> počtem prodaných <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> % <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> sazebník <pad> <pad> 1990 <pad> <pad> <pad>
+<pad> <pad> <pad> , <pad> představí <pad> <pad> <pad> <pad> <pad> <pad> <pad> uděluje <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> stránkovými <pad> <pad> <pad> <pad> <pad> jejichž výdaje <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> pokud <pad> <pad> <pad> <pad> 325000 <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> by <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> prvních <pad> měsících <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> časopisu <pad> <pad> <pad> roku <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> tom <pad> <pad> dobře <pad> <pad> řekl <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> i bez nadměrného <pad> <pad> <pad> <pad> jako <pad> <pad> <pad> <pad> <pad>
+Avšak <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> v <pad> <pad> <pad>
+<pad> <pad> <pad> ověřování <pad> <pad> <pad> <pad> <pad> <pad> největší týdeník <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> náklad <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> období loňského <pad> <pad>
+Prodaný <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> na <pad> <pad> <pad>
+<pad> New <pad> <pad> <pad> vycouvala z <pad> <pad> <pad> <pad> <pad> <pad> <pad> . <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> aby <pad> <pad> <pad> <pad>
+<pad> tah <pad> <pad> <pad> <pad> PS <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> podle <pad> <pad> <pad> <pad> <pad> , <pad> <pad> zbývající externí <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> Electric <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> PS of <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> daleko <pad> <pad> <pad> <pad> <pad> nabídnuté <pad> United <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> sídlí <pad> <pad> <pad> <pad> <pad> Connecticut <pad> společnost <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> of <pad> Hampshire <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> svůj <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> England <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> z <pad> <pad> kdyby <pad> <pad> <pad> <pad> <pad> předpovědi <pad> <pad> <pad> <pad> <pad> <pad> Hampshire <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> by <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> a <pad> <pad> zdály <pad> <pad> <pad> .
+<pad> <pad> těžké <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> společnost <pad> England <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> , <pad> <pad> <pad> je <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> z nejvyšších <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> prostě <pad> <pad> <pad> faktorů <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+Wilbur <pad> <pad> <pad> ze <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> společnosti <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> 4.8 <pad> <pad> <pad> <pad> oproti <pad> <pad> <pad> <pad> <pad> dvěma <pad> <pad> <pad> <pad> <pad> se státními <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> dodal <pad>
+<pad> <pad> <pad> <pad> energetiky <pad> <pad> <pad> <pad> Northeast <pad> <pad> <pad> <pad> společnosti <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> , <pad> <pad> <pad> <pad> znovu <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> komise <pad> <pad> energetiky <pad> <pad> <pad> <pad> <pad> do <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> New <pad> <pad> <pad> <pad> obchodování na <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Toys <pad> <pad> <pad> <pad> <pad> . , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> společnosti <pad> Banking <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> radě nahradí <pad> <pad> <pad> <pad> <pad> <pad> viceprezidenta <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> bylo <pad> <pad> <pad> <pad> <pad> dolarů <pad> <pad> <pad> <pad> <pad> <pad> nezákonným <pad> <pad> <pad> <pad> náklady <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> částka <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> státního <pad> místního <pad> veřejných služeb <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> vrátit v <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , včetně <pad> <pad> <pad> <pad> <pad> <pad> <pad> během <pad> <pad> <pad> <pad>
+<pad> Curry nařídil <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> že <pad> <pad> <pad> <pad> jiné <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> . <pad> nesmí <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+Společnost <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> proti <pad> <pad> <pad> <pad> <pad> <pad> nařízení <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> 31 . <pad> <pad> <pad> <pad>
+Společnost <pad> <pad> <pad> <pad> <pad> nařízení <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> o <pad> <pad> <pad> <pad> <pad>
+<pad> rok 1988 <pad> <pad> Commonwealth <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> dvou <pad> zákazníků <pad> jejichž <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> změnily <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> cenných <pad> <pad> <pad> Comonwealth <pad> <pad> <pad> <pad> <pad> <pad> uzavřela <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> ve <pad> <pad> <pad> <pad> 2.5 <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+Ve <pad> <pad> <pad> <pad> <pad> <pad> Illinoiská <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> aby elektrárnu <pad> <pad>
+<pad> <pad> soudy <pad> <pad> <pad> <pad> proti <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> společnosti <pad> Edison <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> veřejných <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> nárokem <pad> <pad> od <pad> <pad> <pad>
+<pad> <pad> komise <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> na <pad> elektrárny <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> komise <pad> 55 <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> Curry <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> / <pad> poplatků <pad> <pad> sazbou <pad> <pad> <pad> odvolací <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> že <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> jadernou <pad> , <pad> <pad> <pad> společnosti <pad> <pad> <pad>
+<pad> Commonwealth <pad> <pad> <pad> zvýšených <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> očekáváno <pad> <pad> <pad> <pad>
+Minulý <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> LaSalle <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> s <pad> <pad> <pad> <pad> <pad> na <pad> 500004 kusů <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> zářijovém 12 <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> března <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> 0.4 <pad> <pad>
+<pad> <pad> <pad> vzrostl <pad> <pad> % <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> spotřební <pad> <pad> , <pad> <pad> <pad> <pad> více <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Texas <pad> Inc <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Koreji <pad>
+Společnost <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> vyhovět <pad> <pad> <pad> <pad> <pad> poptávce <pad> <pad> <pad> <pad> Jižní <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> a <pad> <pad> <pad>
+Zdá <pad> <pad> <pad> <pad> odtržené <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> obchodu <pad> superpočítači <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> a <pad> <pad> <pad> <pad> <pad>
+<pad> vývoj <pad> <pad> této <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> regulaci <pad> cenných <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> financování , které <pad> <pad> <pad> <pad> <pad> <pad> <pad> nebo <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> že <pad> <pad> <pad> pracuje <pad> projektu <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> rok <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> na <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> s <pad> perspektivními <pad> <pad>
+Třebaže <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> když <pad> <pad> <pad> <pad> odtržení <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad>
+<pad> Neměli <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , finanční <pad> <pad> <pad> <pad> <pad>
+" <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Cray <pad> <pad> <pad> a <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> Research <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> předpovídá <pad> dalších <pad> <pad> <pad> <pad> <pad> financování <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> scénářem <pad>
+<pad> <pad> <pad> <pad> způsobilo <pad> <pad> <pad> <pad> <pad> Research <pad> <pad> při kompozitním <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> společnosti <pad> <pad> <pad> svůj <pad> <pad> <pad> <pad> <pad> milionu <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> být <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> řekl <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> z <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> kapitálem <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> Seymour <pad> <pad> <pad> <pad> <pad> <pad> "
+Kromě <pad> <pad> <pad> další <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> pro <pad> <pad> <pad> <pad> <pad>
+Dokumenty <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , jako <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> obsahovat <pad> <pad> <pad> dvakrát <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+Společnost Cray <pad> <pad> <pad> <pad> <pad> konkurenci <pad> <pad> <pad> <pad> <pad> <pad> Research <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> uvede <pad> <pad> počítač <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> 3 <pad>
+<pad> společnost <pad> rovněž <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Velkou <pad> <pad> <pad> <pad> <pad> <pad> <pad> NEC <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> superpočítače <pad> <pad> mezi <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> počítače <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> společnosti <pad> <pad> , <pad> <pad> <pad> <pad> to <pad> <pad> <pad> <pad> <pad> <pad> <pad> do <pad> týdnů <pad>
+<pad> <pad> <pad> <pad> <pad> stanovena <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> Cray <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> počáteční <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> za <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> asi <pad> <pad> <pad> v <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> - <pad> <pad> <pad> <pad> výdělky <pad> <pad> Research <pad>
+<pad> <pad> <pad> <pad> <pad> proč <pad> <pad> <pad> <pad> <pad> <pad>
+Bez <pad> na <pad> <pad> <pad> počítače <pad> <pad> <pad> <pad> společnost <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> Computer <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> již existovala <pad>
+<pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> tyto <pad> <pad> , <pad> <pad> pro <pad> <pad> z <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> společností <pad> <pad> <pad>
+<pad> <pad> tomu <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> minulý <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> Cray <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> ve <pad> <pad> <pad> , 47 <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> 40 let <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> viceprezident <pad> hardware <pad>
+<pad> <pad> ze <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> očekává , <pad> <pad> <pad> 450 <pad> <pad>
+<pad> R <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> obě <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> generálnímu <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> , <pad> jmenován <pad> <pad> <pad> <pad>
+<pad> byl <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> A <pad> Hatche <pad> <pad> prezidenta <pad> <pad> <pad> <pad>
+<pad> <pad> viceprezidentem <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> Tassinari <pad> <pad> <pad> <pad> <pad> <pad> <pad> viceprezidentem <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad>
+<pad> <pad> jistý <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Saúdskou <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> amerických patentů <pad> <pad> <pad> a dalších <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> Čína <pad> <pad> , <pad> <pad> <pad> <pad> Mexiko <pad> <pad> <pad> <pad> <pad> šetření <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> obchodního zákona <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> obchodování a <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+Carla <pad> uvedla <pad> <pad> <pad> <pad> <pad> zemí <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> " <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> existuje <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> vlastnictví <pad> <pad> obchodujícím <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> porušující <pad> <pad> <pad> <pad>
+<pad> <pad> vyjednavači <pad> <pad> <pad> <pad> <pad> nedostatečnou <pad> <pad> <pad> <pad> <pad> mohly <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> vědce <pad> autory <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> dané <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> zabývající <pad> <pad> <pad> <pad> speciálních <pad> <pad> <pad> <pad> žalobců <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> postupy <pad> <pad> <pad> <pad> pomohl <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> v <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> právech , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> promítání <pad> filmů <pad>
+<pad> <pad> by <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> za promítání <pad> <pad> <pad>
+<pad> se <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> bude <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> počítačový <pad> <pad> literární díla <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> tyto <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> zemí <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> zemí <pad>
+<pad> <pad> <pad> včetně <pad> , <pad> <pad> <pad> <pad> <pad> a <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> patentů <pad> <pad> <pad> <pad> <pad> za <pad> <pad> <pad> <pad> <pad> <pad> <pad> " <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> případy <pad> <pad> <pad> <pad> řekl <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> a <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> s <pad> <pad> <pad> <pad> <pad> duševního <pad> <pad> <pad> vlastním <pad> země <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> americké <pad> <pad> funguje <pad> <pad> <pad> <pad>
+<pad> , <pad> <pad> <pad> <pad> <pad> , <pad> budou <pad> <pad> <pad> <pad> <pad> <pad> <pad> být <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> vývojem <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> "
+<pad> <pad> <pad> <pad> ačkoli <pad> <pad> <pad> <pad> <pad> <pad> <pad> na <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+Obchodní <pad> z <pad> <pad> <pad> Carle <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> natolik závažné <pad> aby <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> prohlásila <pad> <pad> <pad> <pad> banky <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> ve výši <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> ekonomiky <pad> <pad> je <pad> <pad> <pad> první <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> latinskoamerická <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> dluhu <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> snaží <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> dluhu <pad> <pad> prohlásil <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Davidem <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> York <pad> <pad> <pad> <pad> s <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> Carlose <pad> <pad> <pad> <pad> <pad> <pad> <pad> . <pad> <pad> <pad> <pad> <pad> významné <pad> <pad> <pad> <pad> <pad> <pad> způsob , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+Neřekl <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> stého <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> z <pad> <pad> <pad> <pad> <pad> <pad> <pad> americké <pad> historie <pad> <pad>
+<pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> trh <pad> <pad> <pad> <pad>
+<pad> <pad> roce <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+Počítače <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> vlastní <pad> <pad> <pad> <pad> <pad> data <pad> <pad> <pad>
+Apple <pad> však znamenal <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Club <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> 1298 <pad> <pad>
+<pad> <pad> tyto <pad> <pad> počítače <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> stolních <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> centrální <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> - <pad> <pad> <pad> <pad> <pad> <pad> <pad> jako <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> v <pad> <pad> dvou <pad> dat <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> x <pad> <pad> <pad> <pad> <pad> <pad> x <pad> <pad> <pad> <pad> z <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> počítačů <pad>
+<pad> <pad> <pad> vyvinuli <pad> <pad> a <pad> <pad> <pad> jazykově <pad> <pad> <pad> <pad> <pad> <pad> <pad> Gates <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Technology <pad> <pad> <pad> <pad> <pad> <pad> diskovou <pad> <pad> PC <pad>
+<pad> <pad> <pad> <pad> Heatherington <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> telefon <pad>
+Společnost <pad> , <pad> výrobce <pad> <pad> <pad> <pad> <pad> svůj <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> osobních počítačů <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> F <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Inc <pad> získala <pad> <pad> <pad> <pad> <pad> Kalipharma <pad> <pad>
+Společnost <pad> <pad> farmaceutický <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> uvedla <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> hlasovacím <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> vlastnictvím <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> s <pad> <pad> <pad> <pad> .
+<pad> ropy <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> asi <pad> <pad> <pad> <pad> <pad> <pad> Whiting <pad> <pad> <pad> pěti <pad> <pad> <pad> <pad> <pad> <pad> <pad> začít <pad> těžbou <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> . <pad> <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> provozují <pad> <pad> v <pad> <pad> <pad> <pad>
+<pad> <pad> uvedla <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> denně <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> 21 <pad> <pad> <pad>
+<pad> <pad> <pad> pěti <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> Dolphin začnou <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Seahorse <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> Esso <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> co <pad> <pad> <pad> v <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> daně <pad>
+Společnost <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> 10.2 <pad> <pad> <pad> <pad> prezidentem <pad> <pad> R <pad> <pad> <pad> dalšími <pad> <pad>
+<pad> <pad> <pad> <pad> . P <pad> Scherer <pad> <pad> <pad> <pad> Lehman <pad> <pad> v <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> Optical <pad> <pad> <pad> <pad> <pad>
+<pad> dům uvedl <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> typů <pad> <pad> <pad> <pad> vyráběny <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> a <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> změny <pad> generalizovaném <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> hodinek <pad> <pad>
+Společnost <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , spadajících <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> prohlásil , <pad> <pad> prezident <pad> <pad> <pad> <pad> <pad> <pad> <pad> 18 <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> hodinek <pad> <pad> <pad> na <pad> <pad> <pad> <pad>
+<pad> <pad> je <pad> <pad> <pad> <pad> <pad> <pad> , včetně <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> v <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> hlavními <pad> <pad> které <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+Podle <pad> <pad> <pad> <pad> <pad> Hillsové <pad> <pad> <pad> <pad> <pad> <pad> teď <pad> splňovat <pad> <pad> <pad> <pad> cla <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> milionu <pad> <pad> <pad> <pad> <pad> malá <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> Magna <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> výrobci <pad> součástí <pad> <pad> <pad> <pad> , <pad> <pad> .
+<pad> <pad> <pad> <pad> na <pad> <pad> <pad> <pad> <pad> <pad> kapitálu <pad> <pad> <pad> <pad> dosažena <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> současné <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> společnosti <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> začíná <pad> průmysl <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> provozního <pad> <pad> <pad> růstu <pad> <pad>
+<pad> <pad> snížila nedávno své <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> kanadského <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+Na <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> nárůstem <pad> <pad> <pad> <pad> na <pad> <pad> <pad> <pad>
+<pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> post <pad> <pad> <pad> <pad> <pad> <pad> o <pad> <pad> <pad> <pad> <pad>
+Analytici <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> společnosti <pad>
+<pad> <pad> že <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> že <pad> <pad> <pad> <pad> <pad> <pad> asistence <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> McAlpine <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> McAlpine <pad> <pad> <pad> <pad> <pad> kariéře <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> klientů <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> britské <pad> společnosti .
+<pad> <pad> <pad> sami <pad> dva <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> v <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> asociace <pad>
+Tyto <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> řekl předseda <pad> Fannie <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> , <pad> <pad> <pad> <pad> <pad> <pad> bylo <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> Hongkongu <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> po <pad> <pad> <pad> <pad> <pad> <pad> <pad> v <pad> 570 <pad> <pad> <pad>
+<pad> fond <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+Dva nejnovější <pad> <pad> <pad> <pad> společnostmi <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> jeden <pad> <pad> s <pad> <pad> a <pad> <pad> s <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> papíry mohou <pad> <pad> předčasně , <pad> <pad> <pad> <pad> <pad> a <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> platby na <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> že <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Maxwell <pad> se staly <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> prostředky <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> cenných papírech <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> se <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> když <pad> <pad> <pad> <pad> <pad> <pad> <pad> společnosti <pad> Mae <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> . <pad> <pad> <pad> <pad> <pad> <pad> byl <pad> <pad> <pad> <pad> <pad> <pad> <pad> byla <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> oznámila <pad> <pad> <pad> <pad> konkurzního <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> společnost <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> reorganizace <pad> do <pad> . <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> 11 federálního <pad> <pad> <pad> <pad> <pad> <pad> soudní <pad> <pad> <pad> <pad> <pad> <pad> <pad> kdy <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> p <pad> A <pad> <pad> <pad> <pad> <pad> <pad> jednotku <pad> <pad> <pad> <pad> V <pad> <pad> nabídku <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> oběhu <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> dnešním <pad> <pad> <pad> Journal <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> 72 <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> oznámené smlouvy <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> rezervy <pad> <pad> <pad> <pad> měn a <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> 1.82 <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> celková <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> intenzivní intervence <pad> <pad> na <pad> <pad> <pad> <pad> <pad> června <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+Toto <pad> <pad> <pad> <pad> <pad> <pad> <pad> zahraničních <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> investiční <pad> <pad> <pad> <pad> <pad> <pad> Wall <pad> <pad> <pad> <pad> uzavřených <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> . <pad> zabývající <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> alespoň <pad> <pad> zemí <pad> což <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+Dostihová <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> bude <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> poprvé , <pad> hlava <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad>
+<pad> <pad> <pad> možné <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> poznamenává <pad> <pad> <pad> řídící <pad> ve <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> ve <pad> <pad> letech , <pad> <pad> <pad> <pad> <pad> staly <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> 1929 <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> je <pad> <pad> <pad> <pad> fondy <pad> <pad> <pad> <pad> <pad> <pad> <pad> počet <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+Díky <pad> <pad> <pad> <pad> <pad> zemí <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> či <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> aktivech <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> " <pad> , dříve <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> k <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Upham <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> velmi <pad> <pad> <pad>
+Soukromí <pad> <pad> <pad> <pad> <pad> <pad> odvracejí a <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> rozhazují <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> často <pad> investory <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> mnohé <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad>
+Fondy <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> položit <pad>
+Další <pad> <pad> <pad> <pad> <pad> <pad> mají <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> téměř <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> o <pad> <pad> <pad> Španělský <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> roce <pad> <pad> <pad> většiny <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> kolem <pad> <pad> <pad> <pad> <pad> tím <pad> <pad> <pad> <pad> <pad> <pad> <pad> s <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> a <pad> <pad> loňska <pad> <pad> <pad> <pad> více <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> při <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> fondů <pad> letos <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> pravděpodobně vyplatí <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> uzavřených <pad> <pad> investory <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> vylétly <pad> <pad> <pad> <pad> <pad> <pad> <pad> k <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> spjatou <pad> evropskou <pad> <pad> <pad> <pad> 1992 <pad>
+I <pad> <pad> fondů <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> " <pad> <pad> <pad> <pad> Smith <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> .
+<pad> mnohým <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> odolní vůči <pad> vyšších <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> tyto <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> " <pad> <pad> <pad>
+Tak <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> fondů <pad> <pad>
+<pad> <pad> <pad> že <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> fondech <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> obchodovaných v <pad> <pad>
+<pad> si <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+Lidem <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> ze společnosti <pad> <pad> " <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> večírek <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> zahraničních <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> dluhu <pad> <pad> <pad> milionů <pad> <pad> <pad> <pad> <pad> dluží <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> pro <pad> sovětských <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> Sověty <pad> mluvčí <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> se <pad> <pad> .
+<pad> <pad> <pad> <pad> americké <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> v <pad> <pad> <pad>
+Tato <pad> <pad> <pad> <pad> <pad> záležitosti <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> by byla <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> 188 <pad> dolarů <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> se <pad> <pad> <pad> <pad> <pad> komunisté <pad>
+Podle Johnsonova <pad> <pad> <pad> <pad> <pad> <pad> . <pad> <pad> <pad> <pad> <pad> <pad> pro <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> pokud <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> jedné <pad> <pad> <pad> <pad>
+<pad> <pad> v <pad> <pad> <pad> z <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> před <pad> <pad> <pad> klíčové <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> legislativní <pad> <pad> peněz <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> z <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> války <pad>
+Při <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> že objednávky <pad> <pad> a <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+Národní <pad> <pad> <pad> <pad> <pad> <pad> <pad> že <pad> <pad> <pad> <pad> na <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> je <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> poporostl <pad> <pad> 46 <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> čtyřměsíčním <pad> <pad> <pad>
+<pad> obchodu <pad> <pad> <pad> <pad> továrny v <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> ve <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> nedošlo <pad> 59.6 <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> by <pad> <pad> <pad> <pad> <pad>
+<pad> zvláštní <pad> <pad> <pad> <pad> že <pad> <pad> <pad> <pad> <pad> míře <pad> <pad> <pad> <pad> <pad> <pad> oproti <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> stouply <pad>
+<pad> <pad> <pad> zprávách <pad> upravena <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> nebyly <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> Mayland <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> ztenčovat <pad>
+<pad> úrokových <pad> <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> " <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> - <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> Rady <pad> <pad> <pad> <pad>
+<pad> <pad> ekonomů <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> nevyváženost <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+Například <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> , že <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> zásoby <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , <pad> je <pad> <pad> <pad> <pad> 1987 <pad>
+<pad> <pad> <pad> scénáři ' <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+" <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+Hladké <pad> <pad> <pad> ekonomiky <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> spotřeby - <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> 109.73 <pad> dolarů po <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+Objednávky <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> miliardy <pad> <pad> <pad> <pad> nárůstu <pad> <pad> <pad> <pad>
+<pad> předtím <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> o <pad> <pad> <pad>
+<pad> <pad> <pad> o <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> srpnu <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> od <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> % <pad> <pad> <pad> <pad> <pad> což <pad> <pad> <pad> <pad> kapitálových <pad> <pad> <pad> obrany <pad>
+<pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+Ve <pad> <pad> <pad> <pad> <pad> uvedlo <pad> <pad> <pad> že <pad> <pad> <pad> <pad> <pad> <pad> polovinu všech <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> Asociace <pad> <pad> <pad> <pad> <pad> že <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> domů <pad> <pad> <pad> nejdříve <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> soukromou <pad> <pad> klesly <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> přičemž <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> výdaje <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> přepočtu <pad> <pad> <pad> <pad> <pad> <pad> na <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> roku <pad> <pad> <pad> <pad> <pad> <pad> <pad> % <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> W . Dodge <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+Zpráva <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> zakázky <pad> <pad> jsou <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> skupina <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> ekonomiku <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Inc . <pad> <pad> <pad> státě <pad> <pad>
+<pad> <pad> že <pad> <pad> <pad> <pad> <pad> <pad> předpověď <pad> <pad> <pad> by <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> poskytla <pad> <pad> <pad> <pad> <pad> <pad> se <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> září <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> uvedlo <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> manažerů z <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> pod <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , klesly <pad>
+<pad> <pad> ještě <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> že <pad> <pad> <pad> <pad> <pad> <pad> než <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> inflačních <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> než <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> zvedat .
+<pad> <pad> <pad> <pad> <pad> na <pad> od <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> z <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> který <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> dovoz <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> říjnu a 12 <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> z jednoho <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> snižují nebo <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> jen <pad> tucet <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> mléko <pad> <pad> <pad>
+" <pad> <pad> <pad> <pad> <pad> taková <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> výrobci <pad> <pad> <pad> <pad> <pad> mléka <pad>
+Obvinili z <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> článku <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> stavebních <pad> <pad> miliardách <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> jsou <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Wild <pad> Chase <pad> <pad> na <pad> <pad> <pad> <pad> Harukiho <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> ročníků <pad> <pad> <pad> <pad> <pad> společného <pad>
+<pad> <pad> <pad> <pad> do <pad> <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> Dogs <pad> <pad> <pad> <pad> <pad> <pad> B <pad> <pad> <pad> <pad> <pad> epizody <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Harpovi <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> rozbitými <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> onou upjatou <pad> <pad> <pad> amerických <pad> <pad>
+Je <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> do <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> Hon <pad> <pad> <pad> ) <pad> <pad> <pad> <pad> poselství <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> že <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> nás <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> " A <pad> <pad> <pad> <pad> <pad> <pad> <pad> ovci <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> a <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> příkaz <pad> <pad> kriminálníka s <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> ovci <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> , jejíž <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> který <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , hrubě <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> jiného <pad>
+<pad> Murakami <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> " <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> se <pad> <pad> vydání <pad> <pad> <pad> <pad> <pad> prodalo <pad> než <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> jedním <pad> <pad> <pad> spisovatelů <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> japonské <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> jazykem <pad> <pad> <pad> obvykle <pad> <pad> <pad> <pad> <pad> <pad>
+V <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> wa <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> baseballu <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> " <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> ctností <pad> <pad> <pad> <pad> " <pad>
+" <pad> <pad> <pad> <pad> <pad> <pad> duch <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> jako <pad> průměrný <pad> <pad> <pad> <pad>
+Průzkumy <pad> <pad> <pad> <pad> <pad> Tatsunoriho <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> symbol <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> je <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> chybné <pad> pomocníkům na <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> ztráty <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> přísný <pad> chování <pad> <pad> <pad> <pad> <pad> například <pad> <pad> <pad> musí <pad> <pad> <pad> nosit <pad> <pad>
+<pad> <pad> Gotta Have <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> často <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> v <pad> <pad> <pad> <pad> .
+<pad> <pad> obrovské <pad> <pad> <pad> <pad> <pad> <pad> to <pad> <pad> se vztyčí <pad> <pad> <pad> <pad> se <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> ( <pad> <pad> <pad> <pad> <pad> <pad> <pad> 228 <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+Je <pad> <pad> <pad> <pad> <pad> <pad> <pad> na stáži <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> ale <pad> <pad> <pad> občas <pad> kousavých <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> těch <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , <pad> dotěrným <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> černého <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> ze <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> s <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> generálním <pad> <pad> <pad> <pad> že společnost Sony <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> přidělit <pad> nějakou <pad> <pad>
+To <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> z ekonomiky <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> neuvěřitelně <pad> <pad>
+<pad> <pad> <pad> se <pad> <pad> <pad> amerických učebnic <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , když <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> hanba <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> přiučil <pad> <pad> <pad> <pad> <pad> <pad> pan <pad> <pad> <pad>
+Paní <pad> <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> se <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> požaduje <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> před <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> že <pad> <pad> soukromé <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> povoleno <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> veřejných <pad> <pad> <pad> a <pad> <pad> rychlého <pad> <pad>
+<pad> <pad> <pad> <pad> Zaharah <pad> <pad> <pad> ministra <pad> <pad> <pad> <pad> " Týden <pad> kouření <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad>
+V <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> odstranili <pad> <pad> <pad> tabule <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> trh <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> na <pad> <pad> <pad> <pad> <pad>
+<pad> průzkum <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> vypracovaná <pad> <pad> <pad> <pad> <pad> <pad> <pad> , že <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> než <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> zákazníků <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Japonsku <pad> <pad> <pad> <pad> <pad> třetina <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> jsou <pad> ve <pad> <pad> <pad> <pad> <pad> <pad> USA <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> a <pad> <pad> <pad> v <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> na <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Světové <pad> <pad> <pad> <pad> <pad> za <pad> roky <pad>
+<pad> <pad> <pad> <pad> <pad> do <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> hotelu Central Plaza <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> za <pad> <pad> <pad> <pad>
+Současný <pad> <pad> <pad> obavy <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> zaslal <pad> <pad> Mezinárodního <pad> <pad> s <pad> <pad> <pad> <pad> <pad> <pad> přijetí <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> 1979 <pad> <pad> žádost <pad> obnovena <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> zapojit <pad> <pad> <pad> <pad> <pad> v <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Světové <pad> <pad> <pad> .
+<pad> <pad> ' <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> stal <pad> <pad> <pad> <pad> který se <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> provedení <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> dosud <pad> <pad> <pad> <pad> nebyla <pad> <pad> , <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> dobu <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> ze zahraničí <pad>
+<pad> <pad> <pad> <pad> domácností <pad> elektřinu <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> tisková <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> s <pad> <pad> <pad> <pad> <pad> <pad> <pad> .
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Polskem , že <pad> <pad> <pad> varšavské <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> vítězství ekologické <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> rakouské <pad> <pad>
+<pad> přehrada <pad> <pad> <pad> <pad> další <pad> <pad> <pad> <pad> nacházející <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> Miklose <pad> <pad> aby <pad> <pad> <pad> <pad> <pad> <pad> <pad> , <pad> <pad> <pad> <pad> <pad> <pad> požadována <pad>
+<pad> <pad> <pad> <pad> řekl <pad> že <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> i <pad> <pad> <pad>
+<pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad> smlouva <pad> <pad> <pad> <pad> dodržena <pad> mohlo <pad> <pad> <pad> <pad> <pad> <pad> <pad> <pad>

--- a/tests/data/bert/train.pcedt.forms.noisy
+++ b/tests/data/bert/train.pcedt.forms.noisy
@@ -1,0 +1,500 @@
+Jednašedesátiletý Pierre Vinken se připojí ke správní radě jako <unk> <unk> dne 29 . listopadu .
+Vinken je prezidentem <unk> Elsevier N . V . , holandské vydavatelské skupiny <unk>
+Pětapadesátiletý Rudolf Agnew , bývalý předseda společnosti Consolidated Gold Fields PLC , <unk> jmenován nevýkonným ředitelem <unk> britského průmyslového konglomerátu <unk>
+Výzkumníci uvedli , že forma <unk> kdysi používaná k výrobě cigaretových filtrů značky <unk> způsobila vysoký podíl úmrtí na rakovinu mezi dělníky , kteří jí byli vystaveni před více než 30 lety .
+Výzkumníci řekli , že <unk> vlákno , krokydolit , je po vstupu do plic neobvykle reaktivní a viceprezidenta <unk> krátké vystavení se krokydolitu způsobuje příznaky , které <unk> projeví o desítky let později .
+Společnost Lorillard Inc . , jednotka newyorské <unk> Loews Corp . , která vyrábí cigarety <unk> , přestala používat krokydolit ve filtrech svých <unk> Micronite v roce 1956 <unk>
+Ačkoliv byly předběžné nálezy oznámeny více <unk> před rokem , nejnovější <unk> byly zveřejněny v dnešním čísle <unk> <unk> Journal of Medicine , v časopise , který k problému pravděpodobně znovu přiláká pozornost .
+Tisková mluvčí společnosti Lorillard řekla : " <unk> je stará věc .
+Mluvíme <unk> době , kdy ještě nikdo neslyšel o konglomerátu , že by azbest mohl <unk> jakékoliv sporné vlastnosti .
+Teď v <unk> produktech žádný azbest není . "
+Společnost Lorillard ani výzkumníci , kteří prováděli studie s <unk> , si nebyli vědomi žádného výzkumu o <unk> cigaret značky Kent <unk>
+" Nemáme žádné <unk> <unk> o tom , zda jsou <unk> v nebezpečí , " řekl James A . Talcott z bostonského Dana - Farberova <unk> pro výzkum rakoviny .
+Dr <unk> Talcott vedl tým výzkumníků z Národního institutu <unk> výzkum rakoviny a <unk> lékařských fakult Harvardské a Bostonské university .
+Mluvčí společnosti Lorillard uvedla , že <unk> byl na začátku padesátých let používán ve <unk> velmi malých <unk> " při výrobě papíru pro filtry a v roce 1956 byl nahrazen <unk> typem <unk> .
+<unk> uvedla , že v letech 1953 až 1955 bylo prodáno 9.8 miliardy <unk> Kent s těmito filtry .
+Ze 33 mužů , kteří s látkou pracovali , jich zemřelo 28 - <unk> než trojnásobek <unk> počtu .
+Čtyři z pěti přeživších dělníků mají nemoci <unk> s azbestem <unk> včetně tří s nedávno diagnostikovanou rakovinou .
+Výzkumníci uvedli , že počet 18 úmrtí na maligní mezoteliom , rakovinu plic a azbestózu byl sledovaných vyšší , než se <unk> <unk>
+<unk> Tato úmrtnost je <unk> nás , kteří studujeme nemoci <unk> s azbestem , překvapivým zjištěním , " řekl Dr . Talcott .
+Řekl , že podíl úmrtí na rakovinu plic <unk> dělníky v papírně ve West <unk> <unk> Massachusetts je mezi všemi pozorovanými pracovníky s azbestem v západních průmyslových zemích podle <unk> nejvyšší .
+Továrna , kterou vlastní společnost Hollingsworth & Vose , měla se společností Lorillard <unk> <unk> výrobu cigaretových filtrů .
+Dr . Talcott řekl <unk> že zjištění <unk> podpoří ty <unk> kteří tvrdí , že USA by měly regulovat třídu azbestu obsahující krokydolit přísněji , než běžný azbest <unk> chrysotil , který se nachází schválili vedl škol a dalších budov .
+Podle Brooka T . Mossmana , profesora patologie na lékařské fakultě Vermontské university , jsou USA jednou z <unk> <unk> zemí , které nemají vyšší regulační <unk> pro jemná jehlicovitá vlákna , <unk> je krokydolit , která jsou klasifikována <unk> amfobily <unk>
+Dr . Mossman vysvětlil , že obvyklejší chrysotilová <unk> jsou vlnitá a <unk> je dokáže snáze vypudit .
+V červenci zavedla Agentura na <unk> životního prostředí postupný zákaz prakticky všech využití azbestu .
+Do roku 1997 budou postavena <unk> zákon <unk> všechna zbývající užití karcinogenního azbestu .
+Azbestu bylo vystaveno v padesátých letech v továrně vyrábějící papír pro cigarety <unk> asi <unk> dělníků .
+Oblasti továrny , kde se používal krokydolit , byly <unk> zaprášené .
+Dělníci při <unk> používaném k výrobě filtrů vysypali velké jutové pytle dovezeného materiálu do velkého zásobníku , přidali bavlněná a octová vlákna a tato suchá vlákna mechanicky <unk> .
+Dělníci popisovali <unk> mračna modrého prachu " , která se vznášela <unk> částmi <unk> , ačkoliv odsávací větráky oblast provětrávaly .
+" konglomerátu pochyb , že <unk> někteří z těchto dělníků <unk> manažerů nakazili nemocemi spojenými s azbestem , " <unk> Darrell Phillips , viceprezident společnosti Hollingsworth & Vose pro lidské zdroje .
+" Ale musíte uznat , že se tyto události <unk> před 35 lety .
+Nijak se to nevztahuje na naši dnešní <unk> sílu .
+Jako <unk> ze znaků , že správci portfolií očekávají <unk> pokles úrokových <unk> , nadále klesaly výnosy ze vzájemných investičních fondů peněžního trhu .
+Průměrný <unk> složený výnos <unk> zdanitelných fondů sledovaných <unk> Money Fund Report IBC se snížil o zlomek procentového bodu na 8.45 % z 8.47 % pro týden končící v úterý .
+Složené výnosy předpokládají , že dividendy <unk> opět investovány a současné výnosy potrvají další rok .
+Průměrná společnosti investic fondů se prodloužila o jeden den <unk> 41 dní , což je podle společnosti Donoghue <unk> s nejvíce od začátku srpna .
+reaktivní splatnosti <unk> považovány za indikátory klesajících úrokových sazeb , protože dovolují správcům portfolií udržovat relativně vyšší sazby po delší dobu <unk>
+Kratší splatnosti jsou <unk> <unk> znamení <unk> se úrokových zazeb , protože správci portfolií mohou získat vyšší sazby dříve .
+<unk> splatnost pro fondy otevřené pouze pro instituce , která bývá považována za <unk> ukazatel , protože jejich správci trh podrobně sledují , <unk> nejvyššího bodu v tomto roce - 33 dní zapletena
+Brenda Malizia Negusová , redaktorka zpravodaje Money Fund Report , přesto <unk> , že výnosy " mohou <unk> , než města dolů , zase Talcott nahoru " kvůli nedávným nárůstům krátkodobých <unk> sazeb .
+Například <unk> z <unk> krátkodobých státních <unk> prodaných v pondělní aukci se zvedly z 7.90 % na 8.04 % .
+I přes nedávné poklesy výnosů investoři pokračují v sypání hotovosti do peněžních fondů <unk>
+Aktiva 400 zdanitelných fondů vzrostla během <unk> týdne o 1.5 <unk> dolarů na 352.7 miliardy dolarů .
+Peněžní fondy většinou porážejí srovnatelné krátkodobé investice <unk> protože správci portfolií mohou měnit dobu <unk> a usilovat o nejvyšší úrokové sazby .
+Nejlepší peněžní fondy vynášejí v současnosti přes 9 % <unk>
+Sedmidenní složený výnos fondu Dreyfus World - Wide <unk> s nejvyššími výnosy dosáhl v posledním týdnu <unk> % , což je pokles z <unk> % v předchozím sypání .
+Fond intenzivně investuje <unk> zámořských dolarových cenných papírů a v současnosti se vzdává správních poplatků , což jeho <unk> <unk> nahoru .
+Průměrný plán jednoduchý výnos těchto 400 fondů klesl z 8.14 % na 8.12 % .
+Třicetidenní jednoduchý výnos klesl z 8.22 % <unk> průměrných 8.19 % , <unk> složený výnos sklouzl z 8.56 % <unk> průměrných 8.53 % .
+J <unk> P . Bolduc , viceprezident společnosti W <unk> R . Grace & Co . <unk> která drží 83.4 % akcií této energetické společnosti , byl zvolen jejím ředitelem .
+Je nástupcem Terrence D . Danielse , <unk> viceprezidenta společnosti neslyšel . R . Grace , který odstoupil .
+Společnost W . R . Grace drží tři ze <unk> křesel <unk> předsednictvu společnosti Grace Energy .
+Společnost <unk> First Financial Corp <unk> uvedla , že akcionáři schválili její převzetí torontskou společností Royal Trustco Ltd . <unk> 27 dolarů za akcii , neboli za 212 milionů dolarů .
+Tato spořitelní holdingová společnost sdělila , že očekává získání <unk> od regulátora a dokončení předpověď do konce roku .
+Společnost McDermott International Inc . <unk> , že její jednotka Babcock <unk> Wilcox dokončila prodej své společnosti Bailey Controls Operations společnosti Finmeccanica S <unk> p . A . za 295 milionů dolarů .
+Společnost Finmeccanica je italská státní holdingová společnost s účastí v podnicích <unk> inženýrství .
+Společnost <unk> Controls se sídlem ve Wickliffe v Ohiu vyrábí počítačové průmyslové kontrolní <unk> .
+Společnost zaměstnává 2700 lidí <unk> má roční příjem kolem 370 milionů dolarů .
+Federální <unk> pozastavila prodej amerických ukládacích cenných <unk> , protože Kongres nezvedl strop pro vládní dluhy .
+Ministerstvo financí uvedlo , že dokud <unk> jedná , není vláda oprávněna vydávat <unk> nové dluhopisy .
+<unk> oprávnění k uzavírání výpůjček o půlnoci kleslo <unk> 2.87 bilionů dolarů na 2.80 bilionů dolarů .
+Legislativa na zvýšení dluhového stropu <unk> zapletena v boji o snižování daní účel kapitálového zisku .
+Sněmovna reprezentantů odhlasovala zvýšení stropu na 3.1 bilionu dolarů , <unk> renovované Senátu je očekáváno nejdříve příští týden .
+Ministerstvo zaměstnává uvedlo , že USA promešká lhůtu 9 . <unk> , pokud Kongres do té doby nebude jednat .
+Clark J . <unk> byl jmenován hlavním viceprezidentem a generálním ředitelem této americké <unk> <unk> marketingové odnože japonského výrobce automobilů , společnosti Mazda Motor Corp .
+Vitulli bude ve své nové funkci dohlížet na americký prodej , služby , součásti a marketing <unk> Mazda .
+Třiačtyřicetiletý Vitulli byl předtím hlavním marketingovým ředitelem divize Chrysler společnosti Chrysler <unk> .
+Prodejním a marketingovým ekonomiku pracovníkem společnosti Chrysler byl po dobu 20 let .
+Když nastane čas pro pololetní rokování , průmysloví titáni se povětšinou slétají <unk> slunečných oblastí rekreačních středisek , jako je Boca <unk> <unk> Hot Springs .
+Ne však letos .
+Národní asociace výrobců se pro <unk> <unk> svého představenstva usnesla na Indianapolisu , hlavním městě Hoosiers ( obyvatel Indiany ) .
+A město se rozhodlo <unk> že své hosty uvítá spíše jako krále či <unk> hvězdy , než <unk> vlastníky továren .
+Samozřejmý účel : dokázat <unk> zástupcům korporací , kteří mají rozhodování ve svých rukou , že spona na pásu Rust Belt není zas tak prorezlá a <unk> je nejvíce dobré místo pro rozvoj firmy <unk>
+Adresáty tohoto poselství byli zástupci obřích společností , jako je Du Pont či <unk> , spolu s méně <unk> firmami <unk> jako je společnost Trojan Steel a Valley Quenn Cheese Factory .
+Co se <unk> týče , vedoucí <unk> se připojili ke <unk> Williamu H . Hudnutovi III . a <unk> večer s Indianapoliským symfonickým orchestrem a hostujícím komediálním klavíristou Victorem Borgem .
+Následovalo šampaňské a dezert .
+Následující ráno se rozjely autobusy plné řídících pracovníků a <unk> <unk> za doprovodu policejní eskorty k indianapoliské závodní dráze , nezdržovány <unk> či semafory .
+Guvernér se nemohl dostavit , takže mimořádné <unk> přivítal jeho zástupce .
+Snídaně formou bufetu viceprezidentem pořádala v muzeu , kde je jídlo a pití <unk> návštěvníkům zakázáno .
+Poté závodní dráha na počest hostů odkudsi vylovila čtyři řidiče <unk> <unk> a dokonce i <unk> hlasatele Indianapoliské 500 pro desetikolový exhibiční závod .
+<unk> závodě se výkonní pracovníci Fortune 500 zalykali nad auty podrobně jejich řidiči nadšením jako školáci .
+Řidiči , kteří <unk> <unk> hlupáci , zdůraznili , že na svých strojích mají stále ještě volné místo pro <unk> či dva sponzory .
+Zpět v centru stihli šéfové v hotelu pár schůzek , <unk> se opět nalodili do autobusů .
+Tentokrát to bylo kvůli večeři <unk> tanci - o blok dál .
+Pod hvězdami a měsíci renovované tančírny Indiana <unk> <unk> devět nejostřejších šéfkuchařů <unk> města krmilo indianskou kachní pěnou , humřím vývarem , telecími medailonky a čokoládovým dezertem s malinovou <unk> .
+Schopni rozpoznat chutné - a bezplatné - jídlo , když ho mají na talíři , počastovali řídící <unk> kuchaře potleskem <unk> <unk>
+křesel než jen pár ředitelů říká <unk> že je péče na způsob <unk> nevýkonným svádí vrátit se do města v srdci země na některém z příštích zasedání .
+Avšak nyní se již těší na své zimní zasedání - které <unk> bude konat v únoru v <unk> .
+Podle vládních údajů zveřejněných ve středu <unk> Jižní Korea v <unk> deficit obchodní bilance ve výši 101 milionu dolarů , což odráží její <unk> stagnaci .
+<unk> záznamy Ministerstva průmyslu a obchodu <unk> <unk> říjnu další deficit obchodní <unk> , v letošním roce již pátý měsíční pokles , což na jihokorejskou ekonomiku orientovanou na export vrhá stín .
+Říjnový vývoz <unk> zastavil na 5.29 miliardy dolarů , což je pouze <unk> % nárůst <unk> loňskému roku , zatímco dovoz <unk> ostře zvýšil na 5.39 miliardy dolarů , o 20 procent více než v minulém říjnu <unk>
+Jihokorejský ekonomický boom , který začal <unk> 1986 , se letos <unk> kvůli protahovaným pracovním sporům <unk> obchodním konfliktům a stagnujícímu vývozu .
+Vládní úředníci uvedli , že <unk> zůstane ke konci roku pod vládním <unk> 68 miliard dolarů .
+I přes tuto ponurou předpověď zaznamenala <unk> Jižní Korea obchodní <unk> ve výši 71 milionu dolarů .
+Od <unk> do října se oproti stejnému období loňského <unk> souhrnný vývoz v zemi zvedl o 4 % na 50.45 miliardy <unk> .
+Dovoz činil při 19 % <unk> 50.38 miliardy dolarů .
+Časopis <unk> , který se snaží držet krok s <unk> časopisem Time , vyhlásil pro rok 1990 nové sazby inzerce a uvedl , že představí nový <unk> plán pro <unk> .
+<unk> plán <unk> časopisu Newsweek , <unk> společnosti Washington Post Co . , je druhým pobídkovým plánem , který časopis v rozpětí tří let inzerentům nabídl <unk>
+<unk> , které viceprezidentem <unk> slevy za udržování či zvyšování výdajů za inzerci <unk> <unk> staly pevnými součástmi zpravodajských týdeníků a podtrhují zuřivý konkurenční boj mezi časopisem Newsweek , časopisem <unk> společnosti Time Warner Inc . a časopisem U . S . News & World Report Mortimera B . <unk> .
+Čerstvě jmenovaný prezident <unk> Newsweek Alan Spoon oznámil <unk> že inzertní sazebníky <unk> budou v lednu o 5 % zvyšovat .
+Jedna celá strana časopisu Newsweek ve čtyřech barvách používat stát 100980 dolarů .
+Časopis <unk> v polovině října <unk> svůj garantovaný prodaný náklad pro rok 1990 , <unk> S zvýšil inzertní sazby za stránku ; s nižším <unk> <unk> výtisků bude inzertní sazba na jednoho předplatitele o 7.5 % vyšší ; celá stránka v časopisu Time vyjde asi na 120000 dolarů .
+Časopis U . S . News svůj inzertní <unk> pro rok <unk> ještě neoznámil .
+Časopis Newsweek oznámil <unk> že <unk> " Nákladový úvěrový plán " , který <unk> inzerentům prostorové kredity za " obnovenou inzerci " .
+Časopis odmění " <unk> bonusy " ty inzerenty , <unk> <unk> v roce 1990 dosáhnou nebo přesáhnou výdaje za rok 1989 , <unk> v roce 1989 utratili <unk> dolarů a v roce 1990 utratí 340000 dolarů .
+Spoon popřel , že <unk> tento plán byl pokusem o zastavení poklesu počtu stránek inzerce v <unk> devíti <unk> roku 1989 ; podle Vydavatelského informačního úřadu klesl počet reklamních stránek nebude Newsweek oproti minulému <unk> o 3.2 % na 1620 <unk>
+" Ve skutečnosti záleží na tom , kolik inzerenti platí za stránku <unk> a v tomto ohledu jsme na <unk> tento podzim <unk> , " <unk> Spoon .
+Časopisy Newsweek i U . S . News zvyšovaly v posledních letech prodaný náklad město zástupce <unk> obdarovávání předplatitelů elektronikou , <unk> jsou telefony a hodinky .
+<unk> žádný ze tří velkých týdeníků zvýšený prodaný náklad nezaznamenal <unk> poslední době .
+Podle Úřadu pro <unk> nákladu tisku měl časopis Time , <unk> <unk> , průměrný prodaný náklad 4393237 výtisků , což je pokles o 7.3 % .
+Prodaný patologie časopisu Newsweek za první pololetí 1989 byl 3288453 výtisků , stejný jako za stejné vyšší <unk> roku .
+Prodaný náklad časopisu U . S . News klesl za totéž období o 2.6 % <unk> 2303328 výtisků .
+Společnost New England Electric System <unk> <unk> nabídkového řízení o společnost Public Service Co <unk> of New Hampshire s tím <unk> že by riziko bylo příliš vysoké a případný výtěžek příliš vzdálený na to , <unk> ospravedlnil vyšší nabídku .
+Tento těchto ve hře o společnost nárůstům of New Hampshire , která také předložila plán vnitřní reorganizace podle kapitoly 11 konkurzního řízení , Inc něhož by zůstala nezávislou společností <unk> zanechává jako <unk> <unk> zájemce společnosti United Illuminating Co . a Northeast Utilities .
+Společnost New England <unk> se sídlem ve Westborough v Massachusetts nabídla za akvizici společnosti <unk> <unk> New Hampshire 2 miliardy dolarů , což je <unk> méně než 2.29 miliardy dolarů nabídnuté společností filtry Illuminating či 2.25 miliardy dolarů , kterými svou nabídku ohodnotila společnost Northeast .
+Společnost United Illuminating sídlí v New Haven ve státě <unk> a <unk> Northeast sídlí v Hartfordu ve státě Connecticut .
+Společnost PS <unk> New miliardy se sídlem v Manchesteru v New Hampshire oceňuje mechanicky interní reorganizační plán asi na 2.2 miliardy dolarů .
+John Rowe , prezident a generální ředitel společnosti New <unk> Electric <unk> řekl , že by mohl utrpět její výnos <unk> akcií , <unk> společnost nabídla více a její <unk> týkající se společnosti PS of New <unk> - například růst poptávky po elektřině či zvýšená provozní efektivita - <unk> se nevyplnily .
+" Když jsme zvažovali zvýšení nabídky , rizika pro příštích pět let se zdála být značná a přetrvávající a výnosy se zdály být hodně vzdálené <unk>
+To bylo těžké podstoupit , " dodal .
+Rowe také podotkl , že <unk> New <unk> Electric byla rovněž znepokojena politickými zájmy .
+Řekl , že ať už <unk> vlastníkem společnosti PS of New Hampshire kdokoliv , poté , co se dostane z konkurzního řízení , budou její sazby jedny <unk> <unk> v zemi .
+" To přitahuje pozornost . . <unk>
+byl to <unk> další z rizikových <unk> " <unk> které vedly naši společnost k rozhodnutí stáhnout se z nabídkového řízení , dodal .
+<unk> Ross Jr . <unk> společnosti Rothschild Inc . , finanční poradce držitelů akcií problémové společnosti , řekl <unk> že ústup společnosti New England Electric by mohl urychlit reorganizační proces .
+Ross tvrdil , že skutečnost , že společnost New England navrhla pomalejší zvyšování sazeb - <unk> % za sedm let <unk> asi 5.5 % navrhovaných ostatními <unk> externími zájemci - komplikovala jednání <unk> <unk> úředníky .
+" Teď je pole volnější , " <unk> .
+Federální komise pro regulaci <unk> zamítla prozatím žádost společnosti <unk> o schválení případné koupě <unk> PS of New Hampshire .
+Společnost Northeast oznámila <unk> že podá svou žádost výkonní a stále doufá v urychlený posudek ze strany Federální <unk> pro regulaci <unk> , aby mohla dokončit koupi <unk> příštího léta , pokud její nabídka bude odsouhlasena konkurzním soudem .
+Akcie společnosti PS of filtry Hampshire včera v kompozitním <unk> <unk> Newyorské burze cenných papírů zaznamenaly pokles o 25 centů a skončily na 3.75 dolaru .
+Dvaapadesátiletý Norman Ricken , bývalý prezident a provozní ředitel společnosti <unk> " R " Us Inc . <unk> a třiašedesátiletý Frederick Deane jr . , předseda <unk> Signet Banking Corp . , byli zvoleni řediteli tohoto maloobchodního řetězce se spotřební elektronikou a spotřebiči <unk>
+Ve dvanáctičlenné správní radě nahradí Daniela M . Rexingera , výkonného <unk> společnosti Circuit City , který odešel do důchodu <unk> a Roberta R . Glaubera , náměstka ministra financí USA .
+Společnosti Commonwealth Edison Co . <unk> nařízeno vrátit zhruba 250 milionů dolarů svým současným a bývalým poplatníkům kvůli <unk> poplatkům vybíraným za překročené <unk> na jadernou elektrárnu .
+Refundovaná částka byla asi o 55 milionů dolarů vyšší než <unk> nařízená dříve Illinoiskou obchodní komisí a obchodní skupiny řekly , že může jít vůbec o nejvyšší částku požadovanou od <unk> či <unk> podniku <unk> očekávají .
+Soudce státního soudu Richard Curry nařídil společnosti Edison <unk> <unk> průměru zhruba 45 až 50 dolarů každému zákazníkovi <unk> který využíval její služby dodávky elektřiny od dubna 1986 <unk> <unk> asi dvou milionů zákazníků , kteří se <unk> tohoto období přestěhovali .
+Soudce <unk> <unk> , aby splácení začalo 1 . února , a řekl , <unk> nepřipouští žádná odvolání či <unk> pokusy společnosti Edison blokovat jeho nařízení .
+" Refundace . . <unk> se <unk> stát rukojmím v dalším kole odvolání , " řekl soudce Curry .
+<unk> Commonwealth Edison oznámila , že se už odvolává <unk> nařízení komise a zvažuje odvolání proti <unk> soudce Curryho .
+Přesná částka refundace bude určena příští rok na základě skutečně vybraných poplatků do <unk> <unk> prosince tohoto roku .
+<unk> Commonwealth Edison uvedla , že součásti by ji mohlo donutit srazit zisky za rok 1989 Report 1.55 dolaru za akcii .
+Za <unk> <unk> ohlásila společnost <unk> Edison zisky ve výši 737.5 milionu dolarů , neboli 3.01 dolaru za akcii .
+Mluvčí společnosti Commonwealth Edison řekl , že vyhledání <unk> milionů <unk> , staly adresy se v posledních třech a půl letech jednoho , bude " administrativní noční můrou " .
+Při včerejším kompozitním obchodování na Newyorské burze <unk> papírů zaznamenala společnost <unk> Edison pokles o 12.5 centu a <unk> na 38375 dolaru .
+Elektrárna Byron 1 poblíž Rockfordu <unk> státě Illinois v hodnotě <unk> miliardy dolarů byla dokončena v roce 1985 .
+Ve sporném rozhodnutí z roku 1985 uvedla <unk> obchodní komise , že společnost Commonwealth Edison může zvednout sazby za elektřinu o 49 milionu dolarů , <unk> <unk> zaplatila .
+Avšak státní <unk> podpořily žalobu spotřebitelských skupin <unk> zvýšení poplatků a shledaly poplatky nezákonnými .
+Illinoiský nejvyšší soud nařídil komisi , aby provedla audit stavebních výdajů <unk> Commonwealth <unk> a vrátila veškeré nepřiměřené výdaje <unk>
+Tento podnik <unk> služeb vybírá poplatky na výstavbu elektrárny od 3.1 milionu svých zákazníků s <unk> na refundaci <unk> roku 1986 .
+V srpnu <unk> stanovila , že asi 190 až 195 milionů dolarů <unk> stavbu <unk> bylo nepřiměřených a mělo by být vráceno i s úroky .
+Ve svém rozhodnutí přidal soudce Curry k výpočtům <unk> dalších <unk> milionů dolarů .
+Minulý měsíc stanovil soudce <unk> úrokovou sazbu refundace na 9 % .
+Společnosti Commonwealth Edison nyní hrozí další soudně nařízené vrácení letních <unk> zimních poplatků s odlišnou <unk> , které Illinoiský <unk> soud odhadl na 140 milionů dolarů .
+A spotřebitelské skupiny doufají , <unk> rozhodnutí soudce Curryho o elektrárně Byron 1 může stanovit precedens pro druhý případ týkající se sazeb za <unk> elektrárnu <unk> konkrétně Braidwood 2 <unk> Commonwealth Edison .
+Společnost <unk> Edison hodlá na <unk> sazbách vybrat na zaplacení elektrárny Braidwood 2 zhruba 245 milionů dolarů .
+Rozhodnutí komise o elektrárně Braidwood 2 je <unk> do konce roku .
+<unk> rok musela společnost Commonwealth Edison vrátit 72.7 milionu dolarů kvůli špatnému výkonu své jaderné elektrárny <unk> I .
+Japonská asociace obchodníků s automobily oznámila <unk> že japonský domácí trh s osobními automobily , nákladními vozy a autobusy zaznamenal v říjnu v porovnání s minulým rokem 18 % vzrůst na rekordních <unk> <unk> .
+Silný nárůst následoval po srpnovém 21 % a <unk> <unk> % nárůstu oproti minulému roku .
+Měsíční prodeje lámaly rekordy každý měsíc už od filtru .
+Oproti předchozímu měsíci klesl říjnový prodej o <unk> % .
+Prodej osobních aut <unk> o 22 <unk> oproti minulému roku na 361376 kusů .
+Prodej středně velkých aut , která získala po poklesu cen díky zavedení nové naši daně výhodu <unk> se v říjnu 1988 <unk> než zdvojnásobil na 30841 kusů <unk>
+Společnost Texas Instruments Japan Ltd . , součást společnosti městě Instrument <unk> . , oznámila otevření nové továrny na výrobu kontrolních zařízení v Jižní <unk> .
+<unk> uvedla , že nová továrna , umístěná v Chinchonu , zhruba 60 mil od Soulu , pomůže <unk> zvyšující se a rozrůzňující se <unk> po kontrolních zařízeních v <unk> Koreji .
+Továrna bude vyrábět kontrolní zařízení používané v motorových vozidlech <unk> domácích spotřebičích .
+<unk> se , že přežití <unk> společnosti Cray Computer Corp . jako čerstvého opeřence v <unk> se <unk> velmi závisí na kreativitě - a dlouhověkosti - jejího předsedy a hlavního konstruktéra Seymoura Craye .
+Nejen vývoj počátečního počítače <unk> nové společnosti , ale i její rozvaha jsou přímo svázány s Crayem .
+Dokumenty o dosud nerozhodnutém odtržení podané ke Komisi pro <unk> prodeje <unk> papírů odhalily <unk> že společnost Cray Research Inc . stáhne téměř 100 milionů dolarů na <unk> <unk> <unk> nové společnosti poskytuje , pokud Cray odejde <unk> pokud bude zrušen projekt návrhu produktu , který řídí .
+V dokumentech je rovněž řečeno , <unk> ačkoliv 64letý Cray <unk> na <unk> více než šest let , je počítač Cray - 3 nejméně další <unk> vzdálen od plně funkčního prototypu .
+Kromě toho nepřišly dosud <unk> Cray - 3 žádné objednávky , ačkoliv společnost tvrdí , že jedná <unk> několika <unk> zákazníky .
+<unk> společnost Cray Research se sídlem v Minneapolis předvídala mnohá rizika , <unk> poprvé v květnu oznámila <unk> , nitky , kterými svázala financování <unk> nebyly do včerejška zveřejněny .
+" <unk> jsme mnoho na výběr , " řekl v rozhovoru Gregory Barnum <unk> <unk> ředitel společnosti Cray Computer .
+<unk> Předpoklad je , že Seymour je hlavní konstruktér počítače <unk> - 3 , <unk> ten by bez něho nemohl být dokončen .
+Společnost Cray <unk> nechtěla financovat projekt , který by nezahrnoval Seymoura . "
+V dokumentech je rovněž řečeno , že společnost Cray Computer předpovídá potřebu <unk> asi 120 milionů dolarů na <unk> začátkem příštího září .
+Barnum to však nazval " nejhorším možným " prodaných .
+Předložení podrobností o odtržení lékařských , že akcie společnosti Cray <unk> poskočily včera <unk> kompozitním obchodování na Newyorské burze cenných papírů o 2875 dolaru téměř na 38 dolarů .
+Analytici včera poznamenali , že rozhodnutí úmrtnost Cray Research spojit <unk> vlastní úvěr ve výši 98.3 <unk> dolarů s Crayovou účastí zkomplikuje ohodnocení nové společnosti .
+" Musí to <unk> považováno za další riziko pro investora , " <unk> Gary P . Smaby ze společnosti Smaby Group Inc . <unk> Minneapolis .
+" Společnost Cray Computer bude koncepčním akciovým <unk> , " řekl .
+" Buď věříte , že to <unk> opět dokáže , nebo ne . "
+<unk> věku konstruktéra zahrnují <unk> rizikové faktory nové Crayovy společnosti také složitou a neověřenou čipovou technologii pro počítač Cray - 3 .
+<unk> SEC popisují tyto čipy , které jsou vyrobeny z arsenidu galia <unk> <unk> natolik křehké a miniaturní , že vyžadují speciální robotické zařízení pro manipulaci <unk>
+Kromě toho bude počítač Cray - 3 fondy 16 procesorů - <unk> víc , než největší současný superpočítač .
+<unk> <unk> Computer bude také čelit intenzivní <unk> , nejenom ze strany společnosti Cray <unk> , která má okolo 60 % celosvětového trhu superpočítačů a od níž se očekává , že v roce 1991 <unk> na trh <unk> C - 90 , přímého konkurenta počítače Cray - <unk> .
+Odtržená <unk> bude <unk> soutěžit se společností International Business Machines Corp . a s japonskou <unk> trojkou - společnostmi Hitachi Ltd . , <unk> Corp . a Fujitsu Ltd .
+Nová společnost uvedla , že věří , že existuje téměř 100 potenciálních zákazníků na <unk> s cenou <unk> 15 až 30 miliony dolarů - pravděpodobným cenovým rozpětím <unk> Cray - 3 .
+Podle podmínek odtržení mají akcionáři společnosti Cray Research získat jednu akcii společnosti Cray Computer vždy za dvě akcie <unk> Cray Research <unk> které vlastní , a <unk> při rozdělování , jež se očekává asi <unk> dvou <unk> .
+Pro nové akcie nebyla dosud <unk> žádná cena .
+Namísto toho ponechají společnosti na trhu , ať rozhodne <unk>
+Společnost <unk> Computer požádala o obchodování na trhu Nasdaq .
+Analytici spočítali <unk> účetní hodnotu společnosti Cray Computer kolem 4.75 dolaru za akcii .
+Společně s tímto sdělením převádí společnost Cray Research <unk> 53 milionů dolarů v aktivech , hlavně těch , která jsou svázána s vývojem počítače Cray <unk> 3 , jenž odčerpával <unk> společnosti Cray <unk> .
+Předběžné rozvahy jasně ukazují , velmi společnost Cray Research upřednostňovala odtržení .
+Bez výdajů <unk> výzkum a vývoj <unk> Cray - 3 by společnost mohla za první pololetí roku 1989 ohlásit zisk 19.3 milionu dolarů namísto 5.9 milionu dolarů , které skutečně zveřejnila .
+Na druhé straně by společnost Cray <unk> utrpěla ztrátu ve výši 20.5 milionu dolarů , pokud by výrobě <unk> .
+S . Cray <unk> který nebyl k dosažení , aby <unk> zprávy komentoval <unk> bude pracovat <unk> novou společnost <unk> Colorado Springs v Coloradu jako nezávislý dodavatel - což je stejná dohoda , jakou měl i se <unk> Cray Research .
+Vzhledem k <unk> , že je považován za otce superpočítače , vydělal si Cray <unk> rok u společnosti Cray Research 600000 dolarů <unk>
+Ve společnosti zemích Computer obdrží 240000 dolarů .
+Kromě pánů Craye a Barnuma jsou hlavními řídícími pracovníky <unk> společnosti Neil Davenport <unk> <unk> let , prezident a generální ředitel , Joseph M . Blanchard , 37 let <unk> viceprezident , technika , Malcolm A . Hammerton , <unk> <unk> , viceprezident , software , a Douglas R . Wheeland , 45 let , <unk> , <unk> .
+Všichni přišli <unk> společnosti Cray Research .
+Společnost Cray Computer , která v současnosti zaměstnává 241 lidí , uvedla , že do konce roku 1990 <unk> <unk> že bude zaměstnávat <unk> lidí .
+John <unk> . Stevens , 49 let , byl jmenován hlavním výkonným viceprezidentem a provozním ředitelem , <unk> pozice jsou nové .
+Nadále bude podléhat Donaldu Pardusovi , prezidentovi a <unk> řediteli .
+Stevens byl výkonným viceprezidentem tohoto elektrárenského holdingového podniku veřejných služeb <unk>
+Arthur A . Hatch , 59 let Co byl jmenován výkonným viceprezidentem společnosti .
+Předtím nezdržovány prezidentem jednotky této společnosti Eastern Edison Co .
+John D . Carney , 45 let , byl jmenován , aby nahradil A . <unk> . předsednictvu v roli <unk> společnosti Eastern Edison .
+Předtím byl <unk> společnosti Eastern Edison .
+Robert P . Tassinari , 63 let , byl jmenován hlavním <unk> společnosti Eastern Utilities .
+Předtím zastával funkci viceprezidenta .
+USA ohlásily <unk> úspěch své obchodní diplomacie a vyňaly Jižní Koreu , Tchaj - wan a <unk> Arábii ze seznamu zemí , které podrobně sledují kvůli údajnému selhávání při respektování amerických <unk> , autorských práv regulační <unk> práv duševního vlastnictví .
+Nicméně pět jiných zemí - <unk> , Thajsko <unk> Indie , Brazílie a <unk> - zůstanou v důsledku prozatímního <unk> na tomto takzvaném seznamu přednostně sledovaných zemí , oznámila americká obchodní zástupkyně Carla Hillsová <unk>
+Podle nového amerického <unk> nebezpečí by tyto země mohly čelit zrychlenému vyšetřování nepoctivého <unk> <unk> tvrdým obchodním sankcím , pokud do příštího jara nezlepší svou ochranu duševního vlastnictví .
+<unk> Hillsová <unk> , že mnohé z 25 <unk> , které podrobila rozličným stupňům podrobného zkoumání , učinily v této choulostivé věci " skutečný pokrok <unk> .
+Prohlásila , že po celém světě <unk> " rostoucí vědomí " toho , že popření práv duševního věc škodí všem prodaných zemím : a zejména " kreativitě a vynalézavosti vlastních občanů ( <unk> ) země . "
+Američtí obchodní <unk> tvrdí , že země s <unk> ochranou práv duševního vlastnictví by <unk> poškozovat samy sebe tím , že odradí své vlastní <unk> a <unk> , a dále tím , že odradí americké špičkově technologicky vyspělé společnosti od investic nebo prodeje svých nejlepších produktů v <unk> zemi <unk>
+Carla Hillsová pochválila Jižní Koreu za vytvoření komise <unk> se duševním vlastnictvím a <unk> týmů policejních důstojníků a <unk> vyškolených ke stíhání filmového a knižního pirátství <unk>
+Soul také zavedl efektivní pátrací a zabavovací <unk> , aby těmto týmům <unk> , uvedla .
+Tchaj - wan zlepšil svou reputaci <unk> USA , když podepsal bilaterální smlouvu o autorských <unk> <unk> pozměnil zákon o ochranných známkách a zavedl legislativu na ochranu zahraničních filmových producentů proti neautorizovanému <unk> jejich <unk> .
+Toto opatření Dr mohlo přinutit narůstající počet malých tchaj - pejských videopůjčoven , aby platily filmovým producentům <unk> <unk> jejich filmů .
+Co <unk> týče Saúdské Arábie , ta přislíbila <unk> že přijme zákon o autorských právech , který <unk> kompatibilní s mezinárodními standardy , a že tento zákon bude platit pro <unk> software i <unk> <unk> , uvedla C . Hillsová .
+Přesto nejsou <unk> tři země zcela mimo nebezpečí .
+Zůstanou na seznamu <unk> s nižší prioritou , který obsahuje dalších 17 konkurenčním .
+Tyto země - <unk> Japonska <unk> Itálie , Kanady , Řecka zavedla Španělska - jsou stále předmětem určitých obav ze strany USA , ale pro vlastníky amerických <unk> a autorských práv jsou považovány <unk> méně problematické než země na " prioritním <unk> seznamu .
+Gary Hoffman , washingtonský právník specializující se na <unk> porušování duševního vlastnictví , <unk> , že zlepšení učiněná Jižní Koreou , Tchaj - wanem <unk> Saúdskou Arábií vyvolala hrozba amerických protiopatření v kombinaci <unk> rostoucím uznáním , že ochrana <unk> vlastnictví je ve <unk> zájmu <unk> .
+" To nám potvrzuje , že ho obchodní právo <unk> , " řekl .
+Řekl <unk> že jednou z dalších zemí <unk> které čokoládovým odstraněny z prioritního seznamu , by mohlo <unk> Mexiko díky své snaze vytvořit nový patentový zákon .
+Carla Hillsová prohlásila <unk> že USA jsou stále zneklidněny " znepokojujícím <unk> v Turecku a trvale pomalým pokrokem v Malajsii . <unk>
+Dále to nerozváděla , <unk> dřívější zprávy o americkém obchodu si stěžovaly <unk> videopirátství v Malajsii a na opomíjení amerických farmaceutických patentů v Turecku .
+<unk> zákon <unk> roku 1988 nařizuje <unk> Hillsové , aby do 30 . dubna zveřejnila další šetření týkající se těchto zemí .
+Zatím Carla Hillsová nepovažovala žádné případy za <unk> <unk> , <unk> si zasloužily zrychlené šetření podle takzvaného zvláštního ustanovení č . 301 tohoto zákona .
+Argentina <unk> , že požádá věřitelské <unk> , aby snížily na polovinu její zahraniční dluh <unk> <unk> 64 miliard dolarů - třetí největší v rozvojovém světě .
+Prohlášení ministra <unk> Nestora Rapanelliho <unk> považováno za vůbec <unk> podobný krok , který byl učiněn vysokým argentinským představitelem .
+Tato lhůtu země splatila od začátku minulého roku ze svého <unk> jen velmi málo .
+" Argentina se <unk> dosáhnout snížení 50 % z hodnoty svého zahraničního <unk> , " <unk> Rapanelli prostřednictvím svého mluvčího Miguela Alurraldeho .
+Rapanelli se v srpnu setkal s náměstkem ministra financí USA <unk> Mulfordem .
+Argentinský vyjednavač Carlos Carballo navštívil tento týden Washington a New <unk> , aby se sešel <unk> představiteli bank .
+Rapanelli nedávno řekl , že vláda prezidenta města Menema , který nastoupil do úřadu 8 <unk> července , cítí , že <unk> snížení jistiny a úroku je jediný způsob <unk> jak může být problém s dluhem vyřešen .
+postupu ale , že jeho země chce <unk> aby jí byla prominuta polovina dluhu .
+( V roce svého to výročí bude Wall Street Journal přinášet zprávy o událostech indikátory minulého století , jež se staly milníky <unk> obchodní <unk> . )
+TŘI POČÍTAČE <unk> KTERÉ ZMĚNILY tvář práce s počítači , byly uvedeny na <unk> v roce 1977 .
+V tomto roce vstoupily na trh počítače Apple II , Commodore Pet a Tandy TRS - 80 <unk>
+<unk> byly oproti dnešnímu standardu nepropracované .
+Například vlastníci Apple II museli používat <unk> televizory jako monitory a uchovávat <unk> na audiokazetách .
+<unk> II <unk> <unk> velký pokrok oproti Apple I , který Stephen Wozniak a Steven Jobs sestavili v garáži pro nadšence , jako byl například Homebrew Computer Club .
+Kromě toho byl Apple II dostupný za <unk> dolarů .
+Ačkoli byly <unk> první osobní <unk> nedostatečně propracované , brzy spustily prudce rostoucí rozvoj v oblasti <unk> počítačů pro domácnosti a kanceláře .
+Velké <unk> počítače pro podniky už tehdy existovaly léta .
+Ale nová PC z roku 1977 <unk> na rozdíl od dřívějších sestavovaných typů , <unk> byly například Altair , Sol či IMSAI - měly klávesnice a dokázaly přechovávat <unk> paměti kolem dvou stran <unk> .
+Současná PC jsou více než 50 <unk> rychlejší a mají kapacitu paměti 500 <unk> větší než jejich protějšky <unk> roku 1977 .
+Bylo mnoho průkopníků , kteří přispěli k vývoji osobních materiálu .
+V roce 1975 <unk> William Gates <unk> Paul Allen první <unk> - organizační systém pro osobní počítače a <unk> se stal miliardářem šest let poté <unk> co společnost IBM v roce 1981 adaptovala jednu z těchto verzí .
+Alan F . Shugart , v současné době předseda společnosti Seagate <unk> , vedl tým , který vyvinul <unk> mechaniku pro <unk> .
+Dennis Hayes a Dale <unk> , dva inženýři z Atlanty , společně vyvinuli interní modemy <unk> které umožňují osobním počítačům sdílení dat přes telefon .
+<unk> IBM <unk> čelní <unk> počítačů ve světě , nabídla <unk> první osobní počítač až v srpnu 1981 , kdy na trh vstoupilo mnoho dalších společností .
+Dnes dosahuje roční prodej <unk> <unk> na celém světě výše asi 38.3 miliardy dolarů .
+Australská farmaceutická společnost F . H . Faulding & Co . uvedla , že její přidružená společnost Moleculon <unk> . <unk> za 23 miliony dolarů společnost <unk> Inc .
+<unk> Kalipharma je <unk> koncern se sídlem v New Jersey , který prodává své výrobky pod značkou Purepac .
+Společnost Faulding <unk> , že vlastní 33 % akcií společnosti Moleculon s hlasovacím právem a má dohodu k získání dalších 19 % <unk>
+Tento podíl , spolu s <unk> konvertibilních prioritních akcií , poskytuje společnosti Faulding právo zvýšit svůj podíl na 70 % akcií <unk> hlasovacím právem společnosti Moleculon zvolen
+Těžba <unk> z polí v Bassově průlivu v Austrálii bude zvýšena o 11000 barelů denně <unk> na 321000 barelů po otevření pole <unk> , prvního z <unk> malých polí , která mají podle plánu <unk> s <unk> do konce roku 1990 .
+Společnost Esso Australia Ltd <unk> , jednotka newyorské společnosti Exxon Corp . <unk> a společnost Broken Hill Pty . provozují tato pole <unk> rámci společného podniku .
+Společnost Esso <unk> , že pole Whiting začalo s produkcí ropy v úterý <unk>
+Těžba bude postupně zvyšována , dokud nedosáhne kolem 11000 barelů <unk> .
+Toto pole má zásoby ve výši 21 milionů barelů .
+Zásoby ve všech <unk> nových polí čítají celkem 50 milionů barelů .
+Očekává se , že pole Perch a Dolphin <unk> s produkcí začátkem příštího roku , a pole ředitel a Tarwhine později v příštím roce .
+Společnost <unk> uvedla , že pole byla uvedena do provozu poté , řídící se australská vláda <unk> roce 1987 rozhodla osvobodit prvních 30 milionů barelů z nových polí od nepřímé <unk> .
+<unk> R . P . Scherer Corp . uvedla , že dokončila prodej své přidružené společnosti Southern Optical za <unk> milionu dolarů skupině vedené <unk> jednotky Thomasem jedná . Sloanem a <unk> manažery .
+Po akvizici společnosti R <unk> <unk> . té skupinou vedenou společností Shearson <unk> Hutton dříve <unk> tomto roce se tento výrobce želatinových tobolek rozhodl zbavit se určitých svých podniků , které tobolky nevyrábějí .
+Prodej společnosti Southern Optical je součástí tohoto programu .
+Bílý <unk> <unk> , že prezident Bush schválil pro dovoz určitých <unk> hodinek , které nejsou <unk> ve " významném množství " v USA , na Panenských ostrovech rozhodování v jiných amerických državách , osvobození od cla .
+Tento čin přišel jako odpověď na petici za <unk> v <unk> systému preferencí USA pro dovoz z rozvojových zemí podanou společností Timex Inc <unk>
+Dříve bylo toto osvobození od cla dovozcům <unk> odpíráno .
+<unk> Timex žádala o osvobození od cla pro mnoho typů hodinek <unk> spadajících pod 58 různých amerických tarifních tříd .
+Bílý dům prohlásil kuchaře že se <unk> Bush rozhodl poskytnout osvobození od cla pro <unk> kategorií , ale zamítl tento postup pro jiné typy hodinek " kvůli možnému značnému poškození výrobců <unk> v USA a <unk> Panenských ostrovech . "
+Společnost Timex <unk> významný americký výrobce a prodejce hodinek <unk> <unk> levných hodinek na baterie sestavovaných na Filipínách a <unk> jiných rozvojových zemích krytých americkými tarifními preferencemi .
+Američtí zástupci pro obchod uvedli , že <unk> zeměmi , <unk> z prezidentova kroku budou mít prospěch , jsou Filipíny a Thajsko vrátit
+<unk> asistenta obchodní zástupkyně USA Carly <unk> dovoz těch typů hodinek , které <unk> budou splňovat kritéria pro osvobození od <unk> , dosáhl v roce 1988 celkové výše kolem 37.3 tohoto dolarů , což byla poměrně <unk> část z 1 , 5miliardového amerického dovozu hodinek v tomto roce .
+Finanční ředitel společnosti časopise International Inc . James McAlpine odstoupil z funkce a její předseda Frank Stronach vstupuje do děje , aby tomuto <unk> automobilových kde pomohl znovu se vzchopit <unk> uvedla společnost <unk>
+Stronach zaměří své úsilí <unk> snížení režijních nákladů a kontrolu utrácení formou , " dokud nebude dosažena a udržena uspokojivější výše zisku <unk> " uvedla společnost Magna .
+McAlpina nahradí Stephen Akerfeldt , v <unk> době viceprezident pro finance .
+Ambiciózní expanze zanechala <unk> Magna nadbytečnou kapacitu a břemeno velkého dluhu v době , kdy <unk> automobilový <unk> klesat .
+Společnost oznámila v každém z předchozích tří roků pokles <unk> zisku navzdory stálému <unk> prodeje .
+Společnost Magna <unk> <unk> <unk> čtvrtletní dividendy na polovinu a akcie třídy A této společnosti se potácejí hluboko pod 52týdenním vrcholem ve výši 16125 <unk> dolaru ( 13.73 amerického dolaru ) .
+<unk> Torontské burze cenných papírů uzavíraly včera akcie společnosti Magna s <unk> o 37.5 kanadského centu na 9625 kanadského dolaru .
+Stronach <unk> zakladatel a většinový akcionář společnosti Magna , loni rezignoval na <unk> generálního ředitele , aby neúspěšně usiloval o křeslo v kanadském parlamentu .
+<unk> prohlásili , že se chce Stronach znovu ujmout vlivnější role v chodu <unk> .
+Očekávají , <unk> sníží náklady napříč celou společností .
+Společnost uvedla , <unk> Stronach bude osobně řídit restrukturalizaci za asistence Manfreda Gingla , prezidenta a výkonného ředitele .
+Oni ani předběžné nebyli zastiženi , aby se k tomu vyjádřili .
+Společnost Magna uvedla , že <unk> odstoupil , aby se věnoval <unk> poradce se společností Magna jako jedním ze svých klientů .
+Lord Chilver , třiašedesátiletý předseda společnosti English China Clays PLC , byl jmenován nevýkonným ředitelem této <unk> chemické <unk> .
+Japonští investoři téměř <unk> skoupili <unk> nové investiční fondy založené na hypotečních cenných papírech <unk> celkové hodnotě 701 milionů dolarů , uvedla Americká národní hypoteční asociace .
+<unk> nákupy ukazují na silný zájem japonských investorů o americké hypoteční cenné papíry , řekl <unk> společnosti <unk> Mae David O . Maxwell na tiskové konferenci .
+Uvedl <unk> že více než 90 % fondů bylo rozprodáno japonským institucionálním investorům .
+Zbytek přešel k investorům z Francie a <unk> .
+Na začátku tohoto roku skočili japonští investoři <unk> podobném investičním fondu s hypotečními cennými papíry <unk> hodnotě <unk> milionů dolarů .
+Tento <unk> byl založen newyorskou investiční bankou Blackstone Group .
+<unk> <unk> fondy byly sestaveny společně <unk> Goldman , Sachs & Co . z USA a Daiwa Securities Co . z Japonska .
+Tyto nové sedmileté fondy - <unk> nabízející výnos <unk> pevnou sazbou a druhý výnos <unk> pohyblivou sazbou spojenou s londýnskou mezibankovní nabízenou sazbou - nabízejí japonským investorům dvě klíčové výhody .
+Zaprvé jsou navrženy tak , aby eliminovaly riziko předčasných plateb - hypoteční cenné <unk> <unk> být vyplaceny <unk> <unk> když klesne úroková míra , <unk> takové platby předem nutí investory přemístit své peníze za nižší sazby .
+Zadruhé přesouvají měsíční hypoteční <unk> <unk> pololetní , a tím snižují administrativní zatížení investorů .
+Tím , <unk> se nové fondy s těmito problémy vypořádaly , řekl <unk> , se <unk> " extrémně atraktivní pro japonské a další investory mimo USA . "
+Tyto <unk> oživily japonské investice do hypotečních cenných papírů na více než 1 % z 900 miliard dolarů v nevyplacených <unk> <unk> a jejich nákupy vzrůstají rychlým tempem <unk>
+Japonci <unk> také stali velkými kupci korporačního dluhu společnosti Fannie Mae , <unk> během prvních devíti měsíců roku nakoupili dluhopisy <unk> Fannie <unk> v hodnotě 2.4 miliardy dolarů <unk> čili téměř desetinu vydaného množství .
+James L <unk> Pate , čtyřiapadesátiletý výkonný viceprezident , <unk> jmenován ředitelem tohoto ropného koncernu , čímž <unk> správní rada rozšířena na 14 míst .
+Společnost LTV Corp . <unk> , že soudce federálního konkurzního soudu povolil prodloužení lhůty , do níž bude mít tato studujeme vyrábějící ocelářské , letecké a energetické produkty výhradní právo předložit plán <unk> , <unk> 8 <unk> března 1990 .
+Společnost operuje pod ochranou kapitoly <unk> federálního Konkurzního řádu , který jí zaručuje <unk> ochranu před žalobami věřitelů v době , <unk> se pokouší vypracovat plán na splacení svých dluhů .
+Italský obr mezi chemičkami , společnost Montedison S . <unk> . <unk> . , odstartovala přes svou nepřímou <unk> Montedison Acquisition N . vstupu . výhodnou <unk> 37 dolarů na akcii za všechny kmenové akcie v oběhu nizozemské farmaceutické společnosti Erbamont N . V .
+Nabídka oznámená v <unk> vydání Wall Street <unk> má vypršet na konci listopadu .
+Společnost Montedison v současnosti vlastní zhruba <unk> % akcií společnosti Erbamont .
+Tato nabídka je učiněna na základě již dříve ostře <unk> uzavřené mezi těmito společnostmi .
+Japonské ministerstvo financí oznámilo , že <unk> zlata , konvertibilních cizích <unk> <unk> zvláštních práv výběru klesly v říjnu o značnou částku <unk> miliardy dolarů na 84.29 miliardy dolarů .
+Tato <unk> částka je šestým měsíčním poklesem v řadě .
+Tento dlouhodobý pokles odráží <unk> <unk> Japonské banky na podporu jenu přijímané už od <unk> , kdy americká měna dočasně překonala hranici ve výši 150.00 jenu .
+<unk> oznámení následuje po ostřejším zářijovém pádu japonských <unk> měnových zásob o 2.2 miliardy dolaru na 86.12 miliardy dolaru <unk>
+Vyberte si libovolnou zemi .
+Je to nejnovější <unk> šílenství , které se žene po <unk> Street : horečka kolem <unk> fondů zemí , oněch veřejně obchodovaných portfolií , která investují do akcií jediné cizí země <unk>
+Podle washingtonské společnosti Charles E . Simon & Co <unk> , <unk> se průzkumem , bylo letos založeno nebo zaregistrováno <unk> 24 fondů <unk> , <unk> je třikrát tolik než za celý rok 1988 .
+Dostihová dráha míří od Chile přes Rakousko až do Portugalska .
+Příští týden <unk> start Filipínského fondu korunován návštěvou filipínské prezidentky Corazon Aquinové , což je poprvé <unk> kdy <unk> státu odstartuje novou emisi na Newyorské burze .
+Příští oblast ?
+" Všechno je účel - co takhle Novoguinejský fond ? " ironicky <unk> George Foot , <unk> společník <unk> společnosti Newgate Management Associates z Northamptonu v Massachusetts .
+Současná exploze národních fondů je stejná jako " mánie uzavřených fondů " <unk> 20 . <unk> <unk> kdy se úzce zaměřené fondy <unk> nesmírně oblíbené , říká Foot .
+Po krachu v roce <unk> upadly v zapomnění .
+Oproti tradičním otevřeným investičním fondům <unk> většina portfolií jedné země <unk> " uzavřeného " typu , vydávajícími stanovený <unk> akcií , které se veřejně obchodují .
+<unk> tomuto nárůstu se počet fondů <unk> , které jsou nebo brzy budou zaregistrovány v New Yorku <unk> v Londýně , blíží padesátce .
+Tyto fondy teď čítají několik miliard dolarů v <unk> .
+" Lidé chtějí uplatnit své požadavky <unk> teď <unk> <unk> než se vyčerpá počet zemí , které jsou k dispozici , říká Michael Porter , analytik newyorské společnosti Smith Barney , Harris <unk> & Co .
+Za vším tímto nadšením je <unk> tvrdá soutěž .
+<unk> investoři se s léty od burzy odvracejí <unk> investiční firmy se snaží najít produkty , které by se makléřům dobře prodávaly .
+A aby toho dosáhly , <unk> firmy své sítě široko daleko .
+Finanční plánovači <unk> nabádají tří k rozložení investičního rizika a k držení neprůhledných mezinárodních cenných papírů .
+A <unk> probouzející se trhy předběhly ty vyspělejší <unk> jako například USA a Japonsko .
+<unk> zemí představují snadný způsob <unk> jak okusit chuť zahraničních akcií bez obtížného vyhledávání konkrétních společností .
+Ale snadno se přitom spálíte .
+Politické a měnové výkyvy mohou fondy <unk> .
+<unk> problém : ceny akcií těchto fondů <unk> tendenci k větším výkyvům , než širší trh .
+Když se burza 13 . října propadla <unk> o 7 % , například Mexický fond spadl <unk> 18 % a <unk> fond o 16 % .
+A po krachu v <unk> 1987 byly fondy <unk> zemí postiženy hůře , než většina akcií .
+Šílení <unk> fondů je v současnosti zaviněno <unk> , že jsou mnohé z nich obchodovány s historicky nejtučnějšími prémiemi oproti hodnotě svého portfolia .
+Poté , co byly ke konci roku 1987 jen po část loňska obchodovány s průměrným diskontem <unk> než 20 % , se nyní fondy zemí obchodují <unk> průměrné prémii 6 % .
+Důvod : ceny akcií mnoha těchto <unk> rostly <unk> mnohem strměji , než jimi držené zahraniční akcie .
+Někteří specialisté říkají , že se <unk> <unk> zaplatit prémii za fondy , které investují do trhů částečně <unk> pro zahraniční <unk> , jako je například Jižní Korea .
+Avšak některé evropské fondy nedávno vylétly až do nebe ; Španělský fond vystřelil <unk> ohromující prémii 120 % .
+Zaměřili se na něj japonští investoři jako na dobrou dlouhodobou investici , úzce <unk> s <unk> ekonomickou integrací v roce <unk> .
+<unk> několik nových <unk> , které ještě ani nejsou plně zainvestovány , poskočilo k obchodování s vysokými prémiemi .
+" Tato bohatá zhodnocení mě silně znepokojují , <unk> říká Porter ze společnosti <unk> Barney .
+Nedávno ztučnělé prémie odrážejí stále globálnější obchodování s některými fondy zemí jedná navrhuje vysvětlení Porter <unk>
+Oproti <unk> americkým investorům mohou být ti v Asii a v Evropě , kteří hledají přístup k zahraničním akciím , méně <unk> <unk> placení <unk> cen za fondy zemí .
+" Na <unk> kótované fondy se dá nahlížet z mezinárodního hlediska , <unk> říká Porter .
+<unk> či tak jsou mnozí američtí analytici zděšeni z vysokých úrovní obchodování některých <unk> zemí .
+Argumentují tím , <unk> američtí investoři mohou akcie velkých firem zastoupené v mnoha <unk> často nakupovat ve formě amerických depozitních stvrzenek ; tyto takzvané ADR zastupují akcie cizích firem <unk> investovány USA .
+Fondy <unk> tímto způsobem mohou investoři v podstatě koupit bez zaplacení prémie .
+<unk> , kteří teď přesto chtějí fondy nakupovat , radí Foot <unk> společnosti Newgate : <unk> Mám pro ně jedinou radu : ti , kdo na <unk> přijdou pozdě , by raději měli být připraveni rychle odejít .
+Ministerstvo <unk> věcí oznámilo , že USA a Sovětský svaz jednají o možném splacení <unk> ve výši 188 <unk> dolarů , který předkomunistické Rusko dluží americké vládě .
+Pokud by byly dluhy splaceny , mohla by se otevřít cesta <unk> prodej sovětských dluhopisů v USA .
+Po dvou schůzích se <unk> však <unk> ministerstva zahraničních věcí uvedl , že " je příliš brzy na to říci " , zda <unk> tak stane <unk>
+Současně s rozhovory oznámilo <unk> ministerstvo zahraničních věcí , že povolilo sovětské bance otevřít pobočku <unk> New Yorku .
+<unk> pobočka Banky pro zahraniční ekonomické jednoho byla schválena minulé jaro a otevřena v červenci .
+Avšak zdejší sovětská banka by <unk> ochromena , kdyby Moskva nenašla způsob , jak vyrovnat dluh ve výši <unk> milionů dolarů , které si vypůjčila krátce trvající Kerenského demokratická vláda předtím , než se v roce 1917 chopili moci <unk> .
+<unk> <unk> zákona o neplacení dluhů z r <unk> 1934 ve znění pozdějších předpisů je <unk> Američany nelegální poskytovat další úvěry zemím , které již dluží USA , lékařských nejsou členy Světové banky či Mezinárodního měnového fondu .
+SSSR nepatří ani do jedné z těchto organizací .
+Moskva vyrovnala nejvyššími posledních letech dluhy vedoucí období před rokem 1917 jiným zemím za méně , než byla jejich nominální hodnota <unk>
+Ministerstvo zahraničních věcí označilo dluhy vzniklé <unk> rokem 1933 za <unk> pro dodržení Johnsonova zákona .
+Avšak Sověti mohou přesto narážet na <unk> překážky získávání peněz v USA , dokud nesplatí stamiliony dolarů z dalšího dosud nesplaceného dluhu sedmi dohody o půjčce a pronájmu z druhé světové <unk> .
+<unk> dalším náznaku toho , že se růst ekonomiky stabilizuje , oznámila vláda , <unk> <unk> průmyslového zboží <unk> výdaje na stavby přestaly v září růst .
+<unk> sdružení pro řízené nákupy zároveň uvedlo , <unk> jeho nejnovější průzkum ukázal <unk> snížení průmyslové výroby v říjnu , což už <unk> šestý měsíc v řadě .
+Jeho index v říjnu o něco <unk> ze zářijových <unk> % na 47.6 % .
+Jakákoliv hodnota pod 50 % ukazuje , že výrobní sektor všeobecně klesá <unk>
+Manažeři nákupů však také uvedli <unk> že se objednávky v říjnu po <unk> poklesu zvýšily .
+Ministerstvo <unk> oznámilo , že si <unk> <unk> září zajistily objednávky ve výši 236.74 miliardy dolarů , téměř <unk> stejném objemu , jako bylo 236.79 miliardy dolarů v srpnu .
+Kdyby <unk> k <unk> % nárůstu objednávek kapitálových statků od armádních dodavatelů , tovární objednávky <unk> klesly o 2.1 % .
+Ve zvláštní zprávě ministerstvo oznámilo , <unk> stavební náklady byly na roční <unk> 415.6 miliardy dolarů , nepříliš rozdílné <unk> objemu 415.8 miliardy dolarů ohlášenému za srpen .
+Soukromé stavební výdaje klesly , avšak vládní stavební aktivity <unk> .
+Čísla v obou zprávách byla <unk> tak , aby byly odstraněny účinky obvyklých sezónních výchylek , avšak <unk> upraveny s ohledem na inflaci .
+Kenneth <unk> , ekonom clevelandské banky Society Corp . , řekl <unk> že se poptávka po vývozu továrního zboží začíná <unk> .
+Pokles k sazeb , který trvá již od jara , rovněž nepřispěl k oživení odvětví obytné výstavby .
+" Který sektor se hlásí <unk> aby rozvířil stojaté vody ? , plné zeptal se .
+" Nikdo mě nenapadá . "
+Podle většiny měřítek roste národní průmyslový sektor velice pomalu <unk> pokud vůbec .
+Tovární mzdy v září klesly .
+Stejně tak index průmyslové výroby <unk> federálního rezervního systému .
+Přesto mnoho <unk> nepředpovídá , že by ekonomika měla sklouznout do recese .
+Citují , že chybí " <unk> " , která předem signalizuje pokles .
+<unk> zásoby zboží jsou kvůli podobným náznakům bedlivě sledovány .
+Ekonomové říkají <unk> že nárůst zásob může vyvolat pokles produkce , který může vést k recesi .
+Avšak včerejší zpráva o továrních objednávkách přinesla na této frontě dobré zprávy : tovární <unk> podle ní klesly v září o 0.1 % <unk> což <unk> první pokles od února 1987 .
+" To odpovídá <unk> <unk> hladkého přistání ' , " řekl Elliott Platt , ekonom společnosti Donaldson , Lufkin & Jenrette Securities Corp <unk>
+<unk> Nevidím žádné náznaky nadměrných zásob . "
+<unk> přistání je zpomalení <unk> , které snižuje inflaci , aniž by vedlo k recesi .
+Ministerstvo řeklo , že objednávky zboží krátkodobé <unk> <unk> tedy takového , které má mít životnost méně než tři roky - klesly v září o 0.3 % na <unk> miliardy <unk> <unk> 0.9 % nárůstu v předchozím měsíci .
+<unk> zboží dlouhodobé spotřeby vzrostly o 0.2 % na 127.03 <unk> dolarů po 3.9 % <unk> v předešlém měsíci .
+Ministerstvo <unk> odhadovalo , že objednávky zboží dlouhodobé spotřeby v září klesly <unk> 0.1 % .
+Tovární zásilky klesly <unk> 1.6 % na 234.4 miliardy dolarů po 5.4 % nárůstu v <unk> .
+Ministerstvo obchodu poznamenalo , že tyto zásilky jsou <unk> ledna relativně stálé .
+Objem nesplněných objednávek se u výrobců v září zvýšil o 0.5 <unk> na 497.34 miliardy dolarů , což bylo podpořeno silou sektoru <unk> statků pro ministerstvo čtyři .
+Pokud vynecháme tyto objednávky <unk> nesplněné objednávky se snížily o 0.3 % .
+<unk> své zprávě o stavebních výdajích <unk> ministerstvo obchodu , <unk> obytná výstavba , která tvoří téměř polovinu <unk> stavebních výdajů , v září klesla o 0.9 % na roční míru 191.9 miliardy dolarů .
+David Berson , ekonom <unk> hypotečních bankéřů , předpověděl , zimní pokles úrokových sazeb nakonec podpoří výdaje na výstavbu rodinných výši , ale pravděpodobně <unk> na začátku příštího roku .
+Výdaje na <unk> neobytnou výstavbu <unk> o 2.6 % na roční míru 99.1 miliardy dolarů , <unk> jako silný se nejeví žádný sektor .
+Vládní <unk> na výstavbu vzrostly o 4.3 % na 88 miliard dolarů .
+Ministerstvo obchodu uvedlo , že po <unk> na inflaci se v září náklady <unk> výstavbu nezměnily .
+Za prvních devět měsíců tohoto poselství se celkové stavební výdaje vyšplhaly o 2 <unk> nad úroveň minulého roku .
+Vládní údaje o stavebních výdajích jsou v kontrastu se zprávou skupiny F . udržování <unk> Dodge společnosti McGraw - Hill , Inc . , vydanou dříve v tomto týdnu <unk>
+<unk> skupiny Dodge uvádí 8 % nárůst stavebních zakázek zadaných v září .
+Vláda počítá peníze v momentě útraty ; skupina Dodge počítá <unk> , když <unk> zadány .
+Vláda započítává peníze vynaložené na rekonstrukci obytné výstavby ; <unk> Dodge nikoli .
+Ačkoliv index manažerů nákupu stále indikuje zpomalující se <unk> , bezprostřední recesi nesignalizuje <unk> řekl Robert Bretz , předseda výboru asociace pro průzkumy a ředitel řízení materiálů společnosti Pitney Bowes <unk> <unk> ze Stamfordu ve <unk> Connecticut .
+Řekl , průmyslu aby se index dal brát jako <unk> recese , musel <unk> být poblíž spodní 40 % hranice po několik měsíců , .
+Uvedená zpráva poskytla nové důkazy o tom , že <unk> možná zpomaluje tempo růstu národního exportu .
+Pouze 19 % manažerů nákupu ohlásilo za říjen lepší vývozní objednávky <unk> což je oproti <unk> 27 % pokles <unk>
+A 8 % manažerů <unk> , že vývozní objednávky byly minulý měsíc nižší , oproti 6 % manažerů zemřelo předešlého měsíce .
+Zpráva manažerů nákupu také přidala důkazy o tom <unk> že je inflace <unk> kontrolou .
+Pátý měsíc za sebou nákupní manažeři uvedli , že ceny zboží , které nakoupili <unk> <unk> .
+Pokles byl <unk> strmější než v září .
+Uvedli rovněž , <unk> maloobchodníci dodávali v říjnu zboží rychleji <unk> v každém z předchozích pěti měsíců .
+Ekonomové to pokládají za znamení polevujících <unk> tlaků .
+Když je poptávka vyšší , <unk> mohou dodavatelé zvládnout , a dodací doby se prodlužují , ceny mají tendenci se <unk> <unk>
+Zpráva manažerů nákupu je založena <unk> údajích <unk> více než 250 vedoucích nákupu .
+Každý věc ukazatelů průzkumu měří rozdíl mezi počtem nákupčích , kteří v určité oblasti zaznamenali zlepšení , a počtem , <unk> zaznamenal zhoršení nedávno
+Říjnový průzkum se poprvé ptal členů na <unk> .
+Bylo zjištěno , že ze 73 % dovážejících uvedlo 10 % zvýšení dovozu v <unk> <unk> <unk> % sdělilo , že dováželi méně než předchozí měsíc <unk>
+Bretz , který uznává , že údaje <unk> <unk> měsíce neukazují žádný trend , řekl , že " vzbuzují podezření , že se dovozy <unk> <unk> se alespoň příliš nezvyšují " .
+Jako nedostatkový byl označen <unk> asi <unk> položek , ale zahrnoval jednoho nováčka : mléko a <unk> v prášku .
+J Je zvláštní , že se <unk> věc ocitla na seznamu , " podotkl Bretz .
+Uvedl <unk> že je to už druhý měsíc po sobě , co <unk> potravin ohlásili nedostatek odtučněného sušeného mléka .
+<unk> <unk> toho zvýšenou poptávku po mléčných produktech v období výjimečně vysokého amerického vývozu sušeného mléka spojeného s nízkými dovozními kvótami <unk>
+Do tohoto <unk> přispěla Pamela Sebastianová z New Yorku .
+Zde jsou údaje ministerstva obchodu o stavebních výdajích v <unk> dolarů v sezónně upravených ročních mírách .
+Zde <unk> nejnovější údaje ministerstva obchodu pro výrobce v miliardách dolarů nezdržovány upravené sezónně .
+Soudě podle amerických reálií v románu " A Wild Sheep Chase ( Hon křesel divokou ovci ) " <unk> Murakamiho ( nakladatelství Kodansha , 320 stran , 18.95 dolaru ) , mají děti ze silných poválečných <unk> na obou stranách Pacifiku mnoho <unk> .
+Ačkoliv je román zasazen <unk> Japonska , nese se celý v západním <unk> zejména americkém duchu .
+Postavy pijí Salty <unk> , hvízdají si písničku " Johnny <unk> . Goode " a sledují <unk> Bugse Bunnyho .
+Čtou Mickeyho Spillana a mluví o Grouchovi a <unk> .
+Obávají se o svou kariéru , pijí přes míru a trpí <unk> manželstvími a povrchními románky <unk>
+Tohle že má být Japonsko ?
+Pro amerického čtenáře by součástí kouzla tohoto poutavého románu mělo být zjištění , že Japonsko není <unk> <unk> společností podle současných <unk> představ .
+<unk> též osvěžující přečíst si japonského autora , který jasně nepatří přivítal oné sebestředné školy spisovatelů " My Japonci " , stále dokola omílajících představu unikátního Japonska World jež cizinec nedokáže pochopit <unk>
+Jestliže " A Wild Sheep Chase ( <unk> na divokou ovci <unk> " nese nějaké implicitní poselství pro mezinárodní vztahy , pak je to zjištění , <unk> Japonci jsou nám podobnější , než si většina z stará myslí .
+To neznamená , že bláznivá zápletka románu <unk> <unk> Wild Sheep Chase ( Hon na divokou <unk> ) " má reálný podklad .
+Je to fiktivní <unk> často humorné dílko .
+Nespokojený , věčně opilý hrdina těsně před třicítkou odchází na <unk> zlomyslného sečtělého <unk> <unk> titulem ze Stanfordské univerzity do sněžné země hledat nepolapitelnou <unk> s hvězdou na hřbetě .
+V patách má svou jasnozřivou přítelkyni <unk> <unk> štiplavé poznámky z ní nečiní právě poddajnou ženušku .
+Po cestě potkává hrdina románu soucitného křesťanského řidiče , <unk> mu nabídne telefon na Boha a Ovčího muže , sladkou <unk> <unk> načrtnutou figurku , která nosí ovčí kůži , co jiného .
+Čtyřicetiletý <unk> je v Japonsku vydavatelskou senzací .
+Jeho novějšího románu <unk> Norwegian Wood ( Norské dřevo ) " ( snad každý Japonec pod 40 umí nazpaměť texty Beatles ) <unk> od jeho listopadu v nakladatelství Kodansha roku 1987 <unk> více <unk> čtyři miliony výtisků .
+Je však jen <unk> z několika mladých <unk> - tzv . tokijské umělecké skupiny - kteří vedou <unk> žebříčky bestsellerů .
+Jejich knihy jsou psány moderním <unk> plným idiomů a <unk> obsahují pořádné množství amerických reálií .
+<unk> románu " You Gotta Have Wa ( Musíte mít <unk> ) " Roberta Whitinga ( Macmillan , 339 stran Kongres 17.95 dolaru ) ustupují Beatles <unk> , který bychom v japonské verzi sotva nazvali " hrou <unk> .
+Podle Whitingova popisu je japonský baseball " odrazem světoznámých japonských <unk> tvrdé práce a harmonie " .
+<unk> Wa " je japonsky " týmový <unk> " a toho mají japonští baseballoví hráči na rozdávání .
+Zapálenost hráče pro trénink a týmovou image je stejně důležitá <unk> jeho <unk> úspěch na pálce .
+<unk> jednou označily hvězdu Tokyo Giants Tatsunoriho Haru , onu " skromnou , nestěžující si , poslušnou duši " , za mužský <unk> Japonska .
+Ale kromě faktu , že se besuboru hraje s míčkem a pálkou , <unk> to úplně jiná hra : fanoušci zdvořile vracejí <unk> odpaly <unk> <unk> stadionu , strike zóna se rozšiřuje podle velikosti pálkaře , remízy jsou povoleny - dokonce vítány - jelikož beze <unk> cti obchází ostudu poražených , hráči musí dodržovat <unk> kodex <unk> i v osobním životě , <unk> hráči Tokyo Giants musí na veřejnosti vždy <unk> kravaty .
+" You <unk> <unk> Wa ( Musíte mít wa ) " je <unk> zábavná kronika o tom , jak v Japonsku žijí američtí baseballoví hráči , kteří jsou <unk> každém týmu maximálně dva <unk>
+I přes <unk> sumy peněz , které dostávají za <unk> , že <unk> <unk> na japonské metě , <unk> jich nemálo rozhodne , že to vlastně nestojí za to , a utíkají domů .
+" Funny Business <unk> Zábavný podnik ) " ( Soho , <unk> stran , 17.95 dolaru ) od Garyho Katzensteina je další specialitkou .
+<unk> nedůtklivou stížností drzého Američana , který byl <unk> <unk> Luce Fellowship v Tokiu zaměstnán ve společnosti Sony - k lítosti obou stran .
+V občas zábavných , <unk> častěji nadřazených a <unk> i <unk> pasážích popisuje Katzenstein <unk> jak je společnost Sony přítomna i v <unk> nejprozaičtějších aspektech života svých zaměstnanců - v kanceláři s přísným režimem , kde jsou zaměstnancům přidělováni společníci na oběd , i " doma " ve strohé firemní ubytovně <unk> provozované <unk> domovníkem <unk>
+Některé z jeho postřehů o japonském stylu řízení se strefují do <unk> .
+Je patrně pravda , že mnozí zaměstnanci odpracují neproduktivní přesčasové hodiny jen <unk> solidarity , že systém je tak hierarchický , že <unk> vedoucím může mluvit jen asistent vedoucího a s <unk> ředitelem jen vedoucí a <unk> společnost <unk> byla velice obezřetná , když měla mladému krátkodobému zaměstnanci z Ameriky <unk> byť <unk> odpovědnost .
+<unk> všechno muselo být pro Katzensteina , který přišel do společnosti Sony s diplomy <unk> <unk> a informatiky a měl ambice vynalézt další walkman , <unk> frustrující .
+Ale společnost Sony <unk> nakonec poučila z <unk> <unk> managementu a Katzensteina poté , co spáchal společenský zločin , když si domluvil schůzku se ctihodným Akio Moritou , zakladatelem společnosti Sony , vyhodila .
+Je <unk> , že se jejich schůzka nikdy neuskutečnila .
+Katzenstein by se jistě lecčemu <unk> a je dokonce možné , že <unk> Morita také .
+<unk> Kirkpatricková , zástupce redaktora úvodníků našeho listu <unk> pracovala v Tokiu tři roky .
+Stále více míst na zeměkouli <unk> osvobozuje od tabákového kouře .
+V Singapuru <unk> nový zákon pod pokutou 250 dolarů po kuřácích <unk> aby uhasili cigarety Kongres vstupem do restaurací , obchodních domů a sportovních center .
+Jeden úředník uvedl , že diskotéky a <unk> kluby jsou ze zákazu vyňaty a v barech bude kouření <unk> kromě doby podávání jídel .
+Singapur už zakázal kouření ve všech divadlech , autobusech , <unk> výtazích , nemocnicích <unk> v restauracích <unk> občerstvení .
+V Malajsii zahájil Siti <unk> Sulaiman , náměstek <unk> z kanceláře premiéra , <unk> <unk> bez <unk> " na Marském technologickém institutu poblíž Kuala Lumpur a vyzval i ostatní školy k zavedení zákazu kouření ve svých prostorách .
+Jižní Korea má jiné starosti .
+<unk> Soulu začali úředníci navštěvovat asi 26000 stánků s cigaretami , aby výdajů nelegální plakáty a <unk> nesoucí reklamu na cigarety z dovozu .
+Jižní Korea otevřela svůj <unk> cigaretám z ciziny , ale omezuje jejich reklamu na k tomu určená místa .
+Marketingový Kongres naznačuje ředitelem že hongkongští spotřebitelé jsou nejmaterialističtějšími ze 14 velkých trhů , kde průzkum probíhal .
+Studie <unk> reklamní agenturou Backer Spielvogel Bates také zjistila <unk> <unk> zákazníci v této kolonii se cítí více pod tlakem <unk> zákazníci z jakéhokoli jiného trhu podrobeného průzkumu , včetně USA a Japonska <unk>
+Průzkum odhalil , že téměř polovina hongkongských týdne zastává hodnoty , které označili jako materialistické , zatímco v Japonsku a USA je to zhruba <unk> .
+Více než tři z pěti spotřebitelů uvedli , že <unk> většinou dobu velkém stresu , ve srovnání s slevy , kde je to méně než jeden ze dvou , <unk> jedním ze čtyř <unk> Japonsku .
+Thajská vláda schválila návrh ministra financí Pramuala Sabhavasua <unk> výstavbu konferenčního centra za 19 milionů dolarů pro společné setkání <unk> banky a Mezinárodního měnového fondu pevnými dva <unk> .
+Toto setkání , které má <unk> Bangkoku přilákat 20000 lidí , se mělo původně konat v <unk> Central <unk> , avšak vláda nepřijala podmínky , které si hotel stanovil <unk> provedení potřebného rozšíření .
+<unk> plán vyvolává hlavně <unk> , zda se nové centrum podaří vystavět v tak krátké době .
+Tisková agentura WAFA Organizace za osvobození Palestiny ( PLO ) uvedla , že Jásir Arafat zaslal dopis předsedovi Mezinárodního olympijského výboru strop žádostí o podporu palestinského zájmu o <unk> do tohoto výboru .
+Představitel Palestinského olympijského výboru řekl , že výbor poprvé žádal o členství v roce <unk> a že <unk> byla obnovena v srpnu tohoto roku .
+PLO se v posledních měsících snaží <unk> do mezinárodních organizací , avšak <unk> tomto roce se jí nepodařilo stát se členem Světové zdravotnické organizace a <unk> organizace pro turistiku <unk>
+Deník People <unk> s Daily uvedl , že se pekingský prodavač v obchodu s potravinami <unk> prvním pevninským Číňanem , <unk> <unk> nakazil AIDS pohlavním stykem .
+Deník uvedl , že muži <unk> jenž nebyl jmenován , byla nemoc zjištěna po <unk> nemocničních testů .
+Jakmile byla nemoc potvrzena <unk> byla podrobeni testům všichni mužovi spolupracovníci a celá jeho rodina , avšak <unk> u nikoho z nich <unk> nemoc zjištěna <unk> uvedl deník .
+Deník dále uvedl , že muž měl po dlouhou <unk> " chaotický pohlavní život " , včetně poměrů s muži <unk> <unk> .
+Polská vláda zvedla poplatky <unk> za elektřinu o 150 % a zdvojnásobila ceny plynu .
+Oficiální <unk> agentura PAP uvedla , že zvýšení měla vyrovnat nereálně nízké poplatky za energii <unk> výrobními náklady a kompenzovat zvýšené ceny uhlí <unk>
+Šťastnější zpráva je , že Jižní Korea oznámila včera v rámci navazování diplomatických styků s <unk> <unk> <unk> poskytne finančně vyčerpané varšavské vládě půjčky ve výši 450 milionů dolarů .
+Po <unk> <unk> lobby zamítl maďarský parlament projekt ve výši miliard dolarů na přehradu na Dunaji , kterou staví <unk> firmy .
+Nagymaroská jehlicovitá měla být propojena s <unk> téměř dostavěnou přehradou , <unk> se 100 mílí proti proudu v Československu .
+V rámci zakončení maďarské části projektu pověřil parlament premiéra <unk> Nemétha , <unk> modifikoval smlouvu s Československem z roku 1977 , v níž je výstavba přehrady stále <unk> .
+Premiér Neméth v parlamentu <unk> , <unk> kdyby byly obě přehrady postaveny podle plánu , utrpělo by životní prostředí v Československu <unk> v Maďarsku .
+Československo v květnu oznámilo , že pokud by <unk> o spojených přehradách nebyla <unk> , <unk> by od Maďarska požadovat dvě miliardy dolarů .

--- a/tests/data/bert/val.pcedt.forms
+++ b/tests/data/bert/val.pcedt.forms
@@ -1,0 +1,50 @@
+Japonské akcie spadly v pondělí brzy ráno , ale během dopoledne se obrátily zpět .
+Dolar se obchodoval výrazně níže v Tokiu .
+Vyhlídky na nový návrh na odkoupení UAL jsou neradostné .
+Řada bank odmítla jít do 6.79 miliardové transakce , bankéři však říkají , že to nebylo kvůli neochotě financovat převzetí .
+Rozhodnutí vycházelo pouze z problematického pilotního plánu managementu UAL , říkají .
+Prudké změny výrobních cen v září následovaly po třech měsících poklesů , ale analytici se rozcházejí v tom , zda skok o 0.9 % signalizuje kritické zhoršení inflace .
+Také maloobchodní prodej vzrostl o 0.5 % minulý měsíc .
+Snížení daně z příjmů z kapitálového majetku bylo vyškrtnuto ze senátního návrhu na zmenšení deficitu , ale navrhovatelé stále doufají , že se toto snížení letos uzákoní .
+Bush nebude urgovat ustanovení o příjmech z kapitálového majetku v konečné verzi návrhu o deficitu , až se koncem tohoto týdne sejdou k jednání Sněmovna a Senát .
+Firma General Motors vyslala signál , že možná zavře až pět severoamerických montážních závodů v první polovině devadesátých let ve snaze snížit přebytečnou kapacitu .
+Prodej amerických osobních a nákladních aut klesl o 12.6 % počátkem října , v prvním prodejním období modelů roku 1990 , když ho stáhl dolů prudký pokles prodeje GM .
+Firmy Warner a Sony jsou zapleteny do soudního sporu kolem filmových producentů Petera Grubera a Jon Peters .
+Boj by mohl zdržet plány firmy Sony vstoupit do amerického filmového průmyslu .
+Americká skupina firmy Hooker obdržela od jedné investorské skupiny nabídku ve výši 409 milionů dolarů na většinu z jejích aktiv v oblasti realit a nákupních center .
+Nabídka nezahrnuje Bonwit Teller či B . Altman .
+Stávka Boeingu začíná dopadat na aerolinky .
+Firma America West oznámila v pátek , že odsune svou novou službu z Houstonu kvůli zpoždění dodávek letadel z Boeingu .
+Firma Saatchi & Saatchi by zahájila manažerské převzetí , pokud by se objevil zájemce o nepřátelské převzetí , řekl její představitel .
+Firmy British Aerospace a francouzský Thomson - CSF se blíží dohodě o fúzi divize řízených střel .
+Nové americké kvóty na dovoz oceli umožní větší podíl rozvíjejícím se státům , které mají relativně nesubvencovaný průmysl oceli .
+Kvóta pro japonskou ocel bude podstatně snížena .
+Pět krachujících spořitelních a úvěrových družstev S & L bylo prodáno vládními regulátory , nízké nabídky však neumožnily prodej pátého .
+Trhy -
+Akcie : Objem 251170000 akcií .
+Dow Jonesův průmyslový index 2569.26 , pokles 190.58 ; přeprava 1406.29 , pokles 78.06 ; akcie veřejných podniků 211.96 , pokles 7.29 .
+Dluhopisy : Shearson Lehman Hutton Treasury index 3421.29 , růst
+Komodity : Dow Jones futures index 129.87 , růst 0.01 ; spot index 129.25 , růst 0.28 .
+Dolar : 142.10 jen , pokles 2.07 ; 18740 marka , pokles 343 .
+Federální odvolací soud v San Franciscu rozhodl , že akcionáři nemohou činit představitele firmy odpovědné za chybné odhady prodeje nových výrobků , jestliže sdělovací prostředky současně odhalily podstatné informace o závadě na výrobku .
+Soudní nález vychází z žaloby podané roku 1984 akcionáři Apple Computer Inc . , ve které tvrdí , že představitelé firmy oklamali investory očekávaným úspěchem počítače Lisa představeného v roce 1983 .
+Právníci specializující se na akcionářské žaloby prohlásili , že jsou znepokojeni tím , že by se na základě tohoto soudního rozhodnutí mohlo používání " tiskové obrany " mezi firmami obecně rozšířit .
+Podle žaloby vyvolali zástupci firmy Apple nadšení veřejnosti tím , že vychvalovali Lisu jako kancelářský počítač , který přinese revoluci na pracoviště a je mimořádně úspěšný už během svého prvního roku .
+Žalující strana také uvádí , že ještě před oslavnými ódami firma nechávala kolovat interní zprávu poukazující na problémy s počítačem Lisa .
+Žaloba tvrdí , že akcie firmy Apple se vyšplhaly až na 63.50 dolarů za kus na základě firemních optimistických prognóz .
+Ale když firma prozradila slabý prodej koncem roku 1983 , akcie prudce spadly až na 17.37 dolarů za akcii , uvádí žaloba .
+Akcionáři se domáhají více než 150 milionů dolarů za ztráty .
+V roce 1987 okresní soud v San Francisku zamítl tento případ hlavně proto , že novinové zprávy dostatečně vyvážily firemní prohlášení tím , že upozornily spotřebitele na problémy počítače Lisa .
+Koncem minulého měsíce potvrdil odvolací soud , že by případ měl být z velké části zamítnut .
+Nicméně však přiznal akcionářům právo domáhat se soudní cestou menší části svého nároku , která se týká diskové mechaniky u počítače Lisa , známé jako Twiggy .
+Soud rozhodl , že sdělovací prostředky v té době neodhalily problémy Twiggy .
+Právníci se obávají důsledků tohoto rozhodnutí na jiné akcionářské žaloby , ale poukazují na to , že soud zdůraznil , že rozhodnutí má být považováno za velmi specifické pro konkrétní případ Apple .
+" Soud si dával pozor , aby řekl , že se nepříznivé informace objevily v úplně stejných článcích a dostalo se jim stejné pozornosti jako firemním prohlášením , " řekl Patrick Grannon , právník Greenfield & Chimicles v Los Angeles , který nebyl do případu zapojen .
+" Soud říká , že nepříznivá fakta musí být předána na trh se stejnou intenzitou a důvěryhodností jako prohlášení firemních zasvěcenců . "
+Právní zástupci akcionářů z právnické firmy Milberg , Weiss , Bershad , Specthrie & Lerach v New Yorku požádali minulý týden o nové projednání tohoto případu .
+Napsali : " Tento posudek zavádí nové pravidlo imunity - a to , že pokud se bude veřejně publikovat velká rozmanitost názorů na firemní podnikání , pak může firma říci cokoliv bez strachu z odpovědnosti za cenné papíry . "
+NFL musí zaplatit 5.5 milionu $ advokátních odměn zaniklé lize
+National Football League ( národní liga amerického fotbalu ) zvažuje odvolání proti rozhodnutí vyplývajícímu z převážně neúspěšné protitrustové žaloby podané proti nim americkou ligou U.S . Football League .
+Porota v roce 1986 souhlasila s tvrzením USFL , že NFL monopolizuje hlavní ligový americký fotbal .
+Ale porota přiznala lize USFL odškodnění pouze 1 dolar , ztrojnásobené kvůli protitrustovým požadavkům .
+Minulý týden , americký odvolací soud v New Yorku potvrdil přiznání advokátních odměn ve výši 5.5 milionů dolarů pro zaniklou ligu .

--- a/tests/tests_run.sh
+++ b/tests/tests_run.sh
@@ -22,6 +22,7 @@ bin/neuralmonkey-train tests/self-critical.ini
 bin/neuralmonkey-train tests/rl.ini
 bin/neuralmonkey-train tests/transformer.ini
 bin/neuralmonkey-run tests/transformer.ini tests/test_data.ini
+bin/neuralmonkey-train tests/bert.ini
 bin/neuralmonkey-train tests/str.ini
 bin/neuralmonkey-train tests/flat-multiattention.ini
 bin/neuralmonkey-train tests/hier-multiattention.ini

--- a/tests/tests_run.sh
+++ b/tests/tests_run.sh
@@ -13,6 +13,7 @@ bin/neuralmonkey-train tests/post-edit.ini
 bin/neuralmonkey-train tests/factored.ini
 bin/neuralmonkey-train tests/classifier.ini
 bin/neuralmonkey-train tests/labeler.ini
+bin/neuralmonkey-run tests/labeler.ini tests/test_data.ini
 bin/neuralmonkey-train tests/regressor.ini
 bin/neuralmonkey-train tests/language-model.ini
 bin/neuralmonkey-train tests/audio-classifier.ini


### PR DESCRIPTION
Also:
- added SequenceLabeler.output_mask for distinction between train mode and inference mode
- changed dropout in the SequenceLabeler output layer
- (workaround) added `+1` smoothing to SequenceLabeler.cost due to the nature of BERT input data (everything masked in small batches -> can lead to division by zero)