### PR TITLE
Fix blessing for Transformer decoder

### DIFF
--- a/neuralmonkey/decoders/autoregressive.py
+++ b/neuralmonkey/decoders/autoregressive.py
@@ -458,13 +458,13 @@ class AutoregressiveDecoder(ModelPart):
             temperature: float value specifying the softmax temperature
         """
         initial_loop_state = self.get_initial_loop_state()
-        final_loop_state = tf.while_loop(
-            self.loop_continue_criterion,
-            self.get_body(train_mode, sample, temperature),
-            initial_loop_state,
-            shape_invariants=tf.contrib.framework.nest.map_structure(
-                get_state_shape_invariants, initial_loop_state))
-
+        with tf.control_dependencies([self.decoding_w, self.decoding_b]):
+            final_loop_state = tf.while_loop(
+                self.loop_continue_criterion,
+                self.get_body(train_mode, sample, temperature),
+                initial_loop_state,
+                shape_invariants=tf.contrib.framework.nest.map_structure(
+                    get_state_shape_invariants, initial_loop_state))
         self.finalize_loop(final_loop_state, train_mode)
 
         return final_loop_state

--- a/neuralmonkey/decoders/transformer.py
+++ b/neuralmonkey/decoders/transformer.py
@@ -20,7 +20,7 @@ from neuralmonkey.decoders.autoregressive import (
     AutoregressiveDecoder, LoopState, DecoderFeedables)
 from neuralmonkey.encoders.transformer import (
     TransformerLayer, position_signal)
-from neuralmonkey.logging import warn
+from neuralmonkey.logging import warn, debug
 from neuralmonkey.model.sequence import EmbeddedSequence
 from neuralmonkey.model.parameterized import InitializerSpecs
 from neuralmonkey.model.model_part import ModelPart
@@ -433,6 +433,11 @@ class TransformerDecoder(AutoregressiveDecoder):
         # pylint: disable=not-callable
         tr_histories = TransformerHistories(**histories)
         # pylint: enable=not-callable
+
+        for encoder in self.encoders:
+            debug("Encoder states: {}".format(encoder.temporal_states), "bless")
+        debug("Output proj. params.: {}, {}".format(
+            self.decoding_w, self.decoding_b), "bless")
 
         return LoopState(
             histories=tr_histories,

--- a/neuralmonkey/decoders/transformer.py
+++ b/neuralmonkey/decoders/transformer.py
@@ -434,11 +434,6 @@ class TransformerDecoder(AutoregressiveDecoder):
         tr_histories = TransformerHistories(**histories)
         # pylint: enable=not-callable
 
-        for encoder in self.encoders:
-            debug("Encoder states: {}".format(encoder.temporal_states), "bless")
-        debug("Output proj. params.: {}, {}".format(
-            self.decoding_w, self.decoding_b), "bless")
-
         return LoopState(
             histories=tr_histories,
             constants=[],
@@ -534,4 +529,10 @@ class TransformerDecoder(AutoregressiveDecoder):
         # pylint: enable=too-many-locals
 
         return body
+
+    def decoding_loop(self, train_mode: bool, sample: bool = False,
+                      temperature: float = 1) -> LoopState:
+        with tf.control_dependencies([self.decoding_w, self.decoding_b]):
+            return super(TransformerDecoder, self).decoding_loop(
+                train_mode, sample, temperature)
 # pylint: enable=too-many-instance-attributes

--- a/neuralmonkey/decoders/transformer.py
+++ b/neuralmonkey/decoders/transformer.py
@@ -20,7 +20,7 @@ from neuralmonkey.decoders.autoregressive import (
     AutoregressiveDecoder, LoopState, DecoderFeedables)
 from neuralmonkey.encoders.transformer import (
     TransformerLayer, position_signal)
-from neuralmonkey.logging import warn, debug
+from neuralmonkey.logging import warn
 from neuralmonkey.model.sequence import EmbeddedSequence
 from neuralmonkey.model.parameterized import InitializerSpecs
 from neuralmonkey.model.model_part import ModelPart
@@ -529,10 +529,4 @@ class TransformerDecoder(AutoregressiveDecoder):
         # pylint: enable=too-many-locals
 
         return body
-
-    def decoding_loop(self, train_mode: bool, sample: bool = False,
-                      temperature: float = 1) -> LoopState:
-        with tf.control_dependencies([self.decoding_w, self.decoding_b]):
-            return super(TransformerDecoder, self).decoding_loop(
-                train_mode, sample, temperature)
 # pylint: enable=too-many-instance-attributes

--- a/tests/tests_run.sh
+++ b/tests/tests_run.sh
@@ -21,6 +21,7 @@ bin/neuralmonkey-train tests/beamsearch.ini
 bin/neuralmonkey-train tests/self-critical.ini
 bin/neuralmonkey-train tests/rl.ini
 bin/neuralmonkey-train tests/transformer.ini
+bin/neuralmonkey-run tests/transformer.ini tests/test_data.ini
 bin/neuralmonkey-train tests/str.ini
 bin/neuralmonkey-train tests/flat-multiattention.ini
 bin/neuralmonkey-train tests/hier-multiattention.ini


### PR DESCRIPTION
Transformer decoder was crashing when using `neuralmonkey-run` because some of the ops that are usually created in the training part of the graph get created in the while for the first time.

