### PR TITLE
neuralmonkey-run: add -v and -s options for experiment.ini modifications

### DIFF
--- a/neuralmonkey/run.py
+++ b/neuralmonkey/run.py
@@ -29,6 +29,14 @@ def main() -> None:
                         help="the configuration file of the experiment")
     parser.add_argument("datasets", metavar="INI-TEST-DATASETS",
                         help="the configuration of the test datasets")
+    parser.add_argument("-s", "--set", type=str, metavar="SETTING",
+                        action="append", dest="config_changes", default=[],
+                        help="override an option in the configuration; the "
+                        "syntax is [section.]option=value")
+    parser.add_argument("-v", "--var", type=str, metavar="VAR", default=[],
+                        action="append", dest="config_vars",
+                        help="set a variable in the configuration; the syntax "
+                        "is var=value (shorthand for -s vars.var=value)")
     parser.add_argument("--json", type=str, help="write the evaluation "
                         "results to this file in JSON format")
     parser.add_argument("-g", "--grid", dest="grid", action="store_true",
@@ -37,7 +45,10 @@ def main() -> None:
 
     datasets_model = load_runtime_config(args.datasets)
 
-    exp = Experiment(config_path=args.config)
+    args.config_changes.extend("vars.{}".format(s) for s in args.config_vars)
+    exp = Experiment(config_path=args.config,
+                     config_changes=args.config_changes)
+
     exp.build_model()
     exp.load_variables(datasets_model.variables)
 


### PR DESCRIPTION
Similar to the counterparts in the train.py, this can be useful when you need to run a model with different set of runners, evaluators, etc. during inference than during training; now without the need to directly modify the experiment.ini file